### PR TITLE
Make cbor crate no_std compatible

### DIFF
--- a/cbor/src/decode.rs
+++ b/cbor/src/decode.rs
@@ -1,5 +1,10 @@
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::str::Utf8Error;
 use num_traits::FromPrimitive;
-use std::str::Utf8Error;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -35,7 +40,7 @@ pub enum Error {
     InvalidUtf8(#[from] Utf8Error),
 
     #[error(transparent)]
-    TryFromIntError(#[from] std::num::TryFromIntError),
+    TryFromIntError(#[from] core::num::TryFromIntError),
 
     #[error("Loss of floating-point precision")]
     PrecisionLoss,
@@ -113,8 +118,8 @@ impl<'a, 'b: 'a> Value<'a, 'b> {
     }
 }
 
-impl<'a, 'b: 'a> std::fmt::Debug for Value<'a, 'b> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<'a, 'b: 'a> core::fmt::Debug for Value<'a, 'b> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Value::UnsignedInteger(n) => write!(f, "{n:?}"),
             Value::NegativeInteger(n) => write!(f, "-{n:?}"),
@@ -154,9 +159,9 @@ fn parse_tags(data: &[u8]) -> Result<(Vec<u64>, bool, usize), Error> {
 
 fn to_array<const N: usize>(data: &[u8]) -> Result<[u8; N], Error> {
     match data.len().cmp(&N) {
-        std::cmp::Ordering::Less => Err(Error::NotEnoughData),
-        std::cmp::Ordering::Equal => Ok(data.try_into().unwrap()),
-        std::cmp::Ordering::Greater => Ok(data[0..N].try_into().unwrap()),
+        core::cmp::Ordering::Less => Err(Error::NotEnoughData),
+        core::cmp::Ordering::Equal => Ok(data.try_into().unwrap()),
+        core::cmp::Ordering::Greater => Ok(data[0..N].try_into().unwrap()),
     }
 }
 
@@ -270,7 +275,7 @@ where
             offset += len + 1;
             let mut t = Vec::new();
             for b in v {
-                t.push(std::str::from_utf8(b).map_err(Into::into)?);
+                t.push(core::str::from_utf8(b).map_err(Into::into)?);
             }
             f(Value::TextStream(&t), shortest && s, tags)
         }
@@ -279,7 +284,7 @@ where
             let (t, s, len) = parse_data_minor(minor, &data[offset + 1..])?;
             offset += len + 1;
             f(
-                Value::Text(std::str::from_utf8(t).map_err(Into::into)?),
+                Value::Text(core::str::from_utf8(t).map_err(Into::into)?),
                 shortest && s,
                 tags,
             )

--- a/cbor/src/decode_seq.rs
+++ b/cbor/src/decode_seq.rs
@@ -1,4 +1,9 @@
 use super::decode::*;
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use thiserror::Error;
 
 pub struct Series<'a, const D: usize> {
@@ -207,8 +212,8 @@ enum SequenceDebugInfo {
     Map(Vec<(SequenceDebugInfo, SequenceDebugInfo)>),
 }
 
-impl std::fmt::Debug for SequenceDebugInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SequenceDebugInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Unknown => f.write_str("..."),
             Self::Value(s) => f.write_str(s),
@@ -308,8 +313,8 @@ fn sequence_debug_fmt<const D: usize>(
     }
 }
 
-impl<const D: usize> std::fmt::Debug for Series<'_, D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<const D: usize> core::fmt::Debug for Series<'_, D> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut offset = 0;
         {
             let mut self_cloned = Series::<D> {

--- a/cbor/src/decode_tests.rs
+++ b/cbor/src/decode_tests.rs
@@ -1,11 +1,14 @@
 #![cfg(test)]
+extern crate std;
+use std::prelude::rust_2021::*;
+
 use super::decode::*;
 use hex_literal::hex;
 
 fn test_simple<T>(expected: T, data: &[u8])
 where
-    T: FromCbor + PartialEq + std::fmt::Debug,
-    <T as FromCbor>::Error: From<Error> + std::fmt::Debug,
+    T: FromCbor + PartialEq + core::fmt::Debug,
+    <T as FromCbor>::Error: From<Error> + core::fmt::Debug,
 {
     let (v, s, len) = parse::<(T, bool, usize)>(data).unwrap();
     assert!(s);
@@ -15,8 +18,8 @@ where
 
 fn test_sub_simple<T, const D: usize>(expected: T, seq: &mut Series<D>)
 where
-    T: FromCbor + PartialEq + std::fmt::Debug,
-    <T as FromCbor>::Error: From<Error> + std::fmt::Debug,
+    T: FromCbor + PartialEq + core::fmt::Debug,
+    <T as FromCbor>::Error: From<Error> + core::fmt::Debug,
 {
     let (v, s) = seq.parse::<(T, bool)>().unwrap();
     assert!(s);

--- a/cbor/src/encode.rs
+++ b/cbor/src/encode.rs
@@ -1,3 +1,5 @@
+use alloc::{string::String, vec::Vec};
+
 pub trait ToCbor {
     fn to_cbor(self, encoder: &mut Encoder);
 

--- a/cbor/src/lib.rs
+++ b/cbor/src/lib.rs
@@ -1,3 +1,6 @@
+#![no_std]
+extern crate alloc;
+
 pub mod decode;
 pub mod encode;
 


### PR DESCRIPTION
Thankfully, all this needed was a `#![no_std]` and a bunch of imports from the `alloc` crate (shipped with Rust).

The advantage of being `no_std` is that projects targeting embedded platforms without support for the full standard library can make use of it. Due to the alloc dependency, they will still have to provide a dynamic alloctor though.

Fixing this, as far as reasonable, needs more work.