### PR TITLE
Fix warning about crate-level attribute

### DIFF
--- a/bpv7/src/lib.rs
+++ b/bpv7/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
 use alloc::{


### PR DESCRIPTION
rustc 1.88.0 emits:

```
warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
```