### PR TITLE
Rework CBOR parser to handle 'push' semantics

### DIFF
--- a/bpa/src/dispatcher/ingress.rs
+++ b/bpa/src/dispatcher/ingress.rs
@@ -12,7 +12,7 @@ impl Dispatcher {
         match data.first() {
             None => {
                 return Err(hardy_bpv7::Error::InvalidCBOR(
-                    hardy_cbor::decode::Error::NotEnoughData,
+                    hardy_cbor::decode::Error::NeedMoreData(1),
                 )
                 .into());
             }

--- a/bpv7/src/block.rs
+++ b/bpv7/src/block.rs
@@ -247,7 +247,7 @@ impl hardy_cbor::decode::FromCbor for BlockWithNumber {
                 if shortest {
                     // Appendix B of RFC9171
                     let mut seen_24 = false;
-                    for tag in &tags {
+                    for tag in tags {
                         match *tag {
                             24 if !seen_24 => seen_24 = true,
                             _ => {

--- a/bpv7/src/bpsec/parse.rs
+++ b/bpv7/src/bpsec/parse.rs
@@ -26,7 +26,7 @@ fn parse_ranges<const D: usize>(
 
             let data_start = offset + outer_offset + a.offset();
             if a.skip_value(16).map_field_err("value")?.is_none() {
-                return Err(hardy_cbor::decode::Error::NotEnoughData.into());
+                return Err(hardy_cbor::decode::Error::NoMoreItems.into());
             };
             Ok::<_, Error>((id, data_start..offset + outer_offset + a.offset()))
         })? {

--- a/bpv7/src/bundle/parse.rs
+++ b/bpv7/src/bundle/parse.rs
@@ -529,7 +529,7 @@ impl ValidBundle {
                 // TODO: POLICY CHECK
                 // Appendix B of RFC9171
                 let mut seen_55799 = false;
-                for tag in &tags {
+                for tag in tags {
                     match *tag {
                         255799 if !seen_55799 => seen_55799 = true,
                         _ => {

--- a/bpv7/src/eid/cbor_tests.rs
+++ b/bpv7/src/eid/cbor_tests.rs
@@ -19,7 +19,7 @@ fn tests() {
     // Negative tests
     assert!(matches!(
         expect_error(&[]),
-        Error::InvalidCBOR(hardy_cbor::decode::Error::NotEnoughData)
+        Error::InvalidCBOR(hardy_cbor::decode::Error::NeedMoreData(1))
     ));
     assert!(matches!(
         expect_error(&hex!(

--- a/cbor/src/decode.rs
+++ b/cbor/src/decode.rs
@@ -20,9 +20,6 @@ pub enum Error {
     #[error("Invalid minor-type value {0}")]
     InvalidMinorValue(u8),
 
-    #[error("Tags with no following value")]
-    JustTags,
-
     #[error("Incorrect type, expecting {0}, found {1}")]
     IncorrectType(String, String),
 
@@ -241,7 +238,7 @@ where
     let (tags, mut shortest, mut offset) = parse_tags(data)?;
     let Some(marker) = data.get(offset) else {
         if !tags.is_empty() {
-            return Err(Error::JustTags.into());
+            return Err(Error::NeedMoreData(1).into());
         } else {
             return Ok(None);
         }

--- a/cbor/src/decode_seq.rs
+++ b/cbor/src/decode_seq.rs
@@ -95,7 +95,7 @@ impl<'a, const D: usize> Series<'a, D> {
 
     pub fn try_parse_value<T, F, E>(&mut self, f: F) -> Result<Option<T>, E>
     where
-        F: FnOnce(Value, bool, Vec<u64>) -> Result<T, E>,
+        F: FnOnce(Value, bool, &[u64]) -> Result<T, E>,
         E: From<Error>,
     {
         // Check for end of array
@@ -119,7 +119,7 @@ impl<'a, const D: usize> Series<'a, D> {
     #[inline]
     pub fn parse_value<T, F, E>(&mut self, f: F) -> Result<T, E>
     where
-        F: FnOnce(Value, bool, Vec<u64>) -> Result<T, E>,
+        F: FnOnce(Value, bool, &[u64]) -> Result<T, E>,
         E: From<Error>,
     {
         self.try_parse_value(f)?.ok_or(Error::NoMoreItems.into())
@@ -154,7 +154,7 @@ impl<'a, const D: usize> Series<'a, D> {
 
     pub fn try_parse_array<T, F, E>(&mut self, f: F) -> Result<Option<T>, E>
     where
-        F: FnOnce(&mut Array, bool, Vec<u64>) -> Result<T, E>,
+        F: FnOnce(&mut Array, bool, &[u64]) -> Result<T, E>,
         E: From<Error>,
     {
         self.try_parse_value(|value, shortest, tags| match value {
@@ -167,7 +167,7 @@ impl<'a, const D: usize> Series<'a, D> {
 
     pub fn parse_array<T, F, E>(&mut self, f: F) -> Result<T, E>
     where
-        F: FnOnce(&mut Array, bool, Vec<u64>) -> Result<T, E>,
+        F: FnOnce(&mut Array, bool, &[u64]) -> Result<T, E>,
         E: From<Error>,
     {
         self.try_parse_array(f)?.ok_or(Error::NoMoreItems.into())
@@ -175,7 +175,7 @@ impl<'a, const D: usize> Series<'a, D> {
 
     pub fn try_parse_map<T, F, E>(&mut self, f: F) -> Result<Option<T>, E>
     where
-        F: FnOnce(&mut Map, bool, Vec<u64>) -> Result<T, E>,
+        F: FnOnce(&mut Map, bool, &[u64]) -> Result<T, E>,
         E: From<Error>,
     {
         self.try_parse_value(|value, shortest, tags| match value {
@@ -188,7 +188,7 @@ impl<'a, const D: usize> Series<'a, D> {
 
     pub fn parse_map<T, F, E>(&mut self, f: F) -> Result<T, E>
     where
-        F: FnOnce(&mut Map, bool, Vec<u64>) -> Result<T, E>,
+        F: FnOnce(&mut Map, bool, &[u64]) -> Result<T, E>,
         E: From<Error>,
     {
         self.try_parse_map(f)?.ok_or(Error::NoMoreItems.into())
@@ -231,7 +231,7 @@ enum DebugError {
 fn debug_fmt(
     value: Value,
     _shortest: bool,
-    _tags: Vec<u64>,
+    _tags: &[u64],
     max_recursion: usize,
 ) -> Result<SequenceDebugInfo, DebugError> {
     match value {


### PR DESCRIPTION
As per #142, rework the Errors to provide some feedback when a few more bytes are needed.

Also, refactored some of the existing code to use some more modern Rust idioms