### PR TITLE
fix: idempotent certificate generation for dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 target/
 /.vscode
 /test_data
+
+# Developement TLS certificates
+
+bpa-server/ca/
+bpa-server/certs/

--- a/scripts/generate_cert.sh
+++ b/scripts/generate_cert.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+BPA_SERVER="$PROJECT_ROOT/bpa-server"
+
+# Ensure required directories exist
+mkdir -p "$BPA_SERVER/ca" "$BPA_SERVER/certs"
+
 # Generate and self-sign a Certificate Authority (CA) certificate
 openssl req -x509 -newkey rsa:4096 -nodes -days 365 \
-  -keyout ../bpa-server/ca/ca.key -out ../bpa-server/ca/ca.crt -subj "/CN=Test Hardy CA"
+  -keyout "$BPA_SERVER/ca/ca.key" -out "$BPA_SERVER/ca/ca.crt" -subj "/CN=Test Hardy CA"
 
 # Generate a server private key and a Certificate Signing Request (CSR) for the server
-openssl req -newkey rsa:4096 -nodes -keyout ../bpa-server/certs/server.key \
-  -out ../bpa-server/certs/server.csr -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost"
+openssl req -newkey rsa:4096 -nodes -keyout "$BPA_SERVER/certs/server.key" \
+  -out "$BPA_SERVER/certs/server.csr" -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost"
 
 # Sign the server CSR with the CA to issue the server certificate (including the SAN)
-openssl x509 -req -in ../bpa-server/certs/server.csr -CA ../bpa-server/ca/ca.crt -CAkey ../bpa-server/ca/ca.key \
-  -CAcreateserial -out ../bpa-server/certs/server.crt -days 365 -extfile <(printf "subjectAltName=DNS:localhost")
+openssl x509 -req -in "$BPA_SERVER/certs/server.csr" -CA "$BPA_SERVER/ca/ca.crt" -CAkey "$BPA_SERVER/ca/ca.key" \
+  -CAcreateserial -out "$BPA_SERVER/certs/server.crt" -days 365 -extfile <(printf "subjectAltName=DNS:localhost")


### PR DESCRIPTION
Hello :smile:,

The local development certificate generation currently fails out-of-the-box because the required directories (`bpa-server/ca` and `bpa-server/certs`) are not versioned. This prevents the script from creating or updating certificates as expected.

<img width="1600" height="496" alt="image" src="https://github.com/user-attachments/assets/01aec78a-40ca-4c8a-a312-2328d648b933" />

## Solution
This PR improves the certificate generation process by:

1. Ensuring directory existence: automatically creates `bpa-server/ca` and `bpa-server/certs` if they don’t exist.
2. Path flexibility: allows the script to work regardless of the current working directory within the project.

## (Nice) Side Effect
Running `./scripts/generate_cert.sh` will now overwrite existing certificates with new ones, making it easier to renew local development certificates when needed.