### PR TITLE
Use the metadata previous node if there is no PreviousNode block

### DIFF
--- a/bpa/src/bundle.rs
+++ b/bpa/src/bundle.rs
@@ -31,6 +31,21 @@ impl Bundle {
     pub fn has_expired(&self) -> bool {
         self.expiry() <= time::OffsetDateTime::now_utc()
     }
+
+    /// Returns the EID of the node that forwarded this bundle.
+    ///
+    /// Prefers the Previous Node extension block (in-band), falling back to
+    /// the CLA peer node ID (out-of-band). Per RFC 9171 Section 4.4.1, both
+    /// identify the immediate 1-hop forwarding node when present.
+    pub fn previous_node(&self) -> Option<hardy_bpv7::eid::Eid> {
+        self.bundle.previous_node.clone().or_else(|| {
+            self.metadata
+                .read_only
+                .ingress_peer_node
+                .clone()
+                .map(Into::into)
+        })
+    }
 }
 
 #[cfg(test)]

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -331,7 +331,7 @@ impl Dispatcher {
     #[cfg_attr(feature = "tracing", instrument(skip_all,fields(bundle.id = %bundle.bundle.id)))]
     async fn process_bundle(&self, mut bundle: bundle::Bundle, data: Bytes) {
         // Perform RIB lookup (sets bundle.metadata.next_hop for Forward results)
-        match self.rib.find(&bundle.bundle, &mut bundle.metadata) {
+        match self.rib.find(&mut bundle) {
             Some(rib::FindResult::Drop(reason)) => {
                 debug!("Routing lookup indicates bundle should be dropped: {reason:?}");
                 self.drop_bundle(bundle, reason).await

--- a/bpa/src/rib/find.rs
+++ b/bpa/src/rib/find.rs
@@ -11,12 +11,8 @@ enum InternalFindResult<'a> {
 }
 
 impl Rib {
-    #[cfg_attr(feature = "tracing", instrument(skip_all,fields(bundle.id = %bundle.id)))]
-    pub fn find(
-        &self,
-        bundle: &hardy_bpv7::bundle::Bundle,
-        metadata: &mut metadata::BundleMetadata,
-    ) -> Option<FindResult> {
+    #[cfg_attr(feature = "tracing", instrument(skip_all,fields(bundle.id = %bundle.bundle.id)))]
+    pub fn find(&self, bundle: &mut bundle::Bundle) -> Option<FindResult> {
         let inner = self.inner.read();
 
         // TODO: this is where route table switching can occur
@@ -25,24 +21,27 @@ impl Rib {
         let result = find_recurse(
             &inner,
             table,
-            &bundle.destination,
+            &bundle.bundle.destination,
             true,
             &mut HashSet::new(),
         )?;
         if !matches!(result, InternalFindResult::Reflect) {
             // Drop the mutex before the mapping
-            return map_result(result, bundle, metadata);
+            return map_result(result, &bundle.bundle, &mut bundle.metadata);
         };
 
-        // Return the bundle to the source via the 'previous_node' or 'bundle.source'
-        let previous = bundle.previous_node.as_ref().unwrap_or(&bundle.id.source);
+        // Reflect: return the bundle via the previous forwarding node,
+        // falling back to the bundle source as last resort.
+        let previous = bundle
+            .previous_node()
+            .unwrap_or_else(|| bundle.bundle.id.source.clone());
 
-        let result = find_recurse(&inner, table, previous, false, &mut HashSet::new())?;
+        let result = find_recurse(&inner, table, &previous, false, &mut HashSet::new())?;
         if matches!(result, InternalFindResult::Reflect) {
             // Ignore double reflection
             None
         } else {
-            map_result(result, bundle, metadata)
+            map_result(result, &bundle.bundle, &mut bundle.metadata)
         }
     }
 


### PR DESCRIPTION
We had 2 slightly different versions of previous_node, one from an extension block, and one from the CLA we can detect internally.

This adds a utility function to unify them when it comes to Reflect processing