### PR TITLE
Dockerize Hardy server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+docs/
+tests/
+*.md
+*.lock
+!Cargo.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM rust:1-slim-bookworm AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        protobuf-compiler \
+        libprotobuf-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
+COPY . .
+RUN cargo build --release --bin hardy-bpa-server
+
+# ── Stage 2: minimal runtime image ───────────────────────────────────────────
+FROM gcr.io/distroless/cc-debian12 AS runtime
+COPY --from=builder \
+    /build/target/release/hardy-bpa-server \
+    /usr/local/bin/hardy-bpa-server
+EXPOSE 50051
+ENTRYPOINT ["/usr/local/bin/hardy-bpa-server"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Hardy is a modular implementation of the Bundle Protocol Version 7 (BPv7) as def
   - [Services & Filters](#services--filters)
   - [Servers & Tools](#servers--tools)
 - [Getting Started](#getting-started)
+  - [Running with Docker](#running-with-docker)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
 - [License](#license)
@@ -113,6 +114,27 @@ cargo test --workspace
 ```
 
 See the [bpa-server README](./bpa-server/README.md) for detailed configuration options and example configurations.
+
+### Running with Docker
+
+The BPA server can run as a container using the provided [Dockerfile](./Dockerfile) and [Compose file](./compose.yaml).
+
+**Prerequisites:** Docker and Docker Compose (v2.23+ for inline config support).
+
+Build and start:
+
+```bash
+docker compose up --build -d
+```
+
+The server listens on **gRPC** (50051) and **TCPCLv4** (4556). Configuration is embedded in `compose.yaml` via the `hardy-config` config; edit the `configs.hardy-config.content` block to change node settings.
+
+To send a test bundle to the echo service (from the host, using the `bp` tool):
+
+```bash
+cargo build --release -p hardy-tools
+./target/release/bp ping ipn:1.7 --peer 127.0.0.1:4556
+```
 
 ### Bundle Tools
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,60 @@
+services:
+  hardy:
+    build: .
+    image: hardy:latest
+    restart: unless-stopped
+    environment:
+      HARDY_BPA_SERVER_CONFIG_FILE: /etc/hardy/config.toml
+    ports:
+      - "50051:50051"
+      - "4556:4556"
+    volumes:
+      - bundles:/var/lib/hardy/bundles
+    configs:
+      - source: hardy-config
+        target: /etc/hardy/config.toml
+
+volumes:
+  bundles:
+
+configs:
+  hardy-config:
+    content: |
+      log_level = "debug"
+      node_ids = ["ipn:1.0", "dtn://my-node/"]
+      ipn-legacy-nodes = []
+      echo = [7, "echo"]
+      status_reports = true
+      poll_channel_depth = 16
+      processing_pool_size = 16
+
+      [grpc]
+      address = "[::]:50051"
+      services = ["application", "cla", "service"]
+
+      [storage]
+      lru_capacity = 1024
+      max_cached_bundle_size = 16384
+
+      [metadata_storage]
+      type = "memory"
+      
+      [bundle_storage]
+      type = "localdisk"
+      store_dir = "/var/lib/hardy/bundles"
+      fsync = true
+
+      [rfc9171-validity]
+      primary-block-integrity = true
+      bundle-age-required = true
+
+      [[clas]]
+      name = "tcp-cla-1"
+      type = "tcpclv4"
+      address = "[::]:4556"
+      segment_mru = 16384
+      transfer_mru = 562949953421312
+      max_idle_connections = 6
+      contact_timeout = 15
+      keepalive_interval = 60
+      must_use_tls = false


### PR DESCRIPTION
## Summary

Adds Docker and Docker Compose support for running the BPA server in a container, and documents it in the README.

## How to test

1. `docker compose up --build -d`
2. `bp ping ipn:1.7 --peer 127.0.0.1:4556`