### PR TITLE
Hardy bpa-server config file schema validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1194,7 @@ dependencies = [
  "trace-err",
  "tracing",
  "tracing-subscriber",
+ "validator",
  "winnow",
 ]
 
@@ -1708,6 +1744,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2443,6 +2485,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -3613,6 +3677,36 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "validator"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+dependencies = [
+ "darling",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "valuable"

--- a/bpa-server/Cargo.toml
+++ b/bpa-server/Cargo.toml
@@ -37,7 +37,7 @@ hardy-otel = { path = "../otel", optional = true }
 hardy-ipn-legacy-filter = { path = "../ipn-legacy-filter", features = ["serde"], optional = true }
 hardy-echo-service = { path = "../echo-service", optional = true }
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "macros", "signal"] }
-config = { version = "0.15.19", features = ["yaml"] }
+config = { version = "0.15.19", features = ["toml", "yaml"] }
 serde = { version = "1.0.228", features = ["derive"] }
 validator = { version = "0.20.0", features = ["derive"] }
 getopts = "0.2.24"

--- a/bpa-server/Cargo.toml
+++ b/bpa-server/Cargo.toml
@@ -37,8 +37,9 @@ hardy-otel = { path = "../otel", optional = true }
 hardy-ipn-legacy-filter = { path = "../ipn-legacy-filter", features = ["serde"], optional = true }
 hardy-echo-service = { path = "../echo-service", optional = true }
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "macros", "signal"] }
-config = { version = "0.15.19", features = ["toml"] }
+config = { version = "0.15.19", features = ["yaml"] }
 serde = { version = "1.0.228", features = ["derive"] }
+validator = { version = "0.20.0", features = ["derive"] }
 getopts = "0.2.24"
 directories = "6.0.0"
 tracing = "0.1.44"

--- a/bpa-server/src/built_in_services.rs
+++ b/bpa-server/src/built_in_services.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 #[derive(Serialize, Deserialize, Debug, Default, Validate)]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct BuiltInServicesConfig {
     /// Echo service: list of service identifiers (int = IPN, string = DTN).
     #[validate(length(min = 1))]

--- a/bpa-server/src/built_in_services.rs
+++ b/bpa-server/src/built_in_services.rs
@@ -1,9 +1,16 @@
 use super::*;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
 
-pub async fn init(
-    config: &config::BuiltInServicesConfig,
-    bpa: &dyn hardy_bpa::bpa::BpaRegistration,
-) {
+#[derive(Serialize, Deserialize, Debug, Default, Validate)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct BuiltInServicesConfig {
+    /// Echo service: list of service identifiers (int = IPN, string = DTN).
+    #[validate(length(min = 1))]
+    pub echo: Option<Vec<hardy_bpv7::eid::Service>>,
+}
+
+pub async fn init(config: &BuiltInServicesConfig, bpa: &dyn hardy_bpa::bpa::BpaRegistration) {
     #[cfg(feature = "echo")]
     if let Some(services) = &config.echo {
         if services.is_empty() {

--- a/bpa-server/src/config.rs
+++ b/bpa-server/src/config.rs
@@ -2,6 +2,7 @@ use super::*;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
 use tracing::Level;
+use validator::Validate;
 
 mod log_level_serde {
     use super::*;
@@ -54,7 +55,7 @@ pub enum BundleStorage {
     // S3(S3Config),
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Validate)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct StorageConfig {
     /// BPA bundle cache settings (LRU capacity, max cached bundle size).
@@ -68,14 +69,7 @@ pub struct StorageConfig {
     pub bundle: Option<BundleStorage>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
-#[serde(default, rename_all = "kebab-case")]
-pub struct BuiltInServicesConfig {
-    /// Echo service: list of service identifiers (int = IPN, string = DTN).
-    pub echo: Option<Vec<hardy_bpv7::eid::Service>>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Validate)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     /// Logging level
@@ -96,6 +90,7 @@ pub struct Config {
 
     /// Storage configuration (cache + metadata + bundle backends)
     #[serde(default)]
+    #[validate(nested)]
     pub storage: StorageConfig,
 
     #[serde(default)]
@@ -117,7 +112,8 @@ pub struct Config {
     /// Integers are IPN service numbers, strings are DTN service names.
     /// Absent key = service disabled.
     #[serde(default)]
-    pub built_in_services: BuiltInServicesConfig,
+    #[validate(nested)]
+    pub built_in_services: built_in_services::BuiltInServicesConfig,
 
     /// Convergence Layer Adaptors (CLAs)
     #[serde(default)]
@@ -172,8 +168,13 @@ pub fn load(cli: &cli::Args) -> Config {
 
     b = b.add_source(::config::Environment::with_prefix("HARDY_BPA_SERVER"));
 
-    b.build()
+    let config: Config = b
+        .build()
         .expect("Failed to read configuration")
         .try_deserialize()
-        .expect("Failed to parse configuration")
+        .expect("Failed to parse configuration");
+
+    config.validate().expect("Invalid configuration");
+
+    config
 }

--- a/bpa-server/src/config.rs
+++ b/bpa-server/src/config.rs
@@ -161,9 +161,9 @@ pub fn load(cli: &cli::Args) -> Config {
         );
         b = b.add_source(::config::File::with_name(&source))
     } else {
-        let path = config_dir().join(format!("{}.yaml", env!("CARGO_PKG_NAME")));
+        let path = config_dir().join(env!("CARGO_PKG_NAME"));
         eprintln!("Using configuration file '{}'", path.display());
-        b = b.add_source(::config::File::from(path).required(false))
+        b = b.add_source(::config::File::with_name(&path.to_string_lossy()).required(false))
     }
 
     b = b.add_source(::config::Environment::with_prefix("HARDY_BPA_SERVER"));

--- a/bpa-server/src/grpc.rs
+++ b/bpa-server/src/grpc.rs
@@ -2,7 +2,7 @@ use super::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub address: std::net::SocketAddr,
     pub services: Vec<String>,

--- a/bpa-server/src/static_routes/mod.rs
+++ b/bpa-server/src/static_routes/mod.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 mod parse;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Config {
     pub routes_file: PathBuf,
     pub priority: u32,


### PR DESCRIPTION
## Summary (this PR is a proposal, subject to discussion)

This PR introduces structured configuration loading with schema validation for the application configuration file (TOML/YAML) and environment variables.

> Configuration values are now deserialized into strongly-typed Rust structs and validated at startup.

### Motivation

Previously, configuration errors such as:
- misspelled keys,
- invalid value types,
- inconsistent or incomplete configuration,

could silently pass or fail later at runtime, making issues harder to diagnose.

This change ensures configuration problems are detected early **during startup,** with explicit and actionable error messages.

### What's supported after this PR

- Strongly typed `Config` structures using `serde`
- Support for configuration loading from:
  - configuration file (TOML or YAML, auto-detected from extension)
  - environment variables (environment overrides file values)
- Schema validation:
  - **unknown fields are rejected** (`deny_unknown_fields`) on `[grpc]`, `[static-routes]`, and `[built-in-services]`. A typo like `adress` instead of `address` is an immediate error rather than a silently ignored key
  - **type mismatches** are detected during deserialization
  - **semantic validation** via `validator`: `built-in-services.echo`, when present, must contain at least one endpoint
  
## Limitations (what sould we do?)

`deny_unknown_fields` could not be applied to the root `Config` and `[storage]` sections because they use `#[serde(flatten)]`. Serde's unknown-field check runs before flattening resolves, so fields belonging to the inner struct would be incorrectly rejected. The current flat layout (where `node-ids`, `status-reports`, etc. sit at the root level rather than under a `[bpa]` section) is the cause. De-flattening `bpa` into its own section would be a breaking config change but would unlock full unknown-field rejection across the board.