### PR TITLE
fix(interop): update test configs for bpa-server schema changes and fix macOS sed compatibility

### DIFF
--- a/tests/interop/DTNME/test_dtnme_ping.sh
+++ b/tests/interop/DTNME/test_dtnme_ping.sh
@@ -249,7 +249,7 @@ echo ""
 # Extract received count from "N bundles transmitted, M received" line
 STATS_LINE=$(echo "$PING_OUTPUT" | grep -E '[0-9]+ (bundles )?transmitted' | head -1)
 TRANSMITTED=$(echo "$STATS_LINE" | sed -E 's/^([0-9]+).*/\1/')
-RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*,\s*([0-9]+)\s+received.*/\1/')
+RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*, ([0-9]+) received.*/\1/')
 
 if [ $EXIT_CODE -eq 0 ]; then
     if [ "$RECEIVED" = "$TRANSMITTED" ] && [ -n "$RECEIVED" ]; then

--- a/tests/interop/HDTN/test_hdtn_ping.sh
+++ b/tests/interop/HDTN/test_hdtn_ping.sh
@@ -252,7 +252,7 @@ echo ""
 # Extract received count from "N bundles transmitted, M received" line
 STATS_LINE=$(echo "$PING_OUTPUT" | grep -E '[0-9]+ (bundles )?transmitted' | head -1)
 TRANSMITTED=$(echo "$STATS_LINE" | sed -E 's/^([0-9]+).*/\1/')
-RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*,\s*([0-9]+)\s+received.*/\1/')
+RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*, ([0-9]+) received.*/\1/')
 
 if [ $EXIT_CODE -eq 0 ]; then
     if [ "$RECEIVED" = "$TRANSMITTED" ] && [ -n "$RECEIVED" ]; then

--- a/tests/interop/dtn7-rs/test_dtn7rs_ping.sh
+++ b/tests/interop/dtn7-rs/test_dtn7rs_ping.sh
@@ -258,7 +258,7 @@ echo ""
 # Extract received count from "N bundles transmitted, M received" line
 STATS_LINE=$(echo "$PING_OUTPUT" | grep -E '[0-9]+ (bundles )?transmitted' | head -1)
 TRANSMITTED=$(echo "$STATS_LINE" | sed -E 's/^([0-9]+).*/\1/')
-RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*,\s*([0-9]+)\s+received.*/\1/')
+RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*, ([0-9]+) received.*/\1/')
 
 if [ $EXIT_CODE -eq 0 ]; then
     if [ "$RECEIVED" = "$TRANSMITTED" ] && [ -n "$RECEIVED" ]; then

--- a/tests/interop/hardy/test_hardy_ping.sh
+++ b/tests/interop/hardy/test_hardy_ping.sh
@@ -233,7 +233,7 @@ echo ""
 # Extract received count from "N bundles transmitted, M received" line
 STATS_LINE=$(echo "$PING_OUTPUT" | grep -E '[0-9]+ (bundles )?transmitted' | head -1)
 TRANSMITTED=$(echo "$STATS_LINE" | sed -E 's/^([0-9]+).*/\1/')
-RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*,\s*([0-9]+)\s+received.*/\1/')
+RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*, ([0-9]+) received.*/\1/')
 
 if [ $EXIT_CODE -eq 0 ]; then
     if [ "$RECEIVED" = "$TRANSMITTED" ] && [ -n "$RECEIVED" ]; then
@@ -276,7 +276,7 @@ echo ""
 # Extract received count from "N bundles transmitted, M received" line
 STATS_LINE=$(echo "$PING_OUTPUT" | grep -E '[0-9]+ (bundles )?transmitted' | head -1)
 TRANSMITTED=$(echo "$STATS_LINE" | sed -E 's/^([0-9]+).*/\1/')
-RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*,\s*([0-9]+)\s+received.*/\1/')
+RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*, ([0-9]+) received.*/\1/')
 
 if [ $EXIT_CODE -eq 0 ]; then
     if [ "$RECEIVED" = "$TRANSMITTED" ] && [ -n "$RECEIVED" ]; then


### PR DESCRIPTION
## Summary 

- Update interop test configs to match the restructured `bpa-server` config schema (kebab-case field names, `built-in-services` section, nested `storage` block)
- Fix ping stats parsing to use a portable `sed` pattern that works on both GNU (Linux) and BSD (macOS) sed

## How to test

- [x] Run `./tests/interop/hardy/test_hardy_ping.sh` on macOS — both tests should pass
- [x] Run `./tests/interop/hardy/test_hardy_ping.sh` on Linux — both tests should pass
- [x] Run `./tests/interop/dtn7-rs/test_dtn7rs_ping.sh` (requires Docker)
- [x] Run `./tests/interop/HDTN/test_hdtn_ping.sh` (requires Docker)
- [x] Run `./tests/interop/DTNME/test_dtnme_ping.sh` (requires Docker)
