### PR TITLE
refactor(bpa): drop internal config propagation, use explicit params …

### DIFF
--- a/bpa-server/src/config.rs
+++ b/bpa-server/src/config.rs
@@ -54,18 +54,28 @@ pub enum BundleStorage {
     // S3(S3Config),
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct StorageConfig {
-    /// BPA bundle cache settings (LRU capacity, max cached bundle size).
-    #[serde(flatten)]
-    pub cache: hardy_bpa::storage::Config,
-
+    /// LRU capacity for the bundle cache.
+    pub lru_capacity: core::num::NonZeroUsize,
+    /// Max size of a single bundle to keep in the LRU cache (bytes).
+    pub max_cached_bundle_size: core::num::NonZeroUsize,
     /// Metadata storage backend. Uses in-memory if not set.
     pub metadata: Option<MetadataStorage>,
-
     /// Bundle data storage backend. Uses in-memory if not set.
     pub bundle: Option<BundleStorage>,
+}
+
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            lru_capacity: core::num::NonZeroUsize::new(1024).unwrap(),
+            max_cached_bundle_size: core::num::NonZeroUsize::new(16 * 1024).unwrap(),
+            metadata: None,
+            bundle: None,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/bpa-server/src/main.rs
+++ b/bpa-server/src/main.rs
@@ -102,15 +102,16 @@ async fn inner_main(config: config::Config, cli: cli::Args) -> anyhow::Result<()
     let (metadata_storage, bundle_storage) = init_storage(&config.storage, cli.upgrade_storage);
 
     let bpa_config = hardy_bpa::config::Config {
-        storage: config.storage.cache,
+        lru_capacity: config.storage.lru_capacity,
+        max_cached_bundle_size: config.storage.max_cached_bundle_size,
         ..config.bpa
     };
+    info!("Configured node IDs: {}", bpa_config.node_ids);
     let bpa = Arc::new(hardy_bpa::bpa::Bpa::new(
-        &bpa_config,
+        bpa_config,
         metadata_storage,
         bundle_storage,
     ));
-    info!("Configured node IDs: {}", bpa_config.node_ids);
 
     // Prepare for graceful shutdown
     let tasks = TaskPool::new();

--- a/bpa/fuzz/src/lib.rs
+++ b/bpa/fuzz/src/lib.rs
@@ -68,21 +68,19 @@ async fn new_bpa(testname: &str) -> hardy_bpa::bpa::Bpa {
     #[cfg(not(feature = "localdisk-storage"))]
     let bundle_storage = None;
 
-    let bpa = hardy_bpa::bpa::Bpa::new(
-        &hardy_bpa::config::Config {
-            status_reports: true,
-            node_ids: [hardy_bpv7::eid::NodeId::Ipn(hardy_bpv7::eid::IpnNodeId {
-                allocator_id: 0,
-                node_number: 1,
-            })]
-            .as_slice()
-            .try_into()
-            .unwrap(),
-            ..Default::default()
-        },
-        metadata_storage,
-        bundle_storage,
-    );
+    let bpa_config = hardy_bpa::config::Config {
+        status_reports: true,
+        node_ids: [hardy_bpv7::eid::NodeId::Ipn(hardy_bpv7::eid::IpnNodeId {
+            allocator_id: 0,
+            node_number: 1,
+        })]
+        .as_slice()
+        .try_into()
+        .unwrap(),
+        ..Default::default()
+    };
+
+    let bpa = hardy_bpa::bpa::Bpa::new(bpa_config, metadata_storage, bundle_storage);
 
     bpa.start(
         #[cfg(all(feature = "localdisk-storage", feature = "sqlite-storage"))]

--- a/bpa/src/bpa.rs
+++ b/bpa/src/bpa.rs
@@ -172,23 +172,31 @@ pub struct Bpa {
 
 impl Bpa {
     pub fn new(
-        config: &config::Config,
+        config: config::Config,
         metadata_storage: Option<Arc<dyn storage::MetadataStorage>>,
         bundle_storage: Option<Arc<dyn storage::BundleStorage>>,
     ) -> Self {
+        let status_reports = config.status_reports;
+        let poll_channel_depth = config.poll_channel_depth;
+        let processing_pool_size = config.processing_pool_size;
+        let node_ids = config.node_ids;
+
         // New store
         let store = Arc::new(storage::Store::new(
-            config,
+            config.lru_capacity,
+            config.max_cached_bundle_size,
+            poll_channel_depth,
             metadata_storage,
             bundle_storage,
         ));
 
         // New RIB
-        let rib = Arc::new(rib::Rib::new(config, store.clone()));
+        let rib = Arc::new(rib::Rib::new(node_ids.clone(), store.clone()));
 
         // New registries
         let cla_registry = Arc::new(cla::registry::Registry::new(
-            config,
+            (&node_ids).into(),
+            poll_channel_depth.into(),
             rib.clone(),
             store.clone(),
         ));
@@ -196,10 +204,13 @@ impl Bpa {
         // New Keys Registry (TODO: Make this load keys from the Config!)
         let keys_registry = Arc::new(keys::registry::Registry::new());
 
-        let service_registry = Arc::new(services::registry::Registry::new(config, rib.clone()));
+        let service_registry = Arc::new(services::registry::Registry::new(
+            node_ids.clone(),
+            rib.clone(),
+        ));
 
         // New filter registry
-        let filter_registry = Arc::new(filters::registry::Registry::new(config));
+        let filter_registry = Arc::new(filters::registry::Registry::new());
 
         // Auto-register RFC9171 validity filter unless disabled
         #[cfg(not(feature = "no-rfc9171-autoregister"))]
@@ -218,7 +229,10 @@ impl Bpa {
 
         // New dispatcher (returns Arc, starts immediately)
         let dispatcher = dispatcher::Dispatcher::new(
-            config,
+            status_reports,
+            poll_channel_depth,
+            processing_pool_size,
+            node_ids,
             store.clone(),
             cla_registry.clone(),
             service_registry.clone(),

--- a/bpa/src/cla/registry.rs
+++ b/bpa/src/cla/registry.rs
@@ -124,14 +124,19 @@ pub(crate) struct Registry {
 }
 
 impl Registry {
-    pub fn new(config: &config::Config, rib: Arc<rib::Rib>, store: Arc<storage::Store>) -> Self {
+    pub fn new(
+        node_ids: Vec<NodeId>,
+        poll_channel_depth: usize,
+        rib: Arc<rib::Rib>,
+        store: Arc<storage::Store>,
+    ) -> Self {
         Self {
-            node_ids: (&config.node_ids).into(),
+            node_ids,
             clas: Default::default(),
             rib,
             store,
             peers: peers::PeerTable::new(),
-            poll_channel_depth: config.poll_channel_depth.into(),
+            poll_channel_depth,
             tasks: hardy_async::TaskPool::new(),
         }
     }

--- a/bpa/src/config.rs
+++ b/bpa/src/config.rs
@@ -6,10 +6,8 @@ pub struct Config {
     pub status_reports: bool,
     pub poll_channel_depth: core::num::NonZeroUsize,
     pub processing_pool_size: core::num::NonZeroUsize,
-
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pub storage: storage::Config,
-
+    pub lru_capacity: core::num::NonZeroUsize,
+    pub max_cached_bundle_size: core::num::NonZeroUsize,
     pub node_ids: node_ids::NodeIds,
 }
 
@@ -22,7 +20,8 @@ impl Default for Config {
                 hardy_async::available_parallelism().get() * 4,
             )
             .unwrap(),
-            storage: storage::Config::default(),
+            lru_capacity: core::num::NonZeroUsize::new(1024).unwrap(),
+            max_cached_bundle_size: core::num::NonZeroUsize::new(16 * 1024).unwrap(),
             node_ids: node_ids::NodeIds::default(),
         }
     }

--- a/bpa/src/dispatcher/mod.rs
+++ b/bpa/src/dispatcher/mod.rs
@@ -31,7 +31,10 @@ pub(crate) struct Dispatcher {
 impl Dispatcher {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        config: &config::Config,
+        status_reports: bool,
+        poll_channel_depth: core::num::NonZeroUsize,
+        processing_pool_size: core::num::NonZeroUsize,
+        node_ids: node_ids::NodeIds,
         store: Arc<storage::Store>,
         cla_registry: Arc<cla::registry::Registry>,
         service_registry: Arc<services::registry::Registry>,
@@ -40,7 +43,10 @@ impl Dispatcher {
         filter_registry: Arc<filters::registry::Registry>,
     ) -> Arc<Self> {
         let (dispatcher, start) = Self::new_inner(
-            config,
+            status_reports,
+            poll_channel_depth,
+            processing_pool_size,
+            node_ids,
             store,
             cla_registry,
             service_registry,
@@ -54,7 +60,10 @@ impl Dispatcher {
 
     #[allow(clippy::too_many_arguments)]
     fn new_inner(
-        config: &config::Config,
+        status_reports: bool,
+        poll_channel_depth: core::num::NonZeroUsize,
+        processing_pool_size: core::num::NonZeroUsize,
+        node_ids: node_ids::NodeIds,
         store: Arc<storage::Store>,
         cla_registry: Arc<cla::registry::Registry>,
         service_registry: Arc<services::registry::Registry>,
@@ -62,19 +71,19 @@ impl Dispatcher {
         keys_registry: Arc<keys::registry::Registry>,
         filter_registry: Arc<filters::registry::Registry>,
     ) -> (Arc<Self>, impl FnOnce(&Arc<Self>)) {
-        if config.status_reports {
+        if status_reports {
             warn!("Bundle status reports are enabled");
         }
 
-        let poll_channel_depth: usize = config.poll_channel_depth.into();
+        let poll_channel_depth_usize: usize = poll_channel_depth.into();
 
         // Create the dispatch queue channel
         let (dispatch_tx, dispatch_rx) =
-            store.channel(BundleStatus::Dispatching, poll_channel_depth);
+            store.channel(BundleStatus::Dispatching, poll_channel_depth_usize);
 
         let dispatcher = Arc::new(Self {
             tasks: hardy_async::TaskPool::new(),
-            processing_pool: hardy_async::BoundedTaskPool::new(config.processing_pool_size),
+            processing_pool: hardy_async::BoundedTaskPool::new(processing_pool_size),
             store,
             service_registry,
             cla_registry,
@@ -82,9 +91,9 @@ impl Dispatcher {
             keys_registry,
             filter_registry,
             dispatch_tx,
-            status_reports: config.status_reports,
-            node_ids: config.node_ids.clone(),
-            poll_channel_depth,
+            status_reports,
+            node_ids,
+            poll_channel_depth: poll_channel_depth_usize,
         });
 
         (dispatcher, |d| {

--- a/bpa/src/filters/registry.rs
+++ b/bpa/src/filters/registry.rs
@@ -32,7 +32,7 @@ pub struct Registry {
 }
 
 impl Registry {
-    pub fn new(_config: &config::Config) -> Self {
+    pub fn new() -> Self {
         Self {
             inner: RwLock::new(RegistryInner::default()),
         }

--- a/bpa/src/rib/local.rs
+++ b/bpa/src/rib/local.rs
@@ -47,7 +47,7 @@ pub struct LocalInner {
 }
 
 impl LocalInner {
-    pub fn new(config: &config::Config) -> Self {
+    pub fn new(node_ids: &node_ids::NodeIds) -> Self {
         let mut actions = BTreeMap::new();
         let mut finals = BTreeSet::new();
 
@@ -63,7 +63,7 @@ impl LocalInner {
         // Drop LocalNode services
         finals.insert(NodeId::LocalNode.into());
 
-        if let Some(node_id) = &config.node_ids.ipn {
+        if let Some(node_id) = &node_ids.ipn {
             // Add the Admin Endpoint EID itself (exact match, not wildcard)
             // Convert to Eid first to get ipn:N.0, then to EidPattern for exact match
             let admin_eid: Eid = node_id.clone().into();
@@ -77,7 +77,7 @@ impl LocalInner {
             finals.insert(node_id.clone().into());
         }
 
-        if let Some(node_name) = &config.node_ids.dtn {
+        if let Some(node_name) = &node_ids.dtn {
             // Add the Admin Endpoint EID itself (exact match, not wildcard)
             let admin_eid: Eid = node_name.clone().into();
             actions.insert(admin_eid.into(), [local::Action::AdminEndpoint].into());

--- a/bpa/src/rib/mod.rs
+++ b/bpa/src/rib/mod.rs
@@ -34,10 +34,10 @@ pub struct Rib {
 }
 
 impl Rib {
-    pub fn new(config: &config::Config, store: Arc<storage::Store>) -> Self {
+    pub fn new(node_ids: node_ids::NodeIds, store: Arc<storage::Store>) -> Self {
         Self {
             inner: RwLock::new(RibInner {
-                locals: local::LocalInner::new(config),
+                locals: local::LocalInner::new(&node_ids),
                 routes: BTreeMap::new(),
                 address_types: HashMap::new(),
             }),

--- a/bpa/src/services/registry.rs
+++ b/bpa/src/services/registry.rs
@@ -185,9 +185,9 @@ pub(crate) struct Registry {
 }
 
 impl Registry {
-    pub fn new(config: &config::Config, rib: Arc<rib::Rib>) -> Self {
+    pub fn new(node_ids: node_ids::NodeIds, rib: Arc<rib::Rib>) -> Self {
         Self {
-            node_ids: config.node_ids.clone(),
+            node_ids,
             rib,
             services: Default::default(),
             tasks: hardy_async::TaskPool::new(),

--- a/bpa/src/storage/mod.rs
+++ b/bpa/src/storage/mod.rs
@@ -25,23 +25,6 @@ pub(crate) mod store;
 
 mod reaper;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(default, rename_all = "kebab-case"))]
-pub struct Config {
-    pub lru_capacity: core::num::NonZeroUsize,
-    pub max_cached_bundle_size: core::num::NonZeroUsize,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            lru_capacity: core::num::NonZeroUsize::new(1024).unwrap(),
-            max_cached_bundle_size: core::num::NonZeroUsize::new(16 * 1024).unwrap(),
-        }
-    }
-}
-
 /// The `MetadataStorage` trait defines the interface for storing and managing bundle metadata.
 ///
 /// This trait provides a set of asynchronous methods for interacting with the metadata storage,

--- a/bpa/src/storage/store.rs
+++ b/bpa/src/storage/store.rs
@@ -4,7 +4,9 @@ impl Store {
     /// Create a new Store with the configured storage backends.
     /// Uses in-memory storage if no backends are provided.
     pub fn new(
-        config: &config::Config,
+        lru_capacity: core::num::NonZeroUsize,
+        max_cached_bundle_size: core::num::NonZeroUsize,
+        reaper_cache_size: core::num::NonZeroUsize,
         metadata_storage: Option<Arc<dyn storage::MetadataStorage>>,
         bundle_storage: Option<Arc<dyn storage::BundleStorage>>,
     ) -> Self {
@@ -13,13 +15,11 @@ impl Store {
             metadata_storage: metadata_storage
                 .unwrap_or_else(|| metadata_mem::new(&Default::default())),
             bundle_storage: bundle_storage.unwrap_or_else(|| bundle_mem::new(&Default::default())),
-            bundle_cache: hardy_async::sync::spin::Mutex::new(LruCache::new(
-                config.storage.lru_capacity,
-            )),
+            bundle_cache: hardy_async::sync::spin::Mutex::new(LruCache::new(lru_capacity)),
             reaper_cache: Arc::new(Mutex::new(BTreeSet::new())),
             reaper_wakeup: Arc::new(hardy_async::Notify::new()),
-            max_cached_bundle_size: config.storage.max_cached_bundle_size.into(),
-            reaper_cache_size: config.poll_channel_depth.into(),
+            max_cached_bundle_size: max_cached_bundle_size.into(),
+            reaper_cache_size: reaper_cache_size.into(),
         }
     }
 

--- a/tools/src/ping/exec.rs
+++ b/tools/src/ping/exec.rs
@@ -21,15 +21,13 @@ async fn exec_async(args: &Command) -> anyhow::Result<ExitCode> {
         );
     }
 
-    let bpa = hardy_bpa::bpa::Bpa::new(
-        &hardy_bpa::config::Config {
-            status_reports: true,
-            node_ids: [args.node_id()?].as_slice().try_into().unwrap(),
-            ..Default::default()
-        },
-        None,
-        None,
-    );
+    let bpa_config = hardy_bpa::config::Config {
+        status_reports: true,
+        node_ids: [args.node_id()?].as_slice().try_into().unwrap(),
+        ..Default::default()
+    };
+
+    let bpa = hardy_bpa::bpa::Bpa::new(bpa_config, None, None);
 
     // Add a default 'drop' route, we don't want to cache locally
     bpa.add_route(


### PR DESCRIPTION
## Summary

This PR simplifies how configuration flows through the BPA crates:

- **At the boundary**: `Bpa::new(config, metadata_storage, bundle_storage)` still takes a single `config::Config` (BpaConfig), so the "set up a struct, call new" style is unchanged.
- **Inside the crate**: Store, Rib, CLA registry, service registry, filter registry, and Dispatcher no longer take `&config::Config`. They take only the explicit parameters they need (e.g. `lru_capacity`, `node_ids`, `Arc<Store>`, `Arc<Rib>`). Dependencies are visible at each call site.
- **Removed `storage::Config`**: The shared cache config struct is gone. Store and BPA config use explicit `lru_capacity` and `max_cached_bundle_size` (and, for Store, `reaper_cache_size`). bpa-server `StorageConfig` exposes the same two cache fields with a manual `Default`.

Clone usage is tightened: config is passed by value into `Bpa::new` so fields can be moved where possible; `node_ids` is cloned only where multiple owners need it; `Arc` clones for store/rib/registries are unchanged.

