### PR TITLE
5.2-5.4 Implement BP-ARP subsystem

### DIFF
--- a/bpa/Cargo.toml
+++ b/bpa/Cargo.toml
@@ -24,6 +24,7 @@ std = [
     "foldhash/std",
 ]
 tracing = ["hardy-async/tracing"]
+bp-arp = ["hardy-bpv7/bp-arp"]
 
 [lib]
 path = "src/lib.rs"

--- a/bpa/src/bpa.rs
+++ b/bpa/src/bpa.rs
@@ -195,14 +195,8 @@ impl Bpa {
 
         // New registries
         let node_ids_arc = Arc::new(node_ids.clone());
-        let arp = if matches!(config.arp.policy, cla::arp::ArpPolicy::Never) {
-            None
-        } else {
-            Some(cla::arp::ArpSubsystem::new(
-                config.arp,
-                node_ids_arc.clone(),
-            ))
-        };
+        let arp = cla::arp::ArpSubsystem::new(config.arp, node_ids_arc.clone());
+
         let cla_registry = Arc::new(cla::registry::Registry::new(
             node_ids_arc,
             poll_channel_depth.into(),

--- a/bpa/src/bpa.rs
+++ b/bpa/src/bpa.rs
@@ -194,11 +194,21 @@ impl Bpa {
         let rib = Arc::new(rib::Rib::new(node_ids.clone(), store.clone()));
 
         // New registries
+        let node_ids_arc = Arc::new(node_ids.clone());
+        let arp = if matches!(config.arp.policy, cla::arp::ArpPolicy::Never) {
+            None
+        } else {
+            Some(cla::arp::ArpSubsystem::new(
+                config.arp,
+                node_ids_arc.clone(),
+            ))
+        };
         let cla_registry = Arc::new(cla::registry::Registry::new(
-            (&node_ids).into(),
+            node_ids_arc,
             poll_channel_depth.into(),
             rib.clone(),
             store.clone(),
+            arp,
         ));
 
         // New Keys Registry (TODO: Make this load keys from the Config!)

--- a/bpa/src/cla/arp.rs
+++ b/bpa/src/cla/arp.rs
@@ -1,0 +1,175 @@
+use super::*;
+use hardy_bpv7::{
+    bundle::Flags, creation_timestamp::CreationTimestamp, eid::Eid, hop_info::HopInfo,
+    status_report::AdministrativeRecord,
+};
+use trace_err::*;
+
+/// BP-ARP probe/retry interval and retry count.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default, rename_all = "kebab-case"))]
+#[derive(Debug, Clone)]
+pub struct ArpConfig {
+    /// How long to wait between probe retries (in whole seconds).
+    pub probe_interval_secs: u64,
+    /// How many times to retry a probe before giving up.
+    pub retry_count: u32,
+    /// When to probe a CLA peer for its EID.
+    pub policy: ArpPolicy,
+}
+
+impl Default for ArpConfig {
+    fn default() -> Self {
+        Self {
+            probe_interval_secs: 30,
+            retry_count: 5,
+            policy: ArpPolicy::default(),
+        }
+    }
+}
+
+impl ArpConfig {
+    pub fn probe_interval(&self) -> time::Duration {
+        time::Duration::seconds(self.probe_interval_secs as i64)
+    }
+}
+
+/// Controls when BP-ARP probing is triggered.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[derive(Debug, Clone, Default)]
+pub enum ArpPolicy {
+    /// Probe only when the peer's EID is unknown (Neighbour). This is the default.
+    #[default]
+    AsNeeded,
+    /// Always probe every new CLA peer, even if the EID is already known.
+    Always,
+    /// Never send probes (BP-ARP disabled).
+    Never,
+}
+
+struct NeighbourState {
+    _task: hardy_async::JoinHandle<()>,
+}
+
+/// Manages BP-ARP probe tasks for Neighbours.
+///
+/// A Neighbour is a CLA peer whose EID is not yet known. The ARP subsystem sends
+/// periodic `BpArpProbe` admin bundles directly over the CLA (bypassing the RIB)
+/// and waits for a `BpArpAck` response that reveals the remote EID.
+pub struct ArpSubsystem {
+    config: ArpConfig,
+    node_ids: Arc<node_ids::NodeIds>,
+    neighbours: hardy_async::sync::spin::Mutex<HashMap<u32, NeighbourState>>,
+}
+
+impl ArpSubsystem {
+    pub fn new(config: ArpConfig, node_ids: Arc<node_ids::NodeIds>) -> Arc<Self> {
+        Arc::new(Self {
+            config,
+            node_ids,
+            neighbours: hardy_async::sync::spin::Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Called when a Neighbour (peer with unknown EID) is added to the CLA registry.
+    /// Starts a probe-retry task unless `policy` is `Never`.
+    pub async fn on_neighbour_added(
+        self: &Arc<Self>,
+        peer_id: u32,
+        cla: Arc<registry::Cla>,
+        cla_addr: ClaAddress,
+        tasks: &hardy_async::TaskPool,
+    ) {
+        if matches!(self.config.policy, ArpPolicy::Never) {
+            return;
+        }
+
+        let this = self.clone();
+        let probe_bytes = self.build_probe();
+        let retry_count = self.config.retry_count;
+        let probe_interval = self.config.probe_interval();
+
+        let task = tasks.spawn(async move {
+            for attempt in 1..=retry_count {
+                debug!("BP-ARP: sending probe to peer {peer_id} (attempt {attempt}/{retry_count})");
+                if let Err(e) = cla.forward_raw(&cla_addr, probe_bytes.clone()).await {
+                    warn!("BP-ARP: probe send failed for peer {peer_id}: {e}");
+                }
+                hardy_async::time::sleep(probe_interval).await;
+
+                // Check if already resolved (abort() races with sleep completion)
+                if !this.neighbours.lock().contains_key(&peer_id) {
+                    return;
+                }
+            }
+            warn!("BP-ARP: exhausted {retry_count} probe retries for peer {peer_id}, giving up");
+            this.neighbours.lock().remove(&peer_id);
+        });
+
+        self.neighbours
+            .lock()
+            .insert(peer_id, NeighbourState { _task: task });
+    }
+
+    /// Called when a Neighbour is removed from the CLA registry (CLA disconnected).
+    pub async fn on_neighbour_removed(&self, peer_id: u32) {
+        // Dropping the JoinHandle does not abort the task, so we explicitly abort.
+        if let Some(state) = self.neighbours.lock().remove(&peer_id) {
+            state._task.abort();
+        }
+    }
+
+    /// Called when a `BpArpAck` (or `BpArpProbe`) is received that resolves a Neighbour.
+    /// Cancels the outstanding probe task.
+    pub async fn on_ack_received(&self, peer_id: u32) {
+        if let Some(state) = self.neighbours.lock().remove(&peer_id) {
+            state._task.abort();
+        }
+    }
+
+    /// Builds a `BpArpProbe` admin bundle as raw bytes, ready to send directly over a CLA.
+    ///
+    /// - Source: our admin endpoint (e.g. `ipn:42.0`)
+    /// - Destination: `ipn:!.0` (LocalNode) so the remote BPA routes it to its admin endpoint
+    /// - `is_admin_record` flag set
+    /// - Hop Count block (limit 1) per spec §4.2 to prevent forwarding beyond the neighbour
+    fn build_probe(&self) -> Bytes {
+        let source = self.node_ids.get_admin_endpoint(&Eid::LocalNode(0));
+        let destination = Eid::LocalNode(0);
+        let payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArpProbe).0;
+
+        let (_, data) = hardy_bpv7::builder::Builder::new(source, destination)
+            .with_flags(Flags {
+                is_admin_record: true,
+                ..Default::default()
+            })
+            .with_hop_count(&HopInfo { limit: 1, count: 0 })
+            .with_payload(payload.into())
+            .build(CreationTimestamp::now())
+            .trace_expect("Failed to build BpArpProbe bundle");
+
+        Bytes::from(data)
+    }
+
+    /// Builds a `BpArpAck` admin bundle as raw bytes, addressed to the given destination.
+    ///
+    /// The payload contains a CBOR array of ALL our admin endpoint EIDs so the probing node
+    /// can install routes for every scheme we support (§4.3).
+    pub fn build_ack(&self, destination: &Eid) -> Bytes {
+        let source = self.node_ids.get_admin_endpoint(destination);
+        let eids = self.node_ids.get_all_admin_endpoints();
+        let payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArpAck(eids)).0;
+
+        let (_, data) = hardy_bpv7::builder::Builder::new(source, destination.clone())
+            .with_flags(Flags {
+                is_admin_record: true,
+                ..Default::default()
+            })
+            .with_payload(payload.into())
+            .build(CreationTimestamp::now())
+            .trace_expect("Failed to build BpArpAck bundle");
+
+        Bytes::from(data)
+    }
+}

--- a/bpa/src/cla/arp.rs
+++ b/bpa/src/cla/arp.rs
@@ -1,175 +1,265 @@
 use super::*;
-use hardy_bpv7::{
-    bundle::Flags, creation_timestamp::CreationTimestamp, eid::Eid, hop_info::HopInfo,
-    status_report::AdministrativeRecord,
-};
-use trace_err::*;
 
-/// BP-ARP probe/retry interval and retry count.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(default, rename_all = "kebab-case"))]
-#[derive(Debug, Clone)]
-pub struct ArpConfig {
-    /// How long to wait between probe retries (in whole seconds).
-    pub probe_interval_secs: u64,
-    /// How many times to retry a probe before giving up.
-    pub retry_count: u32,
-    /// When to probe a CLA peer for its EID.
-    pub policy: ArpPolicy,
-}
+#[cfg(feature = "bp-arp")]
+pub use enabled::*;
 
-impl Default for ArpConfig {
-    fn default() -> Self {
-        Self {
-            probe_interval_secs: 30,
-            retry_count: 5,
-            policy: ArpPolicy::default(),
-        }
-    }
-}
+#[cfg(feature = "bp-arp")]
+mod enabled {
+    use super::*;
+    use hardy_bpv7::{
+        bundle::Flags, creation_timestamp::CreationTimestamp, eid::Eid, hop_info::HopInfo,
+        status_report::AdministrativeRecord,
+    };
+    use trace_err::*;
 
-impl ArpConfig {
-    pub fn probe_interval(&self) -> time::Duration {
-        time::Duration::seconds(self.probe_interval_secs as i64)
-    }
-}
-
-/// Controls when BP-ARP probing is triggered.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
-#[derive(Debug, Clone, Default)]
-pub enum ArpPolicy {
-    /// Probe only when the peer's EID is unknown (Neighbour). This is the default.
-    #[default]
-    AsNeeded,
-    /// Always probe every new CLA peer, even if the EID is already known.
-    Always,
-    /// Never send probes (BP-ARP disabled).
-    Never,
-}
-
-struct NeighbourState {
-    _task: hardy_async::JoinHandle<()>,
-}
-
-/// Manages BP-ARP probe tasks for Neighbours.
-///
-/// A Neighbour is a CLA peer whose EID is not yet known. The ARP subsystem sends
-/// periodic `BpArpProbe` admin bundles directly over the CLA (bypassing the RIB)
-/// and waits for a `BpArpAck` response that reveals the remote EID.
-pub struct ArpSubsystem {
-    config: ArpConfig,
-    node_ids: Arc<node_ids::NodeIds>,
-    neighbours: hardy_async::sync::spin::Mutex<HashMap<u32, NeighbourState>>,
-}
-
-impl ArpSubsystem {
-    pub fn new(config: ArpConfig, node_ids: Arc<node_ids::NodeIds>) -> Arc<Self> {
-        Arc::new(Self {
-            config,
-            node_ids,
-            neighbours: hardy_async::sync::spin::Mutex::new(HashMap::new()),
-        })
+    /// BP-ARP probe/retry interval and retry count.
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(default, rename_all = "kebab-case"))]
+    #[derive(Debug, Clone)]
+    pub struct ArpConfig {
+        /// How long to wait between probe retries (in whole seconds).
+        pub probe_interval_secs: u64,
+        /// How many times to retry a probe before giving up.
+        pub retry_count: u32,
+        /// When to probe a CLA peer for its EID.
+        pub policy: ArpPolicy,
     }
 
-    /// Called when a Neighbour (peer with unknown EID) is added to the CLA registry.
-    /// Starts a probe-retry task unless `policy` is `Never`.
-    pub async fn on_neighbour_added(
-        self: &Arc<Self>,
-        peer_id: u32,
-        cla: Arc<registry::Cla>,
-        cla_addr: ClaAddress,
-        tasks: &hardy_async::TaskPool,
-    ) {
-        if matches!(self.config.policy, ArpPolicy::Never) {
-            return;
-        }
-
-        let this = self.clone();
-        let probe_bytes = self.build_probe();
-        let retry_count = self.config.retry_count;
-        let probe_interval = self.config.probe_interval();
-
-        let task = tasks.spawn(async move {
-            for attempt in 1..=retry_count {
-                debug!("BP-ARP: sending probe to peer {peer_id} (attempt {attempt}/{retry_count})");
-                if let Err(e) = cla.forward_raw(&cla_addr, probe_bytes.clone()).await {
-                    warn!("BP-ARP: probe send failed for peer {peer_id}: {e}");
-                }
-                hardy_async::time::sleep(probe_interval).await;
-
-                // Check if already resolved (abort() races with sleep completion)
-                if !this.neighbours.lock().contains_key(&peer_id) {
-                    return;
-                }
+    impl Default for ArpConfig {
+        fn default() -> Self {
+            Self {
+                probe_interval_secs: 30,
+                retry_count: 5,
+                policy: ArpPolicy::default(),
             }
-            warn!("BP-ARP: exhausted {retry_count} probe retries for peer {peer_id}, giving up");
-            this.neighbours.lock().remove(&peer_id);
-        });
-
-        self.neighbours
-            .lock()
-            .insert(peer_id, NeighbourState { _task: task });
-    }
-
-    /// Called when a Neighbour is removed from the CLA registry (CLA disconnected).
-    pub async fn on_neighbour_removed(&self, peer_id: u32) {
-        // Dropping the JoinHandle does not abort the task, so we explicitly abort.
-        if let Some(state) = self.neighbours.lock().remove(&peer_id) {
-            state._task.abort();
         }
     }
 
-    /// Called when a `BpArpAck` (or `BpArpProbe`) is received that resolves a Neighbour.
-    /// Cancels the outstanding probe task.
-    pub async fn on_ack_received(&self, peer_id: u32) {
-        if let Some(state) = self.neighbours.lock().remove(&peer_id) {
-            state._task.abort();
+    impl ArpConfig {
+        pub fn probe_interval(&self) -> time::Duration {
+            time::Duration::seconds(self.probe_interval_secs as i64)
         }
     }
 
-    /// Builds a `BpArpProbe` admin bundle as raw bytes, ready to send directly over a CLA.
-    ///
-    /// - Source: our admin endpoint (e.g. `ipn:42.0`)
-    /// - Destination: `ipn:!.0` (LocalNode) so the remote BPA routes it to its admin endpoint
-    /// - `is_admin_record` flag set
-    /// - Hop Count block (limit 1) per spec §4.2 to prevent forwarding beyond the neighbour
-    fn build_probe(&self) -> Bytes {
-        let source = self.node_ids.get_admin_endpoint(&Eid::LocalNode(0));
-        let destination = Eid::LocalNode(0);
-        let payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArpProbe).0;
-
-        let (_, data) = hardy_bpv7::builder::Builder::new(source, destination)
-            .with_flags(Flags {
-                is_admin_record: true,
-                ..Default::default()
-            })
-            .with_hop_count(&HopInfo { limit: 1, count: 0 })
-            .with_payload(payload.into())
-            .build(CreationTimestamp::now())
-            .trace_expect("Failed to build BpArpProbe bundle");
-
-        Bytes::from(data)
+    /// Controls when BP-ARP probing is triggered.
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+    #[derive(Debug, Clone, Default)]
+    pub enum ArpPolicy {
+        /// Probe only when the peer's EID is unknown (Neighbour). This is the default.
+        #[default]
+        AsNeeded,
+        /// Always probe every new CLA peer, even if the EID is already known.
+        Always,
+        /// Never send probes (BP-ARP disabled).
+        Never,
     }
 
-    /// Builds a `BpArpAck` admin bundle as raw bytes, addressed to the given destination.
+    struct NeighbourState {
+        _task: hardy_async::JoinHandle<()>,
+    }
+
+    /// Manages BP-ARP probe tasks for Neighbours.
     ///
-    /// The payload contains a CBOR array of ALL our admin endpoint EIDs so the probing node
-    /// can install routes for every scheme we support (§4.3).
-    pub fn build_ack(&self, destination: &Eid) -> Bytes {
-        let source = self.node_ids.get_admin_endpoint(destination);
-        let eids = self.node_ids.get_all_admin_endpoints();
-        let payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArpAck(eids)).0;
+    /// A Neighbour is a CLA peer whose EID is not yet known. The ARP subsystem sends
+    /// periodic `BpArpProbe` admin bundles directly over the CLA (bypassing the RIB)
+    /// and waits for a `BpArpAck` response that reveals the remote EID.
+    pub struct ArpSubsystem {
+        config: ArpConfig,
+        node_ids: Arc<node_ids::NodeIds>,
+        neighbours: hardy_async::sync::spin::Mutex<HashMap<u32, NeighbourState>>,
+    }
 
-        let (_, data) = hardy_bpv7::builder::Builder::new(source, destination.clone())
-            .with_flags(Flags {
-                is_admin_record: true,
-                ..Default::default()
+    impl ArpSubsystem {
+        pub fn new(config: ArpConfig, node_ids: Arc<node_ids::NodeIds>) -> Arc<Self> {
+            Arc::new(Self {
+                config,
+                node_ids,
+                neighbours: hardy_async::sync::spin::Mutex::new(HashMap::new()),
             })
-            .with_payload(payload.into())
-            .build(CreationTimestamp::now())
-            .trace_expect("Failed to build BpArpAck bundle");
+        }
 
-        Bytes::from(data)
+        /// Called when a Neighbour (peer with unknown EID) is added to the CLA registry.
+        /// Starts a probe-retry task unless `policy` is `Never`.
+        pub async fn on_neighbour_added(
+            self: &Arc<Self>,
+            peer_id: u32,
+            cla: Arc<registry::Cla>,
+            cla_addr: ClaAddress,
+            tasks: &hardy_async::TaskPool,
+        ) {
+            if matches!(self.config.policy, ArpPolicy::Never) {
+                return;
+            }
+
+            let this = self.clone();
+            let probe_bytes = self.build_probe();
+            let retry_count = self.config.retry_count;
+            let probe_interval = self.config.probe_interval();
+
+            let task = tasks.spawn(async move {
+                for attempt in 1..=retry_count {
+                    debug!(
+                        "BP-ARP: sending probe to peer {peer_id} (attempt {attempt}/{retry_count})"
+                    );
+                    if let Err(e) = cla.forward_raw(&cla_addr, probe_bytes.clone()).await {
+                        warn!("BP-ARP: probe send failed for peer {peer_id}: {e}");
+                    }
+                    hardy_async::time::sleep(probe_interval).await;
+
+                    // Check if already resolved (abort() races with sleep completion)
+                    if !this.neighbours.lock().contains_key(&peer_id) {
+                        return;
+                    }
+                }
+                warn!(
+                    "BP-ARP: exhausted {retry_count} probe retries for peer {peer_id}, giving up"
+                );
+                this.neighbours.lock().remove(&peer_id);
+            });
+
+            self.neighbours
+                .lock()
+                .insert(peer_id, NeighbourState { _task: task });
+        }
+
+        /// Called when a Neighbour is removed from the CLA registry (CLA disconnected).
+        pub async fn on_neighbour_removed(&self, peer_id: u32) {
+            // Dropping the JoinHandle does not abort the task, so we explicitly abort.
+            if let Some(state) = self.neighbours.lock().remove(&peer_id) {
+                state._task.abort();
+            }
+        }
+
+        /// Called when a `BpArpAck` (or `BpArpProbe`) is received that resolves a Neighbour.
+        /// Cancels the outstanding probe task.
+        pub async fn on_ack_received(&self, peer_id: u32) {
+            if let Some(state) = self.neighbours.lock().remove(&peer_id) {
+                state._task.abort();
+            }
+        }
+
+        /// Builds a `BpArpProbe` admin bundle as raw bytes, ready to send directly over a CLA.
+        ///
+        /// - Source: our admin endpoint (e.g. `ipn:42.0`)
+        /// - Destination: `ipn:!.0` (LocalNode) so the remote BPA routes it to its admin endpoint
+        /// - `is_admin_record` flag set
+        /// - Hop Count block (limit 1) per spec §4.2 to prevent forwarding beyond the neighbour
+        fn build_probe(&self) -> Bytes {
+            let source = self.node_ids.get_admin_endpoint(&Eid::LocalNode(0));
+            let destination = Eid::LocalNode(0);
+            let payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArp(Vec::new())).0;
+
+            let (_, data) = hardy_bpv7::builder::Builder::new(source, destination)
+                .with_flags(Flags {
+                    is_admin_record: true,
+                    ..Default::default()
+                })
+                .with_hop_count(&HopInfo { limit: 1, count: 0 })
+                .with_payload(payload.into())
+                .build(CreationTimestamp::now())
+                .trace_expect("Failed to build BpArpProbe bundle");
+
+            Bytes::from(data)
+        }
+
+        /// Builds a `BpArpAck` admin bundle as raw bytes, addressed to the given destination.
+        ///
+        /// The payload contains a CBOR array of ALL our admin endpoint EIDs so the probing node
+        /// can install routes for every scheme we support (§4.3).
+        pub fn build_ack(&self, destination: &Eid) -> Bytes {
+            let source = self.node_ids.get_admin_endpoint(destination);
+            let eids = self.node_ids.get_all_admin_endpoints();
+            let payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArp(eids)).0;
+
+            let (_, data) = hardy_bpv7::builder::Builder::new(source, destination.clone())
+                .with_flags(Flags {
+                    is_admin_record: true,
+                    ..Default::default()
+                })
+                .with_payload(payload.into())
+                .build(CreationTimestamp::now())
+                .trace_expect("Failed to build BpArpAck bundle");
+
+            Bytes::from(data)
+        }
+    }
+}
+// ============================================================================
+// DISABLED: Stub Implementation
+// ============================================================================
+#[cfg(not(feature = "bp-arp"))]
+pub use disabled::*;
+
+#[cfg(not(feature = "bp-arp"))]
+mod disabled {
+    use super::*;
+    /// BP-ARP probe/retry interval and retry count.
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(default, rename_all = "kebab-case"))]
+    #[derive(Debug, Clone)]
+    pub struct ArpConfig {
+        /// How long to wait between probe retries (in whole seconds).
+        pub probe_interval_secs: u64,
+        /// How many times to retry a probe before giving up.
+        pub retry_count: u32,
+        /// When to probe a CLA peer for its EID.
+        pub policy: ArpPolicy,
+    }
+
+    impl Default for ArpConfig {
+        fn default() -> Self {
+            Self {
+                probe_interval_secs: 30,
+                retry_count: 5,
+                policy: ArpPolicy::default(),
+            }
+        }
+    }
+
+    impl ArpConfig {
+        pub fn probe_interval(&self) -> time::Duration {
+            time::Duration::seconds(self.probe_interval_secs as i64)
+        }
+    }
+
+    /// Controls when BP-ARP probing is triggered.
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+    #[derive(Debug, Clone, Default)]
+    pub enum ArpPolicy {
+        /// Probe only when the peer's EID is unknown (Neighbour). This is the default.
+        AsNeeded,
+        /// Always probe every new CLA peer, even if the EID is already known.
+        Always,
+        /// Never send probes (BP-ARP disabled).
+        #[default]
+        Never,
+    }
+
+    /// Manages BP-ARP probe tasks for Neighbours.
+    ///
+    /// A Neighbour is a CLA peer whose EID is not yet known. The ARP subsystem sends
+    /// periodic `BpArpProbe` admin bundles directly over the CLA (bypassing the RIB)
+    /// and waits for a `BpArpAck` response that reveals the remote EID.
+    pub struct ArpSubsystem;
+
+    impl ArpSubsystem {
+        pub fn new(_config: ArpConfig, _node_ids: Arc<node_ids::NodeIds>) -> Arc<Self> {
+            Arc::new(Self)
+        }
+
+        pub async fn on_neighbour_added(
+            self: &Arc<Self>,
+            _peer_id: u32,
+            _cla: Arc<registry::Cla>,
+            _cla_addr: ClaAddress,
+            _tasks: &hardy_async::TaskPool,
+        ) {
+        }
+
+        pub async fn on_neighbour_removed(&self, _peer_id: u32) {}
+
+        pub async fn on_ack_received(&self, _peer_id: u32) {}
     }
 }

--- a/bpa/src/cla/mod.rs
+++ b/bpa/src/cla/mod.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 
 pub(crate) mod registry;
 
+pub mod arp;
 mod egress_queue;
 mod peers;
 

--- a/bpa/src/cla/registry.rs
+++ b/bpa/src/cla/registry.rs
@@ -20,6 +20,19 @@ pub struct Cla {
     address_type: Option<ClaAddressType>,
 }
 
+impl Cla {
+    /// Forward `data` bytes directly to a specific CLA address without going through the
+    /// egress queue or the RIB. Used by the BP-ARP subsystem to send probes to Neighbours
+    /// that have no route installed yet.
+    pub(crate) async fn forward_raw(
+        &self,
+        cla_addr: &ClaAddress,
+        data: Bytes,
+    ) -> cla::Result<cla::ForwardBundleResult> {
+        self.cla.forward(None, cla_addr, data).await
+    }
+}
+
 impl PartialEq for Cla {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
@@ -115,7 +128,7 @@ impl Drop for Sink {
 }
 
 pub(crate) struct Registry {
-    node_ids: Vec<NodeId>,
+    node_ids: Arc<node_ids::NodeIds>,
     // sync::spin::Mutex for O(1) CLA HashMap operations (no read-only access needed)
     clas: hardy_async::sync::spin::Mutex<HashMap<String, Arc<Cla>>>,
     rib: Arc<rib::Rib>,
@@ -123,14 +136,16 @@ pub(crate) struct Registry {
     peers: peers::PeerTable,
     poll_channel_depth: usize,
     tasks: hardy_async::TaskPool,
+    arp: Option<Arc<arp::ArpSubsystem>>,
 }
 
 impl Registry {
     pub fn new(
-        node_ids: Vec<NodeId>,
+        node_ids: Arc<node_ids::NodeIds>,
         poll_channel_depth: usize,
         rib: Arc<rib::Rib>,
         store: Arc<storage::Store>,
+        arp: Option<Arc<arp::ArpSubsystem>>,
     ) -> Self {
         Self {
             node_ids,
@@ -140,7 +155,13 @@ impl Registry {
             peers: peers::PeerTable::new(),
             poll_channel_depth,
             tasks: hardy_async::TaskPool::new(),
+            arp,
         }
+    }
+
+    /// Returns all admin endpoint EIDs for this node, used to populate BP-ARP ack payloads.
+    pub fn all_admin_endpoints(&self) -> Vec<hardy_bpv7::eid::Eid> {
+        self.node_ids.get_all_admin_endpoints()
     }
 
     pub async fn shutdown(&self) {
@@ -195,11 +216,11 @@ impl Registry {
                     registry: self.clone(),
                     dispatcher: dispatcher.clone(),
                 }),
-                &self.node_ids,
+                &Vec::<NodeId>::from(&*self.node_ids),
             )
             .await;
 
-        Ok(self.node_ids.clone())
+        Ok(Vec::<NodeId>::from(&*self.node_ids))
     }
 
     async fn unregister(&self, cla: Arc<Cla>) {
@@ -223,6 +244,10 @@ impl Registry {
             // Remove RIB entries for all EIDs associated with this address
             for node_id in node_ids {
                 self.rib.remove_forward(node_id, peer_id).await;
+            }
+            // Notify ARP subsystem so it can cancel any outstanding probe task
+            if let Some(arp) = &self.arp {
+                arp.on_neighbour_removed(peer_id).await;
             }
             // Remove from peer table (stops forwarding, signals drain)
             self.peers.remove(peer_id).await;
@@ -273,9 +298,9 @@ impl Registry {
         // Start the peer polling the queue
         peer.start(
             self.poll_channel_depth,
-            cla,
+            cla.clone(),
             peer_id,
-            cla_addr,
+            cla_addr.clone(),
             self.store.clone(),
             dispatcher,
             &self.tasks,
@@ -288,6 +313,14 @@ impl Registry {
             self.rib.add_forward(node_id.clone(), peer_id).await;
         }
 
+        // Notify BP-ARP subsystem about new Neighbour (no EID known yet)
+        if node_ids.is_empty() {
+            if let Some(arp) = &self.arp {
+                arp.on_neighbour_added(peer_id, cla, cla_addr, &self.tasks)
+                    .await;
+            }
+        }
+
         true
     }
 
@@ -295,6 +328,13 @@ impl Registry {
         let Some((node_ids, peer_id)) = cla.peers.lock().remove(cla_addr) else {
             return false;
         };
+
+        // Notify ARP if this was a Neighbour (no EIDs known)
+        if node_ids.is_empty() {
+            if let Some(arp) = &self.arp {
+                arp.on_neighbour_removed(peer_id).await;
+            }
+        }
 
         self.peers.remove(peer_id).await;
         for node_id in node_ids {
@@ -304,6 +344,67 @@ impl Registry {
         debug!("Removed peer {peer_id}");
 
         true
+    }
+
+    /// Promotes a Neighbour (peer with unknown EID) to a named Peer by learning its EID
+    /// from an incoming BP-ARP message. Installs a RIB route and cancels the probe task.
+    ///
+    /// This is idempotent: if the Neighbour is already a Peer (EID already known),
+    /// or if the address is not found, this is a no-op.
+    pub async fn promote_neighbour(&self, cla_addr: &ClaAddress, eids: Vec<hardy_bpv7::eid::Eid>) {
+        // Filter to valid node admin endpoint IDs only.
+        let node_ids: Vec<NodeId> = eids
+            .into_iter()
+            .filter_map(|eid| NodeId::try_from(eid).ok())
+            .collect();
+
+        if node_ids.is_empty() {
+            debug!("BP-ARP: cannot promote Neighbour — no valid node admin endpoints in EID list");
+            return;
+        }
+
+        // Find the CLA owning this address and update the peer entry.
+        let clas: Vec<Arc<Cla>> = self.clas.lock().values().cloned().collect();
+        for cla in clas {
+            let maybe_promote = {
+                let mut peers = cla.peers.lock();
+                if let Some(entry) = peers.get_mut(cla_addr) {
+                    let was_neighbour = entry.0.is_empty();
+                    // Collect EIDs that are new for this peer.
+                    let new_ids: Vec<NodeId> = node_ids
+                        .iter()
+                        .filter(|id| !entry.0.contains(id))
+                        .cloned()
+                        .collect();
+                    for id in &new_ids {
+                        entry.0.push(id.clone());
+                    }
+                    if !new_ids.is_empty() {
+                        Some((entry.1, new_ids, was_neighbour))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            };
+
+            if let Some((peer_id, new_ids, was_neighbour)) = maybe_promote {
+                for node_id in &new_ids {
+                    self.rib.add_forward(node_id.clone(), peer_id).await;
+                    info!("BP-ARP: promoted peer {peer_id} at {cla_addr} to {node_id}");
+                }
+                if was_neighbour {
+                    // Cancel any outstanding ARP probe now that we have at least one EID.
+                    if let Some(arp) = &self.arp {
+                        arp.on_ack_received(peer_id).await;
+                    }
+                }
+                return;
+            }
+        }
+
+        debug!("BP-ARP: promote_neighbour called for unknown address {cla_addr}");
     }
 
     pub async fn forward(&self, peer_id: u32, bundle: bundle::Bundle) {

--- a/bpa/src/cla/registry.rs
+++ b/bpa/src/cla/registry.rs
@@ -20,6 +20,7 @@ pub struct Cla {
     address_type: Option<ClaAddressType>,
 }
 
+#[cfg(feature = "bp-arp")]
 impl Cla {
     /// Forward `data` bytes directly to a specific CLA address without going through the
     /// egress queue or the RIB. Used by the BP-ARP subsystem to send probes to Neighbours
@@ -136,7 +137,7 @@ pub(crate) struct Registry {
     peers: peers::PeerTable,
     poll_channel_depth: usize,
     tasks: hardy_async::TaskPool,
-    arp: Option<Arc<arp::ArpSubsystem>>,
+    arp: Arc<arp::ArpSubsystem>,
 }
 
 impl Registry {
@@ -145,7 +146,7 @@ impl Registry {
         poll_channel_depth: usize,
         rib: Arc<rib::Rib>,
         store: Arc<storage::Store>,
-        arp: Option<Arc<arp::ArpSubsystem>>,
+        arp: Arc<arp::ArpSubsystem>,
     ) -> Self {
         Self {
             node_ids,
@@ -159,6 +160,7 @@ impl Registry {
         }
     }
 
+    #[cfg(feature = "bp-arp")]
     /// Returns all admin endpoint EIDs for this node, used to populate BP-ARP ack payloads.
     pub fn all_admin_endpoints(&self) -> Vec<hardy_bpv7::eid::Eid> {
         self.node_ids.get_all_admin_endpoints()
@@ -246,9 +248,7 @@ impl Registry {
                 self.rib.remove_forward(node_id, peer_id).await;
             }
             // Notify ARP subsystem so it can cancel any outstanding probe task
-            if let Some(arp) = &self.arp {
-                arp.on_neighbour_removed(peer_id).await;
-            }
+            self.arp.on_neighbour_removed(peer_id).await;
             // Remove from peer table (stops forwarding, signals drain)
             self.peers.remove(peer_id).await;
         }
@@ -314,12 +314,9 @@ impl Registry {
         }
 
         // Notify BP-ARP subsystem about new Neighbour (no EID known yet)
-        if node_ids.is_empty() {
-            if let Some(arp) = &self.arp {
-                arp.on_neighbour_added(peer_id, cla, cla_addr, &self.tasks)
-                    .await;
-            }
-        }
+        self.arp
+            .on_neighbour_added(peer_id, cla, cla_addr, &self.tasks)
+            .await;
 
         true
     }
@@ -330,11 +327,7 @@ impl Registry {
         };
 
         // Notify ARP if this was a Neighbour (no EIDs known)
-        if node_ids.is_empty() {
-            if let Some(arp) = &self.arp {
-                arp.on_neighbour_removed(peer_id).await;
-            }
-        }
+        self.arp.on_neighbour_removed(peer_id).await;
 
         self.peers.remove(peer_id).await;
         for node_id in node_ids {
@@ -346,6 +339,7 @@ impl Registry {
         true
     }
 
+    #[cfg(feature = "bp-arp")]
     /// Promotes a Neighbour (peer with unknown EID) to a named Peer by learning its EID
     /// from an incoming BP-ARP message. Installs a RIB route and cancels the probe task.
     ///
@@ -396,9 +390,7 @@ impl Registry {
                 }
                 if was_neighbour {
                     // Cancel any outstanding ARP probe now that we have at least one EID.
-                    if let Some(arp) = &self.arp {
-                        arp.on_ack_received(peer_id).await;
-                    }
+                    self.arp.on_ack_received(peer_id).await;
                 }
                 return;
             }

--- a/bpa/src/config.rs
+++ b/bpa/src/config.rs
@@ -9,6 +9,8 @@ pub struct Config {
     pub lru_capacity: core::num::NonZeroUsize,
     pub max_cached_bundle_size: core::num::NonZeroUsize,
     pub node_ids: node_ids::NodeIds,
+    /// BP-ARP configuration for automatic EID resolution of Neighbours.
+    pub arp: cla::arp::ArpConfig,
 }
 
 impl Default for Config {
@@ -23,6 +25,7 @@ impl Default for Config {
             lru_capacity: core::num::NonZeroUsize::new(1024).unwrap(),
             max_cached_bundle_size: core::num::NonZeroUsize::new(16 * 1024).unwrap(),
             node_ids: node_ids::NodeIds::default(),
+            arp: cla::arp::ArpConfig::default(),
         }
     }
 }
@@ -32,6 +35,7 @@ impl core::fmt::Debug for Config {
         f.debug_struct("Config")
             .field("status_reports", &self.status_reports)
             .field("node_ids", &self.node_ids)
+            .field("arp", &self.arp)
             .finish_non_exhaustive()
     }
 }

--- a/bpa/src/dispatcher/admin.rs
+++ b/bpa/src/dispatcher/admin.rs
@@ -108,6 +108,51 @@ impl Dispatcher {
                     }
                 }
             }
+            Ok(AdministrativeRecord::BpArpProbe) => {
+                // A remote BPA is probing us to learn our EID.
+                // Learn the sender's EID from the bundle source and respond with a BpArpAck.
+                debug!("Received BP-ARP probe from {}", bundle.bundle.id.source);
+                let source = bundle.bundle.id.source.clone();
+
+                // If we know the ingress peer address, promote the Neighbour → Peer using the
+                // probe source EID (the only EID available in a probe, per §4.2).
+                if let Some(peer_addr) = bundle.metadata.read_only.ingress_peer_addr.clone() {
+                    self.cla_registry
+                        .promote_neighbour(&peer_addr, vec![source.clone()])
+                        .await;
+                }
+
+                // Send a BpArpAck back so the probing BPA learns all of our EIDs (§4.3).
+                let ack_payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArpAck(
+                    self.cla_registry.all_admin_endpoints(),
+                ))
+                .0;
+                self.dispatch_admin_bundle(ack_payload, &source).await;
+
+                self.drop_bundle(bundle, None).await;
+            }
+            Ok(AdministrativeRecord::BpArpAck(eids)) => {
+                // The remote BPA responded to our probe, revealing all of its EIDs.
+                debug!("Received BP-ARP ack from {}", bundle.bundle.id.source);
+
+                // Combine the bundle source EID with the payload EID list so we learn every
+                // EID the remote node advertises, even if the payload is unexpectedly empty.
+                let mut all_eids = eids;
+                let source = bundle.bundle.id.source.clone();
+                if !all_eids.contains(&source) {
+                    all_eids.push(source);
+                }
+
+                if let Some(peer_addr) = bundle.metadata.read_only.ingress_peer_addr.clone() {
+                    self.cla_registry
+                        .promote_neighbour(&peer_addr, all_eids)
+                        .await;
+                } else {
+                    debug!("BP-ARP ack received without ingress peer address, cannot promote");
+                }
+
+                self.drop_bundle(bundle, None).await;
+            }
         }
     }
 }

--- a/bpa/src/dispatcher/admin.rs
+++ b/bpa/src/dispatcher/admin.rs
@@ -108,49 +108,44 @@ impl Dispatcher {
                     }
                 }
             }
-            Ok(AdministrativeRecord::BpArpProbe) => {
-                // A remote BPA is probing us to learn our EID.
-                // Learn the sender's EID from the bundle source and respond with a BpArpAck.
-                debug!("Received BP-ARP probe from {}", bundle.bundle.id.source);
-                let source = bundle.bundle.id.source.clone();
+            #[cfg(feature = "bp-arp")]
+            Ok(AdministrativeRecord::BpArp(eids)) => {
+                // Check if this is a Request (Probe) or Response (Ack) based on Destination EID
+                // Request: Destination is ipn:!.0 (LocalNode)
+                if matches!(
+                    bundle.bundle.destination,
+                    hardy_bpv7::eid::Eid::LocalNode(0)
+                ) {
+                    // A remote BPA is probing us to learn our EID.
+                    // Learn the sender's EID from the bundle source and respond with a BpArpAck.
+                    debug!("Received BP-ARP probe from {}", bundle.bundle.id.source);
+                    let source = bundle.bundle.id.source.clone();
 
-                // If we know the ingress peer address, promote the Neighbour → Peer using the
-                // probe source EID (the only EID available in a probe, per §4.2).
-                if let Some(peer_addr) = bundle.metadata.read_only.ingress_peer_addr.clone() {
-                    self.cla_registry
-                        .promote_neighbour(&peer_addr, vec![source.clone()])
-                        .await;
+                    // Send a BpArpAck back so the probing BPA learns all of our EIDs (§4.3).
+                    let ack_payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArp(
+                        self.cla_registry.all_admin_endpoints(),
+                    ))
+                    .0;
+                    self.dispatch_admin_bundle(ack_payload, &source).await;
+                    // The remote BPA responded to our probe, revealing all of its EIDs.
+                    debug!("Received BP-ARP ack from {}", bundle.bundle.id.source);
+
+                    // Combine the bundle source EID with the payload EID list so we learn every
+                    // EID the remote node advertises, even if the payload is unexpectedly empty.
+                    let mut all_eids = eids;
+                    let source = bundle.bundle.id.source.clone();
+                    if !all_eids.contains(&source) {
+                        all_eids.push(source);
+                    }
+
+                    if let Some(peer_addr) = bundle.metadata.read_only.ingress_peer_addr.clone() {
+                        self.cla_registry
+                            .promote_neighbour(&peer_addr, all_eids)
+                            .await;
+                    } else {
+                        debug!("BP-ARP ack received without ingress peer address, cannot promote");
+                    }
                 }
-
-                // Send a BpArpAck back so the probing BPA learns all of our EIDs (§4.3).
-                let ack_payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArpAck(
-                    self.cla_registry.all_admin_endpoints(),
-                ))
-                .0;
-                self.dispatch_admin_bundle(ack_payload, &source).await;
-
-                self.drop_bundle(bundle, None).await;
-            }
-            Ok(AdministrativeRecord::BpArpAck(eids)) => {
-                // The remote BPA responded to our probe, revealing all of its EIDs.
-                debug!("Received BP-ARP ack from {}", bundle.bundle.id.source);
-
-                // Combine the bundle source EID with the payload EID list so we learn every
-                // EID the remote node advertises, even if the payload is unexpectedly empty.
-                let mut all_eids = eids;
-                let source = bundle.bundle.id.source.clone();
-                if !all_eids.contains(&source) {
-                    all_eids.push(source);
-                }
-
-                if let Some(peer_addr) = bundle.metadata.read_only.ingress_peer_addr.clone() {
-                    self.cla_registry
-                        .promote_neighbour(&peer_addr, all_eids)
-                        .await;
-                } else {
-                    debug!("BP-ARP ack received without ingress peer address, cannot promote");
-                }
-
                 self.drop_bundle(bundle, None).await;
             }
         }

--- a/bpa/src/dispatcher/report.rs
+++ b/bpa/src/dispatcher/report.rs
@@ -133,38 +133,47 @@ impl Dispatcher {
     async fn dispatch_status_report(&self, payload: Vec<u8>, report_to: &Eid) {
         // Check reports are enabled
         if self.status_reports {
-            // Build the bundle
-            let (bundle, data) = hardy_bpv7::builder::Builder::new(
-                self.node_ids.get_admin_endpoint(report_to),
-                report_to.clone(),
-            )
-            .with_flags(hardy_bpv7::bundle::Flags {
-                is_admin_record: true,
-                ..Default::default()
-            })
-            .with_payload(payload.into())
-            .build(hardy_bpv7::creation_timestamp::CreationTimestamp::now())
-            .trace_expect("Failed to create new bundle");
-
-            // Wrap in bundle::Bundle with initial metadata (not stored yet)
-            let mut bundle = bundle::Bundle {
-                metadata: metadata::BundleMetadata {
-                    status: metadata::BundleStatus::New,
-                    ..Default::default()
-                },
-                bundle,
-            };
-
-            // Store (no Originate filter - not user-originated)
-            let data = Bytes::from(data);
-            if !self.store.store(&mut bundle, &data).await {
-                // Duplicate status report - shouldn't happen but handle gracefully
-                debug!("Duplicate status report bundle");
-                return;
-            }
-
-            // Just fire the report off now - it ensures sequential reporting (ish)
-            Box::pin(self.ingest_bundle_inner(bundle, data)).await
+            self.dispatch_admin_bundle(payload, report_to).await;
         }
+    }
+
+    /// Build and dispatch an administrative record bundle to `destination`.
+    ///
+    /// The bundle is stored and then ingested into the normal dispatch pipeline
+    /// so it is routed to the destination via the RIB. Use this for bundles whose
+    /// destination route is already known (e.g. BP-ARP acks sent after promotion).
+    pub(super) async fn dispatch_admin_bundle(&self, payload: Vec<u8>, destination: &Eid) {
+        // Build the bundle
+        let (bundle, data) = hardy_bpv7::builder::Builder::new(
+            self.node_ids.get_admin_endpoint(destination),
+            destination.clone(),
+        )
+        .with_flags(hardy_bpv7::bundle::Flags {
+            is_admin_record: true,
+            ..Default::default()
+        })
+        .with_payload(payload.into())
+        .build(hardy_bpv7::creation_timestamp::CreationTimestamp::now())
+        .trace_expect("Failed to create new bundle");
+
+        // Wrap in bundle::Bundle with initial metadata (not stored yet)
+        let mut bundle = bundle::Bundle {
+            metadata: metadata::BundleMetadata {
+                status: metadata::BundleStatus::New,
+                ..Default::default()
+            },
+            bundle,
+        };
+
+        // Store (no Originate filter - not user-originated)
+        let data = Bytes::from(data);
+        if !self.store.store(&mut bundle, &data).await {
+            // Duplicate bundle - shouldn't happen but handle gracefully
+            debug!("Duplicate admin bundle");
+            return;
+        }
+
+        // Just fire the bundle off now
+        Box::pin(self.ingest_bundle_inner(bundle, data)).await
     }
 }

--- a/bpa/src/node_ids.rs
+++ b/bpa/src/node_ids.rs
@@ -44,6 +44,22 @@ impl NodeIds {
         }
     }
 
+    /// Returns ALL admin endpoint EIDs for this node — one per configured scheme.
+    /// Used to populate the BP-ARP response payload (§4.3).
+    pub(crate) fn get_all_admin_endpoints(&self) -> Vec<Eid> {
+        let mut eids = Vec::new();
+        if let Some(node_id) = &self.ipn {
+            eids.push(Eid::Ipn {
+                fqnn: node_id.clone(),
+                service_number: 0,
+            });
+        }
+        if let Some(node_id) = &self.dtn {
+            eids.push(node_id.clone().into());
+        }
+        eids
+    }
+
     /*pub(crate) fn contains(&self, eid: &Eid) -> bool {
         match (eid, &self.ipn, &self.dtn) {
             (Eid::LocalNode { service_number }, Some(_), _) => service_number == &0,

--- a/bpa/src/node_ids.rs
+++ b/bpa/src/node_ids.rs
@@ -44,15 +44,13 @@ impl NodeIds {
         }
     }
 
+    #[cfg(feature = "bp-arp")]
     /// Returns ALL admin endpoint EIDs for this node — one per configured scheme.
     /// Used to populate the BP-ARP response payload (§4.3).
     pub(crate) fn get_all_admin_endpoints(&self) -> Vec<Eid> {
         let mut eids = Vec::new();
         if let Some(node_id) = &self.ipn {
-            eids.push(Eid::Ipn {
-                fqnn: node_id.clone(),
-                service_number: 0,
-            });
+            eids.push(node_id.clone().into());
         }
         if let Some(node_id) = &self.dtn {
             eids.push(node_id.clone().into());

--- a/bpv7/Cargo.toml
+++ b/bpv7/Cargo.toml
@@ -32,6 +32,8 @@ serde = ["dep:serde","hashbrown/serde"]
 # Internal feature: enables BPSec signing/encryption modules.
 # Automatically enabled by security context features (rfc9173, and future cose).
 bpsec = []
+# Internal feature: enables BP-Arp modules.
+bp-arp = []
 
 [dependencies]
 hardy-cbor = { path = "../cbor" }

--- a/bpv7/src/status_report.rs
+++ b/bpv7/src/status_report.rs
@@ -6,6 +6,8 @@ on the status of a bundle. This can include events like bundle reception, forwar
 */
 
 use super::*;
+#[cfg(feature = "bp-arp")]
+use crate::eid::Eid;
 use crate::error::CaptureFieldErr;
 use thiserror::Error;
 
@@ -345,13 +347,11 @@ impl hardy_cbor::decode::FromCbor for BundleStatusReport {
 pub enum AdministrativeRecord {
     /// A bundle status report (RFC 9171 type 1).
     BundleStatusReport(BundleStatusReport),
-    /// A BP-ARP probe (type 2). Sent to `ipn:!.0` (LocalNode) to solicit an EID reply.
-    /// The sender's EID is carried in the bundle primary block source field; payload is empty.
-    BpArpProbe,
-    /// A BP-ARP acknowledgement (type 3). Sent in response to a `BpArpProbe`.
-    /// The sender's EID is carried in the bundle primary block source field.
-    /// The payload contains a CBOR array of ALL the responding node's EIDs.
-    BpArpAck(Vec<crate::eid::Eid>),
+    /// A BP-ARP record (type 2).
+    /// - If destination is `ipn:!.0`, it is a Request (Probe).
+    /// - If destination is a Node ID, it is a Response (Ack).
+    #[cfg(feature = "bp-arp")]
+    BpArp(Vec<Eid>),
 }
 
 impl hardy_cbor::encode::ToCbor for AdministrativeRecord {
@@ -360,14 +360,9 @@ impl hardy_cbor::encode::ToCbor for AdministrativeRecord {
     fn to_cbor(&self, encoder: &mut hardy_cbor::encode::Encoder) -> Self::Result {
         match self {
             AdministrativeRecord::BundleStatusReport(report) => encoder.emit(&(1u64, report)),
-            // BpArpProbe carries no payload — the sender's EID is in the bundle source field.
-            AdministrativeRecord::BpArpProbe => encoder.emit_array(Some(2), |a| {
+            #[cfg(feature = "bp-arp")]
+            AdministrativeRecord::BpArp(eids) => encoder.emit_array(Some(2), |a| {
                 a.emit(&2u64);
-                a.emit_array(Some(0), |_| {});
-            }),
-            // BpArpAck payload is a CBOR array of all node EIDs the responder owns.
-            AdministrativeRecord::BpArpAck(eids) => encoder.emit_array(Some(2), |a| {
-                a.emit(&3u64);
                 a.emit(eids.as_slice());
             }),
         }
@@ -393,14 +388,13 @@ impl hardy_cbor::decode::FromCbor for AdministrativeRecord {
                     let (r, s) = a.parse().map_field_err::<Error>("bundle status report")?;
                     Ok((Self::BundleStatusReport(r), shortest && s))
                 }
-                2u64 => Ok((Self::BpArpProbe, shortest)),
-                3u64 => {
-                    // Parse the payload array of EIDs.
+                #[cfg(feature = "bp-arp")]
+                2u64 => {
                     let (eids, s) = a
                         .parse_array(|a, s, _tags| {
                             let mut eids = Vec::new();
                             while let Some(eid) = a
-                                .try_parse::<crate::eid::Eid>()
+                                .try_parse::<Eid>()
                                 .map_field_err::<Error>("BpArpAck eid")?
                             {
                                 eids.push(eid);
@@ -408,7 +402,7 @@ impl hardy_cbor::decode::FromCbor for AdministrativeRecord {
                             Ok::<_, Error>((eids, s))
                         })
                         .map_field_err::<Error>("BpArpAck payload")?;
-                    Ok((Self::BpArpAck(eids), shortest && s))
+                    Ok((Self::BpArp(eids), shortest && s))
                 }
                 v => Err(Error::UnknownAdminRecordType(v)),
             }

--- a/bpv7/src/status_report.rs
+++ b/bpv7/src/status_report.rs
@@ -340,11 +340,18 @@ impl hardy_cbor::decode::FromCbor for BundleStatusReport {
 /// Represents an administrative record.
 ///
 /// An administrative record is a special type of bundle payload that is used for network
-/// management purposes. The only type currently supported is the `BundleStatusReport`.
+/// management purposes.
 #[derive(Debug)]
 pub enum AdministrativeRecord {
-    /// A bundle status report.
+    /// A bundle status report (RFC 9171 type 1).
     BundleStatusReport(BundleStatusReport),
+    /// A BP-ARP probe (type 2). Sent to `ipn:!.0` (LocalNode) to solicit an EID reply.
+    /// The sender's EID is carried in the bundle primary block source field; payload is empty.
+    BpArpProbe,
+    /// A BP-ARP acknowledgement (type 3). Sent in response to a `BpArpProbe`.
+    /// The sender's EID is carried in the bundle primary block source field.
+    /// The payload contains a CBOR array of ALL the responding node's EIDs.
+    BpArpAck(Vec<crate::eid::Eid>),
 }
 
 impl hardy_cbor::encode::ToCbor for AdministrativeRecord {
@@ -352,7 +359,17 @@ impl hardy_cbor::encode::ToCbor for AdministrativeRecord {
 
     fn to_cbor(&self, encoder: &mut hardy_cbor::encode::Encoder) -> Self::Result {
         match self {
-            AdministrativeRecord::BundleStatusReport(report) => encoder.emit(&(1, report)),
+            AdministrativeRecord::BundleStatusReport(report) => encoder.emit(&(1u64, report)),
+            // BpArpProbe carries no payload — the sender's EID is in the bundle source field.
+            AdministrativeRecord::BpArpProbe => encoder.emit_array(Some(2), |a| {
+                a.emit(&2u64);
+                a.emit_array(Some(0), |_| {});
+            }),
+            // BpArpAck payload is a CBOR array of all node EIDs the responder owns.
+            AdministrativeRecord::BpArpAck(eids) => encoder.emit_array(Some(2), |a| {
+                a.emit(&3u64);
+                a.emit(eids.as_slice());
+            }),
         }
     }
 }
@@ -375,6 +392,23 @@ impl hardy_cbor::decode::FromCbor for AdministrativeRecord {
                 1u64 => {
                     let (r, s) = a.parse().map_field_err::<Error>("bundle status report")?;
                     Ok((Self::BundleStatusReport(r), shortest && s))
+                }
+                2u64 => Ok((Self::BpArpProbe, shortest)),
+                3u64 => {
+                    // Parse the payload array of EIDs.
+                    let (eids, s) = a
+                        .parse_array(|a, s, _tags| {
+                            let mut eids = Vec::new();
+                            while let Some(eid) = a
+                                .try_parse::<crate::eid::Eid>()
+                                .map_field_err::<Error>("BpArpAck eid")?
+                            {
+                                eids.push(eid);
+                            }
+                            Ok::<_, Error>((eids, s))
+                        })
+                        .map_field_err::<Error>("BpArpAck payload")?;
+                    Ok((Self::BpArpAck(eids), shortest && s))
                 }
                 v => Err(Error::UnknownAdminRecordType(v)),
             }

--- a/implementation_guide.md
+++ b/implementation_guide.md
@@ -1,0 +1,260 @@
+# BP-ARP Implementation Guide
+
+This guide details the steps required to update the BP-ARP implementation in `hardy` to align with the latest RFC draft and introduce a feature flag.
+
+## Overview of Changes
+
+1. **Feature Flagging**: Introduce a `bp-arp` feature in both `bpv7` and `bpa` crates.
+2. **Administrative Record**: Replace `BpArpProbe` (type 2) and `BpArpAck` (type 3) with a single `BpArp` variant (type 2).
+3. **Protocol Logic**: Distinguish BP-ARP Requests (Probes) from Responses (Acks) based on the destination EID.
+    - **Request**: Destination is `ipn:!.0` (LocalNode).
+    - **Response**: Destination is a specific Node ID.
+
+---
+
+## Step 1: Update `bpv7` Crate
+
+### 1.1 Add Feature Flag to `bpv7/Cargo.toml`
+
+Add the `bp-arp` feature to the `[features]` section.
+
+```toml
+[features]
+default = ["rfc9173"]
+# ... existing features ...
+bp-arp = []
+```
+
+### 1.2 Refactor `AdministrativeRecord` in `bpv7/src/status_report.rs`
+
+Modify the `AdministrativeRecord` enum to use a single `BpArp` variant, gated behind the `bp-arp` feature.
+
+**Remove:**
+
+```rust
+    /// A BP-ARP probe (type 2). Sent to `ipn:!.0` (LocalNode) to solicit an EID reply.
+    BpArpProbe,
+    /// A BP-ARP acknowledgement (type 3). Sent in response to a `BpArpProbe`.
+    BpArpAck(Vec<crate::eid::Eid>),
+```
+
+**Add:**
+
+```rust
+    /// A BP-ARP record (type 2).
+    /// - If destination is `ipn:!.0`, it is a Request (Probe).
+    /// - If destination is a Node ID, it is a Response (Ack).
+    #[cfg(feature = "bp-arp")]
+    BpArp(Vec<crate::eid::Eid>),
+```
+
+**Update `ToCbor` implementation:**
+
+```rust
+impl hardy_cbor::encode::ToCbor for AdministrativeRecord {
+    type Result = ();
+
+    fn to_cbor(&self, encoder: &mut hardy_cbor::encode::Encoder) -> Self::Result {
+        match self {
+            AdministrativeRecord::BundleStatusReport(report) => encoder.emit(&(1u64, report)),
+
+            #[cfg(feature = "bp-arp")]
+            AdministrativeRecord::BpArp(eids) => encoder.emit_array(Some(2), |a| {
+                a.emit(&2u64); // Type 2 (TBD1)
+                a.emit(eids.as_slice());
+            }),
+        }
+    }
+}
+```
+
+**Update `FromCbor` implementation:**
+
+```rust
+impl hardy_cbor::decode::FromCbor for AdministrativeRecord {
+    type Error = Error;
+
+    fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
+        hardy_cbor::decode::parse_array(data, |a, mut shortest, tags| {
+            // ... existing setup ...
+
+            match a.parse()... {
+                1u64 => { ... },
+
+                #[cfg(feature = "bp-arp")]
+                2u64 => {
+                     let (eids, s) = a.parse_array(|a, s, _tags| {
+                        let mut eids = Vec::new();
+                        while let Some(eid) = a
+                            .try_parse::<crate::eid::Eid>()
+                            .map_field_err::<Error>("BpArp eid")?
+                        {
+                            eids.push(eid);
+                        }
+                        Ok::<_, Error>((eids, s))
+                    }).map_field_err::<Error>("BpArp payload")?;
+                    Ok((Self::BpArp(eids), shortest && s))
+                },
+
+                v => Err(Error::UnknownAdminRecordType(v)),
+            }
+        })
+        .map(...)
+    }
+}
+```
+
+---
+
+## Step 2: Update `bpa` Crate Configuration and Logic
+
+### 2.1 Add Feature Flag to `bpa/Cargo.toml`
+
+Add `bp-arp` feature and propagate it to `hardy-bpv7`.
+
+```toml
+[features]
+# ... existing features ...
+bp-arp = ["hardy-bpv7/bp-arp"]
+```
+
+### 2.2 Update `ArpSubsystem` in `bpa/src/cla/arp.rs`
+
+To support the feature flag without breaking the `Registry` (which depends on `ArpSubsystem` and `ArpConfig`), we will provide a **stub implementation** when `bp-arp` is disabled. This avoids the need to gate fields in `Config` and `Registry`, keeping those files clean.
+
+Wrap the existing code in a module or `cfg` block, and add a stub for the disabled state.
+
+**Structure of `bpa/src/cla/arp.rs`:**
+
+```rust
+use super::*;
+// ... other imports ...
+
+// ============================================================================
+// ENABLED: Real Implementation
+// ============================================================================
+#[cfg(feature = "bp-arp")]
+pub use enabled::*;
+
+#[cfg(feature = "bp-arp")]
+mod enabled {
+    use super::*;
+    use hardy_bpv7::{
+        bundle::Flags, creation_timestamp::CreationTimestamp, eid::Eid, hop_info::HopInfo,
+        status_report::AdministrativeRecord,
+    };
+    use trace_err::*;
+
+    // ... MOVE ALL EXISTING STRUCTS (ArpConfig, ArpPolicy, ArpSubsystem) HERE ...
+
+    // ... Update build_probe and build_ack as described below ...
+
+    impl ArpSubsystem {
+        // ... existing methods ...
+
+        fn build_probe(&self) -> Bytes {
+             // ...
+             let payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArp(Vec::new())).0;
+             // ...
+        }
+
+        pub fn build_ack(&self, destination: &Eid) -> Bytes {
+             // ...
+             let payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArp(eids)).0;
+             // ...
+        }
+    }
+}
+
+// ============================================================================
+// DISABLED: Stub Implementation
+// ============================================================================
+#[cfg(not(feature = "bp-arp"))]
+pub use disabled::*;
+
+#[cfg(not(feature = "bp-arp"))]
+mod disabled {
+    use super::*;
+
+    /// Stub ArpConfig (empty) to satisfy Config struct requirements
+    #[derive(Debug, Clone, Default)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    pub struct ArpConfig;
+
+    /// Stub ArpPolicy (empty)
+    #[derive(Debug, Clone, Default)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    pub struct ArpPolicy;
+
+    /// Stub ArpSubsystem (no-op)
+    pub struct ArpSubsystem;
+
+    impl ArpSubsystem {
+        pub fn new(_config: ArpConfig, _node_ids: Arc<node_ids::NodeIds>) -> Arc<Self> {
+            Arc::new(Self)
+        }
+
+        pub async fn on_neighbour_added(
+            self: &Arc<Self>,
+            _peer_id: u32,
+            _cla: Arc<registry::Cla>,
+            _cla_addr: ClaAddress,
+            _tasks: &hardy_async::TaskPool,
+        ) {}
+
+        pub async fn on_neighbour_removed(&self, _peer_id: u32) {}
+
+        pub async fn on_ack_received(&self, _peer_id: u32) {}
+    }
+}
+```
+
+### 2.3 Update `Dispatcher` in `bpa/src/dispatcher/admin.rs`
+
+Handle the `BpArp` record type and implement the request/response distinction logic.
+
+```rust
+            #[cfg(feature = "bp-arp")]
+            Ok(AdministrativeRecord::BpArp(eids)) => {
+                // Check if this is a Request (Probe) or Response (Ack) based on Destination EID
+                // Request: Destination is ipn:!.0 (LocalNode)
+                if matches!(bundle.bundle.id.destination, hardy_bpv7::eid::Eid::LocalNode(0)) {
+                    // It's a Probe (Request)
+                    debug!("Received BP-ARP probe from {}", bundle.bundle.id.source);
+                    let source = bundle.bundle.id.source.clone();
+
+                    // Send a Response (Ack) back with our EIDs
+                    let ack_payload = hardy_cbor::encode::emit(&AdministrativeRecord::BpArp(
+                        self.cla_registry.all_admin_endpoints(),
+                    ))
+                    .0;
+                    self.dispatch_admin_bundle(ack_payload, &source).await;
+                } else {
+                    // It's an Ack (Response)
+                    debug!("Received BP-ARP response from {}", bundle.bundle.id.source);
+
+                    // Promote neighbour
+                    let mut all_eids = eids;
+                    let source = bundle.bundle.id.source.clone();
+                    if !all_eids.contains(&source) {
+                        all_eids.push(source);
+                    }
+
+                    if let Some(peer_addr) = bundle.metadata.read_only.ingress_peer_addr.clone() {
+                        self.cla_registry
+                            .promote_neighbour(&peer_addr, all_eids)
+                            .await;
+                    } else {
+                        debug!("BP-ARP response received without ingress peer address, cannot promote");
+                    }
+                }
+                self.drop_bundle(bundle, None).await;
+            }
+```
+
+## Step 3: Verification
+
+1. Run `cargo check` (default features, bp-arp disabled) -> Should pass.
+2. Run `cargo check --features bp-arp` -> Should pass.
+3. Run `cargo fmt` to ensure formatting.
+4. Run `cargo clippy` to check for lints.


### PR DESCRIPTION
- Add BpArpProbe (type 2) and BpArpAck (type 3) to AdministrativeRecord in bpv7/src/status_report.rs. Both records carry no payload; the sender EID is conveyed in the bundle primary block source field.

- New bpa/src/cla/arp.rs: ArpSubsystem with per-Neighbour probe retry tasks, ArpConfig (probe_interval_secs, retry_count) and ArpPolicy (as-needed / always / never).

- Add Cla::forward_raw() for direct CLA injection bypassing the RIB, used by the ARP subsystem to send probes to Neighbours that have no route installed yet.

- Add Registry::promote_neighbour() which upgrades a Neighbour to a named Peer: updates the EID vec, installs a RIB forward route, and cancels the outstanding ARP probe task.

- CLA registry notifies the ARP subsystem when Neighbours are added or removed (add_peer / remove_peer / unregister_cla).

- Dispatcher handles BpArpProbe (learn sender EID, promote Neighbour, send BpArpAck back) and BpArpAck (learn sender EID, promote Neighbour).

- Refactor dispatch_status_report into a shared dispatch_admin_bundle helper so the admin handler can send acks without duplicating code.

- Add arp: ArpConfig field to bpa Config with serde support.

- Create bpa/docs/bp_arp_design.md design document.

- Mark TODO.md tasks 5.2, 5.2.1, 5.3, 5.4 as done.

Closes #362 