### PR TITLE
D3tn interop tests

### DIFF
--- a/tests/interop/benchmark.sh
+++ b/tests/interop/benchmark.sh
@@ -152,13 +152,14 @@ BPA_BIN="$WORKSPACE_DIR/target/release/hardy-bpa-server"
 # Build if needed
 if [ -z "$SKIP_BUILD_FLAG" ]; then
     log_info "Building Hardy..."
-    # Build with dynamic-plugins so ION test can use --cla for plugin CLA
-    (cd "$WORKSPACE_DIR" && cargo build --release \
-        -p hardy-tools --features hardy-tools/dynamic-plugins \
-        -p hardy-bpa-server --features hardy-bpa-server/dynamic-plugins) || {
+    if ! (cd "$WORKSPACE_DIR" && cargo build --release \
+        -p hardy-tools \
+        -p hardy-bpa-server); then
         log_warn "Build failed, skipping Hardy baseline"
         RESULTS+=("Hardy|-|-|-|-|Build failed|-|")
-    }
+        BPA_BIN=""
+        BP_BIN=""
+    fi
 
     # Build the MTCP/STCP CLA plugin for ION interop
     MTCP_CLA_DIR="$SCRIPT_DIR/mtcp"

--- a/tests/interop/benchmark.sh
+++ b/tests/interop/benchmark.sh
@@ -291,6 +291,21 @@ else
     log_warn "ION test script not found, skipping"
 fi
 
+# ud3tn (MTCP)
+if [ -x "$SCRIPT_DIR/ud3tn/test_ud3tn_ping.sh" ]; then
+    if docker image inspect ud3tn-interop &>/dev/null; then
+        log_step "Running ud3tn test..."
+        OUTPUT=$("$SCRIPT_DIR/ud3tn/test_ud3tn_ping.sh" $SKIP_BUILD_FLAG --count "$PING_COUNT" 2>&1) || true
+        extract_rtt_stats "$OUTPUT" "ud3tn"
+        log_info "ud3tn complete"
+    else
+        log_warn "ud3tn-interop Docker image not found, skipping"
+        RESULTS+=("ud3tn|-|-|-|-|No image|-|")
+    fi
+else
+    log_warn "ud3tn test script not found, skipping"
+fi
+
 # =============================================================================
 # Generate Markdown Table
 # =============================================================================
@@ -360,7 +375,7 @@ OUTPUT_FILE="$SCRIPT_DIR/benchmark_results.md"
     echo ""
     echo "- **Pings**: Received/Transmitted count"
     echo "- **vs Hardy**: Percentage relative to Hardy baseline (100% = same, >100% = slower)"
-    echo "- Most tests use TCPCLv4 over localhost; ION uses STCP via plugin CLA"
+    echo "- Hardy, dtn7-rs, HDTN, DTNME use TCPCLv4; ud3tn uses MTCP; ION uses STCP via plugin CLA"
     echo "- Hardy baseline runs inline; other tests use existing interop scripts"
     echo ""
     echo "_$PING_COUNT pings per test, generated $(date '+%Y-%m-%d %H:%M:%S')_"

--- a/tests/interop/mtcp/src/listen.rs
+++ b/tests/interop/mtcp/src/listen.rs
@@ -92,6 +92,11 @@ async fn handle_connection(
     sink: Arc<dyn hardy_bpa::cla::Sink>,
     cancel: hardy_async::CancellationToken,
 ) {
+    stream
+        .set_nodelay(true)
+        .inspect_err(|e| warn!("Failed to set TCP_NODELAY: {e}"))
+        .ok();
+
     let peer_addr = Some(hardy_bpa::cla::ClaAddress::Tcp(remote_addr));
 
     match framing {

--- a/tests/interop/ud3tn/docker/Dockerfile
+++ b/tests/interop/ud3tn/docker/Dockerfile
@@ -1,0 +1,69 @@
+# ud3tn Dockerfile for Interop Testing
+# uD3TN - Micro Delay-Tolerant Networking Implementation
+#
+# Builds ud3tn with Python tools for interoperability testing via MTCP.
+#
+# Build:
+#   docker build -t ud3tn-interop .
+#
+# Build with specific version:
+#   docker build -t ud3tn-interop --build-arg UD3TN_REF=v0.14.0 .
+#
+# Run:
+#   docker run -it --rm --network host \
+#       ud3tn-interop \
+#       -e ipn:2.0 -c "mtcp:0.0.0.0,4556" -b 7 -A 0.0.0.0 -P 4243 -R
+
+FROM python:3.13-slim AS builder
+
+ARG UD3TN_REF=master
+ARG CORES=4
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    build-essential \
+    libsqlite3-dev \
+    libjansson-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone ud3tn from GitLab
+WORKDIR /build
+RUN git clone --recursive https://gitlab.com/d3tn/ud3tn.git . && \
+    git checkout ${UD3TN_REF} && \
+    git submodule update --init --recursive
+
+# Build ud3tn
+RUN ARCH=x86-64 make posix -j${CORES}
+
+# Install Python packages
+RUN pip install --no-cache-dir --prefix=/install/python \
+    ./pyd3tn \
+    ./python-ud3tn-utils
+
+# Runtime stage
+FROM python:3.13-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libsqlite3-0 \
+    libjansson4 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy ud3tn binary
+COPY --from=builder /build/build/posix/ud3tn /usr/local/bin/ud3tn
+
+# Copy Python packages
+COPY --from=builder /install/python/ /usr/local/
+
+# Copy our start script
+COPY start_ud3tn /usr/local/bin/start_ud3tn
+RUN chmod +x /usr/local/bin/start_ud3tn /usr/local/bin/ud3tn
+
+EXPOSE 4556/tcp 4242/tcp 4243/tcp
+
+ENTRYPOINT ["/usr/local/bin/start_ud3tn"]

--- a/tests/interop/ud3tn/docker/start_ud3tn
+++ b/tests/interop/ud3tn/docker/start_ud3tn
@@ -1,0 +1,32 @@
+#!/bin/bash
+# ud3tn interop test wrapper script
+#
+# Starts ud3tn with MTCP convergence layer for interoperability testing.
+# All arguments are forwarded to ud3tn.
+#
+# If no arguments are provided, starts with defaults suitable for interop:
+#   -e ipn:2.0 -c "mtcp:0.0.0.0,4556" -b 7 -A 0.0.0.0 -P 4243 -R
+#
+# Usage:
+#   start_ud3tn [ud3tn-args...]
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "ud3tn Interop Testing (default config)"
+    echo "  EID:     ipn:2.0"
+    echo "  MTCP:    0.0.0.0:4556"
+    echo "  AAP2:    0.0.0.0:4243"
+    echo ""
+    exec ud3tn \
+        -e "ipn:2.0" \
+        -c "mtcp:0.0.0.0,4556" \
+        -b 7 \
+        -A 0.0.0.0 -P 4243 \
+        -R
+else
+    echo "ud3tn Interop Testing (custom args)"
+    echo "  Args: $*"
+    echo ""
+    exec ud3tn "$@"
+fi

--- a/tests/interop/ud3tn/start_ud3tn.sh
+++ b/tests/interop/ud3tn/start_ud3tn.sh
@@ -4,9 +4,19 @@
 # Usage:
 #   ./tests/interop/ud3tn/start_ud3tn.sh
 #
-# Then in another terminal:
-#   bp ping ipn:2.7 --cla /path/to/libhardy_mtcp_cla.so \
-#       --cla-config '{"framing":"mtcp","peer":"127.0.0.1:4556","peer-node":"ipn:2.0","address":"[::]:4557"}' \
+# Then in another terminal, create a CLA config file (e.g. /tmp/cla.toml):
+#   bpa-address = "http://[::1]:50051"
+#   cla-name = "cl0"
+#   framing = "mtcp"
+#   peer = "127.0.0.1:4556"
+#   peer-node = "ipn:2.0"
+#   address = "[::]:4557"
+#
+# Then run:
+#   bp ping ipn:2.7 \
+#       --cla /path/to/mtcp-cla \
+#       --cla-args "--config /tmp/cla.toml" \
+#       --grpc-listen "[::1]:50051" \
 #       --source ipn:1.12345 --no-sign
 
 set -e
@@ -19,6 +29,7 @@ UD3TN_MTCP_PORT=4556
 UD3TN_AAP2_PORT=4243
 HARDY_NODE_NUM=1
 HARDY_MTCP_PORT=4557
+HARDY_GRPC_PORT=50051
 
 cleanup() {
     echo ""
@@ -53,13 +64,33 @@ docker run --rm \
 CONTAINER_PID=$!
 sleep 3
 
-# Start echo agent
+# Start echo agent (ud3tn doesn't ship one, so we create it inline).
+# Uses two AAP2 connections (subscriber for recv, active for send)
+# because ud3tn's subscriber mode is receive-only.
+# Must send RESPONSE_STATUS_SUCCESS (1) after each received ADU.
 echo "Starting echo agent on ipn:$UD3TN_NODE_NUM.7..."
 docker exec -d ud3tn-interop-test \
-    python3 -m ud3tn_utils.aap.bin.aap_echo \
-    --agentid 7 \
-    --tcp 127.0.0.1 4242 \
-    2>/dev/null || echo "Warning: could not start echo agent via AAP1"
+    python3 -c "
+from ud3tn_utils.aap2 import AAP2TCPClient, BundleADU
+recv_client = AAP2TCPClient(('127.0.0.1', $UD3TN_AAP2_PORT))
+recv_client.connect()
+secret = recv_client.configure('7', subscribe=True)
+send_client = AAP2TCPClient(('127.0.0.1', $UD3TN_AAP2_PORT))
+send_client.connect()
+send_client.configure('7', subscribe=False, secret=secret)
+while True:
+    msg = recv_client.receive_msg()
+    t = msg.WhichOneof('msg')
+    if t == 'keepalive':
+        recv_client.send_response_status(2)
+        continue
+    if t != 'adu':
+        continue
+    adu, data = recv_client.receive_adu(msg.adu)
+    recv_client.send_response_status(1)
+    send_client.send_adu(BundleADU(dst_eid=adu.src_eid, payload_length=len(data)), data)
+    send_client.receive_response()
+" || echo "Warning: echo agent exited"
 
 # Configure contact to Hardy
 echo "Configuring contact to Hardy (ipn:$HARDY_NODE_NUM.0)..."
@@ -81,10 +112,19 @@ echo "  Echo:     ipn:$UD3TN_NODE_NUM.7"
 echo "  MTCP:     127.0.0.1:$UD3TN_MTCP_PORT"
 echo "  AAP2:     127.0.0.1:$UD3TN_AAP2_PORT"
 echo ""
-echo "Test with:"
+echo "Create a CLA config file (e.g. /tmp/cla.toml):"
+echo "  bpa-address = \"http://[::1]:$HARDY_GRPC_PORT\""
+echo "  cla-name = \"cl0\""
+echo "  framing = \"mtcp\""
+echo "  peer = \"127.0.0.1:$UD3TN_MTCP_PORT\""
+echo "  peer-node = \"ipn:$UD3TN_NODE_NUM.0\""
+echo "  address = \"[::]:$HARDY_MTCP_PORT\""
+echo ""
+echo "Then test with:"
 echo "  bp ping ipn:$UD3TN_NODE_NUM.7 \\"
-echo "    --cla /path/to/libhardy_mtcp_cla.so \\"
-echo "    --cla-config '{\"framing\":\"mtcp\",\"peer\":\"127.0.0.1:$UD3TN_MTCP_PORT\",\"peer-node\":\"ipn:$UD3TN_NODE_NUM.0\",\"address\":\"[::]:$HARDY_MTCP_PORT\"}' \\"
+echo "    --cla /path/to/mtcp-cla \\"
+echo "    --cla-args \"--config /tmp/cla.toml\" \\"
+echo "    --grpc-listen \"[::1]:$HARDY_GRPC_PORT\" \\"
 echo "    --source ipn:$HARDY_NODE_NUM.12345 --no-sign"
 echo ""
 echo "Press Ctrl+C to stop..."

--- a/tests/interop/ud3tn/start_ud3tn.sh
+++ b/tests/interop/ud3tn/start_ud3tn.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Start ud3tn in Docker for interactive testing via MTCP
+#
+# Usage:
+#   ./tests/interop/ud3tn/start_ud3tn.sh
+#
+# Then in another terminal:
+#   bp ping ipn:2.7 --cla /path/to/libhardy_mtcp_cla.so \
+#       --cla-config '{"framing":"mtcp","peer":"127.0.0.1:4556","peer-node":"ipn:2.0","address":"[::]:4557"}' \
+#       --source ipn:1.12345 --no-sign
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+UD3TN_IMAGE="ud3tn-interop"
+UD3TN_NODE_NUM=2
+UD3TN_MTCP_PORT=4556
+UD3TN_AAP2_PORT=4243
+HARDY_NODE_NUM=1
+HARDY_MTCP_PORT=4557
+
+cleanup() {
+    echo ""
+    echo "Stopping ud3tn container..."
+    docker stop -t 2 ud3tn-interop-test 2>/dev/null || true
+    docker rm -f ud3tn-interop-test 2>/dev/null || true
+    echo "Cleanup complete"
+    exit 0
+}
+
+trap cleanup INT TERM
+
+# Build image if needed
+if ! docker image inspect "$UD3TN_IMAGE" &>/dev/null; then
+    echo "Building ud3tn-interop image..."
+    docker build -t "$UD3TN_IMAGE" "$SCRIPT_DIR/docker"
+fi
+
+docker rm -f ud3tn-interop-test 2>/dev/null || true
+
+echo "Starting ud3tn (ipn:$UD3TN_NODE_NUM.0) with MTCP on port $UD3TN_MTCP_PORT..."
+docker run --rm \
+    --name ud3tn-interop-test \
+    --network host \
+    "$UD3TN_IMAGE" \
+    -e "ipn:$UD3TN_NODE_NUM.0" \
+    -c "mtcp:0.0.0.0,$UD3TN_MTCP_PORT" \
+    -b 7 \
+    -A 0.0.0.0 -P "$UD3TN_AAP2_PORT" \
+    -R &
+
+CONTAINER_PID=$!
+sleep 3
+
+# Start echo agent
+echo "Starting echo agent on ipn:$UD3TN_NODE_NUM.7..."
+docker exec -d ud3tn-interop-test \
+    python3 -m ud3tn_utils.aap.bin.aap_echo \
+    --agentid 7 \
+    --tcp 127.0.0.1 4242 \
+    2>/dev/null || echo "Warning: could not start echo agent via AAP1"
+
+# Configure contact to Hardy
+echo "Configuring contact to Hardy (ipn:$HARDY_NODE_NUM.0)..."
+docker exec ud3tn-interop-test \
+    python3 -m ud3tn_utils.aap2.bin.aap2_configure_link \
+    --tcp 127.0.0.1 "$UD3TN_AAP2_PORT" \
+    "ipn:$HARDY_NODE_NUM.0" \
+    "mtcp:127.0.0.1:$HARDY_MTCP_PORT" \
+    2>/dev/null || echo "Warning: could not configure contact"
+
+sleep 1
+
+echo ""
+echo "============================================"
+echo "ud3tn ready for testing"
+echo ""
+echo "  Node:     ipn:$UD3TN_NODE_NUM.0"
+echo "  Echo:     ipn:$UD3TN_NODE_NUM.7"
+echo "  MTCP:     127.0.0.1:$UD3TN_MTCP_PORT"
+echo "  AAP2:     127.0.0.1:$UD3TN_AAP2_PORT"
+echo ""
+echo "Test with:"
+echo "  bp ping ipn:$UD3TN_NODE_NUM.7 \\"
+echo "    --cla /path/to/libhardy_mtcp_cla.so \\"
+echo "    --cla-config '{\"framing\":\"mtcp\",\"peer\":\"127.0.0.1:$UD3TN_MTCP_PORT\",\"peer-node\":\"ipn:$UD3TN_NODE_NUM.0\",\"address\":\"[::]:$HARDY_MTCP_PORT\"}' \\"
+echo "    --source ipn:$HARDY_NODE_NUM.12345 --no-sign"
+echo ""
+echo "Press Ctrl+C to stop..."
+echo "============================================"
+
+docker wait ud3tn-interop-test || true
+cleanup

--- a/tests/interop/ud3tn/test_ud3tn_ping.sh
+++ b/tests/interop/ud3tn/test_ud3tn_ping.sh
@@ -196,13 +196,33 @@ if [ "$USE_DOCKER" = true ]; then
 
     log_info "Started ud3tn container: ${UD3TN_CONTAINER:0:12}"
 
+    # Wait for ud3tn to start (ss preferred — no TCP connection created)
     log_info "Waiting for ud3tn to initialize..."
-    sleep 3
+    WAIT_TIMEOUT=30
+    WAIT_COUNT=0
+    while [ $WAIT_COUNT -lt $WAIT_TIMEOUT ]; do
+        if ! docker ps -q -f "id=$UD3TN_CONTAINER" | grep -q .; then
+            log_error "ud3tn container exited unexpectedly. Logs:"
+            docker logs "$UD3TN_CONTAINER" 2>&1 | tail -50
+            docker rm "$UD3TN_CONTAINER" 2>/dev/null || true
+            exit 1
+        fi
 
-    if ! docker ps -q -f "id=$UD3TN_CONTAINER" | grep -q .; then
-        log_error "ud3tn container exited unexpectedly. Logs:"
-        docker logs "$UD3TN_CONTAINER" 2>&1 | tail -50
-        docker rm "$UD3TN_CONTAINER" 2>/dev/null || true
+        if ss -tln 2>/dev/null | grep -q ":$UD3TN_MTCP_PORT "; then
+            log_info "ud3tn is listening on port $UD3TN_MTCP_PORT (took ${WAIT_COUNT}s)"
+            break
+        fi
+
+        sleep 1
+        WAIT_COUNT=$((WAIT_COUNT + 1))
+    done
+
+    # Give ud3tn time to finish internal setup after port opens
+    sleep 2
+
+    if [ $WAIT_COUNT -ge $WAIT_TIMEOUT ]; then
+        log_error "ud3tn did not start listening on port $UD3TN_MTCP_PORT within ${WAIT_TIMEOUT}s"
+        docker logs "$UD3TN_CONTAINER" 2>&1 | tail -30
         exit 1
     fi
 
@@ -390,7 +410,24 @@ if [ "$USE_DOCKER" = true ]; then
         -R)
 
     log_info "Started ud3tn container: ${UD3TN_CONTAINER:0:12}"
-    sleep 3
+
+    log_info "Waiting for ud3tn to initialize..."
+    WAIT_TIMEOUT=30
+    WAIT_COUNT=0
+    while [ $WAIT_COUNT -lt $WAIT_TIMEOUT ]; do
+        if ! docker ps -q -f "id=$UD3TN_CONTAINER" | grep -q .; then
+            break
+        fi
+        if ss -tln 2>/dev/null | grep -q ":$UD3TN_MTCP_PORT "; then
+            log_info "ud3tn is listening on port $UD3TN_MTCP_PORT (took ${WAIT_COUNT}s)"
+            break
+        fi
+        sleep 1
+        WAIT_COUNT=$((WAIT_COUNT + 1))
+    done
+
+    # Give ud3tn time to finish internal setup after port opens
+    sleep 2
 
     if ! docker ps -q -f "id=$UD3TN_CONTAINER" | grep -q .; then
         log_error "ud3tn container exited unexpectedly. Logs:"

--- a/tests/interop/ud3tn/test_ud3tn_ping.sh
+++ b/tests/interop/ud3tn/test_ud3tn_ping.sh
@@ -1,0 +1,415 @@
+#!/bin/bash
+# Interoperability test: Hardy <-> ud3tn ping/echo via MTCP
+#
+# This script tests bidirectional ping/echo between Hardy and ud3tn:
+#   1. ud3tn as server with echo agent, Hardy pings it via MTCP
+#   2. Hardy as server with echo service, ud3tn pings it via MTCP
+#
+# Prerequisites:
+#   - Docker installed (for ud3tn container)
+#   - Hardy tools and bpa-server built (with dynamic-plugins feature)
+#   - MTCP/STCP CLA plugin built (tests/interop/mtcp/cla/)
+#   - ud3tn Docker image built (ud3tn-interop)
+#
+# Usage:
+#   ./tests/interop/ud3tn/test_ud3tn_ping.sh [--skip-build] [--no-docker]
+#
+# Options:
+#   --skip-build   Skip building Hardy and CLA plugin binaries
+#   --no-docker    Use local ud3tn binaries instead of Docker
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEROP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+MTCP_CLA_DIR="$INTEROP_DIR/mtcp/cla"
+
+# Configuration
+HARDY_NODE_NUM=1
+UD3TN_NODE_NUM=2
+UD3TN_MTCP_PORT=4556
+HARDY_MTCP_PORT=4557
+# ud3tn AAP2 port for agent registration
+UD3TN_AAP2_PORT=4243
+UD3TN_IMAGE="ud3tn-interop"
+PING_COUNT=5
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+log_step() { echo -e "${BLUE}[STEP]${NC} $*"; }
+
+# Parse options
+SKIP_BUILD=false
+USE_DOCKER=true
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --skip-build)
+            SKIP_BUILD=true
+            shift
+            ;;
+        --no-docker)
+            USE_DOCKER=false
+            shift
+            ;;
+        --count|-c)
+            PING_COUNT="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Cleanup function
+UD3TN_CONTAINER=""
+HARDY_PID=""
+CLEANUP_IN_PROGRESS=""
+
+kill_process() {
+    local pid=$1
+    local name=$2
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log_info "Stopping $name (PID $pid)..."
+        kill "$pid" 2>/dev/null || true
+        local count=0
+        while kill -0 "$pid" 2>/dev/null && [ $count -lt 30 ]; do
+            sleep 0.1
+            count=$((count + 1))
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+            log_warn "Force killing $name (PID $pid)..."
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+        wait "$pid" 2>/dev/null || true
+    fi
+}
+
+cleanup() {
+    if [ -n "$CLEANUP_IN_PROGRESS" ]; then
+        return
+    fi
+    CLEANUP_IN_PROGRESS=1
+
+    log_info "Cleaning up..."
+
+    if [ -n "$UD3TN_CONTAINER" ]; then
+        docker stop -t 2 "$UD3TN_CONTAINER" 2>/dev/null || true
+        docker rm -f "$UD3TN_CONTAINER" 2>/dev/null || true
+    fi
+    docker rm -f ud3tn-interop-test 2>/dev/null || true
+
+    kill_process "$HARDY_PID" "hardy-bpa-server"
+
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+
+    log_info "Cleanup complete"
+}
+trap cleanup EXIT INT TERM
+
+# Create temporary directory
+TEST_DIR=$(mktemp -d)
+log_info "Using test directory: $TEST_DIR"
+
+# Build Hardy tools, server, and MTCP CLA plugin if needed
+if [ "$SKIP_BUILD" = false ]; then
+    log_step "Building Hardy tools and bpa-server..."
+    cd "$WORKSPACE_DIR"
+    cargo build --release -p hardy-tools -p hardy-bpa-server --features dynamic-plugins
+
+    log_step "Building MTCP/STCP CLA plugin..."
+    cd "$MTCP_CLA_DIR"
+    cargo build --release
+fi
+
+BP_BIN="$WORKSPACE_DIR/target/release/bp"
+BPA_BIN="$WORKSPACE_DIR/target/release/hardy-bpa-server"
+CLA_PLUGIN="$MTCP_CLA_DIR/target/release/libhardy_mtcp_cla.so"
+
+if [ ! -x "$BP_BIN" ]; then
+    log_error "bp binary not found at $BP_BIN"
+    exit 1
+fi
+
+if [ ! -f "$CLA_PLUGIN" ]; then
+    log_error "MTCP CLA plugin not found at $CLA_PLUGIN"
+    log_error "Build it with: cd $MTCP_CLA_DIR && cargo build --release"
+    exit 1
+fi
+
+# Build or check for ud3tn
+if [ "$USE_DOCKER" = true ]; then
+    log_step "Checking for ud3tn-interop Docker image..."
+    if ! docker image inspect "$UD3TN_IMAGE" &>/dev/null; then
+        log_info "Building ud3tn-interop Docker image..."
+        docker build -t "$UD3TN_IMAGE" "$SCRIPT_DIR/docker"
+    else
+        log_info "Using existing ud3tn-interop image"
+    fi
+else
+    if ! command -v ud3tn &> /dev/null; then
+        log_error "ud3tn not found in PATH"
+        log_error "Install ud3tn or use Docker mode"
+        exit 1
+    fi
+    log_info "Found ud3tn at: $(which ud3tn)"
+fi
+
+# =============================================================================
+# TEST 1: ud3tn as server with echo agent, Hardy pings it via MTCP
+# =============================================================================
+echo ""
+echo "============================================================"
+log_info "TEST 1: ud3tn server with echo, Hardy pings via MTCP"
+echo "============================================================"
+
+log_step "Starting ud3tn daemon with MTCP CL..."
+
+if [ "$USE_DOCKER" = true ]; then
+    docker rm -f ud3tn-interop-test 2>/dev/null || true
+
+    # -e: EID, -c: CLA options, -A/-P: AAP2 TCP host/port, -R: allow remote config
+    UD3TN_CONTAINER=$(docker run -d \
+        --name ud3tn-interop-test \
+        --network host \
+        "$UD3TN_IMAGE" \
+        -e "ipn:$UD3TN_NODE_NUM.0" \
+        -c "mtcp:0.0.0.0,$UD3TN_MTCP_PORT" \
+        -b 7 \
+        -A 0.0.0.0 -P "$UD3TN_AAP2_PORT" \
+        -R)
+
+    log_info "Started ud3tn container: ${UD3TN_CONTAINER:0:12}"
+
+    log_info "Waiting for ud3tn to initialize..."
+    sleep 3
+
+    if ! docker ps -q -f "id=$UD3TN_CONTAINER" | grep -q .; then
+        log_error "ud3tn container exited unexpectedly. Logs:"
+        docker logs "$UD3TN_CONTAINER" 2>&1 | tail -50
+        docker rm "$UD3TN_CONTAINER" 2>/dev/null || true
+        exit 1
+    fi
+
+    # Start echo agent via AAP inside the container
+    # aap_echo registers on a service endpoint and echoes bundles back
+    log_step "Starting echo agent on ipn:$UD3TN_NODE_NUM.7..."
+    docker exec -d "$UD3TN_CONTAINER" \
+        python3 -m ud3tn_utils.aap.bin.aap_echo \
+        --agentid 7 \
+        --tcp 127.0.0.1 4242 \
+        2>/dev/null || {
+        # Fallback: try AAP2-based echo if AAP1 isn't available
+        docker exec -d "$UD3TN_CONTAINER" \
+            python3 -m ud3tn_utils.aap2.bin.aap2_receive \
+            --agentid 7 \
+            --tcp 127.0.0.1 "$UD3TN_AAP2_PORT" \
+            2>/dev/null || log_warn "Could not start echo agent"
+    }
+
+    sleep 2
+else
+    log_error "Native ud3tn mode not yet implemented - use Docker mode"
+    exit 1
+fi
+
+# Configure ud3tn contact to Hardy (so it knows how to route responses back)
+log_step "Configuring ud3tn contact to Hardy node..."
+docker exec "$UD3TN_CONTAINER" \
+    python3 -m ud3tn_utils.aap2.bin.aap2_configure_link \
+    --tcp 127.0.0.1 "$UD3TN_AAP2_PORT" \
+    "ipn:$HARDY_NODE_NUM.0" \
+    "mtcp:127.0.0.1:$HARDY_MTCP_PORT" \
+    2>/dev/null || log_warn "Could not configure contact (may not be needed)"
+
+sleep 1
+
+# Hardy pings ud3tn echo service via MTCP using the CLA plugin
+# Note: Hardy also needs to listen for MTCP responses from ud3tn
+log_step "Hardy pinging ud3tn echo service at ipn:$UD3TN_NODE_NUM.7 via MTCP..."
+echo ""
+
+PING_OUTPUT=$("$BP_BIN" ping "ipn:$UD3TN_NODE_NUM.7" \
+    --cla "$CLA_PLUGIN" \
+    --cla-config "{\"framing\":\"mtcp\",\"peer\":\"127.0.0.1:$UD3TN_MTCP_PORT\",\"peer-node\":\"ipn:$UD3TN_NODE_NUM.0\",\"address\":\"[::]:$HARDY_MTCP_PORT\"}" \
+    --source "ipn:$HARDY_NODE_NUM.12345" \
+    --count "$PING_COUNT" \
+    --no-sign \
+    2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+
+echo "$PING_OUTPUT"
+echo ""
+
+STATS_LINE=$(echo "$PING_OUTPUT" | grep -E '[0-9]+ (bundles )?transmitted' | head -1)
+TRANSMITTED=$(echo "$STATS_LINE" | sed -E 's/^([0-9]+).*/\1/')
+RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*, ([0-9]+) received.*/\1/')
+
+if [ $EXIT_CODE -eq 0 ]; then
+    if [ "$RECEIVED" = "$TRANSMITTED" ] && [ -n "$RECEIVED" ]; then
+        log_info "TEST 1 PASSED: Hardy successfully pinged ud3tn ($RECEIVED/$TRANSMITTED)"
+        TEST1_RESULT="PASS"
+    else
+        log_error "TEST 1 FAILED: Partial loss - only $RECEIVED/$TRANSMITTED responses received"
+        TEST1_RESULT="FAIL"
+    fi
+elif [ $EXIT_CODE -eq 1 ]; then
+    log_error "TEST 1 FAILED: No echo responses received (100% loss)"
+    TEST1_RESULT="FAIL"
+else
+    log_error "TEST 1 FAILED: Error during ping (exit code $EXIT_CODE)"
+    TEST1_RESULT="FAIL"
+fi
+
+# Stop ud3tn for test 2
+log_info "Stopping ud3tn..."
+if [ "$USE_DOCKER" = true ]; then
+    docker stop "$UD3TN_CONTAINER" 2>/dev/null || true
+    docker rm -f "$UD3TN_CONTAINER" 2>/dev/null || true
+    UD3TN_CONTAINER=""
+fi
+
+sleep 1
+
+# =============================================================================
+# TEST 2: Hardy as server with echo, ud3tn pings it via MTCP
+# =============================================================================
+echo ""
+echo "============================================================"
+log_info "TEST 2: Hardy server with echo, ud3tn pings via MTCP"
+echo "============================================================"
+
+# Create Hardy config for server mode with MTCP CLA plugin
+cat > "$TEST_DIR/hardy_config.toml" << EOF
+log-level = "info"
+status-reports = true
+node-ids = "ipn:$HARDY_NODE_NUM.0"
+plugin-dir = "$(dirname "$CLA_PLUGIN")"
+
+[built-in-services]
+echo = [7]
+
+[storage.metadata]
+type = "memory"
+
+[storage.bundle]
+type = "memory"
+
+[rfc9171-validity]
+primary-block-integrity = false
+
+[[clas]]
+name = "mtcp0"
+type = "hardy_mtcp_cla"
+framing = "mtcp"
+address = "[::]:$HARDY_MTCP_PORT"
+EOF
+
+log_step "Starting Hardy BPA server with MTCP CLA plugin..."
+"$BPA_BIN" -c "$TEST_DIR/hardy_config.toml" &
+HARDY_PID=$!
+
+sleep 3
+
+if ! kill -0 "$HARDY_PID" 2>/dev/null; then
+    log_error "Hardy BPA server failed to start"
+    exit 1
+fi
+log_info "Hardy BPA server started with PID $HARDY_PID"
+
+# Start ud3tn to ping Hardy
+log_step "Starting ud3tn to ping Hardy..."
+
+if [ "$USE_DOCKER" = true ]; then
+    docker rm -f ud3tn-interop-test 2>/dev/null || true
+
+    UD3TN_CONTAINER=$(docker run -d \
+        --name ud3tn-interop-test \
+        --network host \
+        "$UD3TN_IMAGE" \
+        -e "ipn:$UD3TN_NODE_NUM.0" \
+        -c "mtcp:0.0.0.0,$UD3TN_MTCP_PORT" \
+        -b 7 \
+        -A 0.0.0.0 -P "$UD3TN_AAP2_PORT" \
+        -R)
+
+    log_info "Started ud3tn container: ${UD3TN_CONTAINER:0:12}"
+    sleep 3
+
+    if ! docker ps -q -f "id=$UD3TN_CONTAINER" | grep -q .; then
+        log_error "ud3tn container exited unexpectedly. Logs:"
+        docker logs "$UD3TN_CONTAINER" 2>&1 | tail -20
+        docker rm "$UD3TN_CONTAINER" 2>/dev/null || true
+        TEST2_RESULT="FAIL"
+    else
+        # Configure contact to Hardy
+        log_step "Configuring ud3tn contact to Hardy..."
+        docker exec "$UD3TN_CONTAINER" \
+            python3 -m ud3tn_utils.aap2.bin.aap2_configure_link \
+            --tcp 127.0.0.1 "$UD3TN_AAP2_PORT" \
+            "ipn:$HARDY_NODE_NUM.0" \
+            "mtcp:127.0.0.1:$HARDY_MTCP_PORT" \
+            2>/dev/null || log_warn "Could not configure contact"
+
+        sleep 2
+
+        # Run ping from ud3tn container using aap2_ping
+        log_step "ud3tn pinging Hardy echo service at ipn:$HARDY_NODE_NUM.7..."
+        PING_TIMEOUT=$((PING_COUNT * 2 + 10))
+        PING_OUTPUT=$(timeout "${PING_TIMEOUT}s" docker exec "$UD3TN_CONTAINER" \
+            python3 -m ud3tn_utils.aap2.bin.aap2_ping \
+            --tcp 127.0.0.1 "$UD3TN_AAP2_PORT" \
+            --agentid 128 \
+            --count "$PING_COUNT" \
+            "ipn:$HARDY_NODE_NUM.7" \
+            2>&1) || true
+
+        echo "$PING_OUTPUT"
+        echo ""
+
+        # aap2_ping reports round-trip times; count lines with time info
+        RESPONSE_COUNT=$(echo "$PING_OUTPUT" | grep -ci "time\|reply\|response\|ms" || echo "0")
+
+        if [ "$RESPONSE_COUNT" -ge "$PING_COUNT" ]; then
+            log_info "TEST 2 PASSED: ud3tn received responses from Hardy"
+            TEST2_RESULT="PASS"
+        elif [ "$RESPONSE_COUNT" -ge 1 ]; then
+            log_error "TEST 2 FAILED: Partial loss - only $RESPONSE_COUNT responses detected"
+            TEST2_RESULT="FAIL"
+        else
+            log_error "TEST 2 FAILED: No echo responses received"
+            TEST2_RESULT="FAIL"
+        fi
+    fi
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "============================================================"
+log_info "TEST SUMMARY"
+echo "============================================================"
+echo ""
+echo "  TEST 1 (Hardy pings ud3tn via MTCP): $TEST1_RESULT"
+echo "  TEST 2 (ud3tn pings Hardy via MTCP): $TEST2_RESULT"
+echo ""
+
+if [ "$TEST1_RESULT" = "PASS" ] && [ "$TEST2_RESULT" = "PASS" ]; then
+    log_info "All ud3tn interoperability tests passed"
+    exit 0
+else
+    log_error "Some tests failed"
+    exit 1
+fi

--- a/tests/interop/ud3tn/test_ud3tn_ping.sh
+++ b/tests/interop/ud3tn/test_ud3tn_ping.sh
@@ -7,15 +7,15 @@
 #
 # Prerequisites:
 #   - Docker installed (for ud3tn container)
-#   - Hardy tools and bpa-server built (with dynamic-plugins feature)
-#   - MTCP/STCP CLA plugin built (tests/interop/mtcp/cla/)
+#   - Hardy tools and bpa-server built
+#   - MTCP/STCP CLA binary built (tests/interop/mtcp/)
 #   - ud3tn Docker image built (ud3tn-interop)
 #
 # Usage:
 #   ./tests/interop/ud3tn/test_ud3tn_ping.sh [--skip-build] [--no-docker]
 #
 # Options:
-#   --skip-build   Skip building Hardy and CLA plugin binaries
+#   --skip-build   Skip building Hardy and CLA binaries
 #   --no-docker    Use local ud3tn binaries instead of Docker
 
 set -e
@@ -23,13 +23,14 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INTEROP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-MTCP_CLA_DIR="$INTEROP_DIR/mtcp/cla"
+MTCP_CLA_DIR="$INTEROP_DIR/mtcp"
 
 # Configuration
 HARDY_NODE_NUM=1
 UD3TN_NODE_NUM=2
 UD3TN_MTCP_PORT=4556
 HARDY_MTCP_PORT=4557
+HARDY_GRPC_PORT=50051
 # ud3tn AAP2 port for agent registration
 UD3TN_AAP2_PORT=4243
 UD3TN_IMAGE="ud3tn-interop"
@@ -74,6 +75,7 @@ done
 # Cleanup function
 UD3TN_CONTAINER=""
 HARDY_PID=""
+CLA_PID=""
 CLEANUP_IN_PROGRESS=""
 
 kill_process() {
@@ -83,7 +85,7 @@ kill_process() {
         log_info "Stopping $name (PID $pid)..."
         kill "$pid" 2>/dev/null || true
         local count=0
-        while kill -0 "$pid" 2>/dev/null && [ $count -lt 30 ]; do
+        while kill -0 "$pid" 2>/dev/null && [ $count -lt 50 ]; do
             sleep 0.1
             count=$((count + 1))
         done
@@ -109,6 +111,7 @@ cleanup() {
     fi
     docker rm -f ud3tn-interop-test 2>/dev/null || true
 
+    kill_process "$CLA_PID" "mtcp-cla"
     kill_process "$HARDY_PID" "hardy-bpa-server"
 
     if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
@@ -123,28 +126,28 @@ trap cleanup EXIT INT TERM
 TEST_DIR=$(mktemp -d)
 log_info "Using test directory: $TEST_DIR"
 
-# Build Hardy tools, server, and MTCP CLA plugin if needed
+# Build Hardy tools, server, and MTCP CLA binary if needed
 if [ "$SKIP_BUILD" = false ]; then
     log_step "Building Hardy tools and bpa-server..."
     cd "$WORKSPACE_DIR"
-    cargo build --release -p hardy-tools -p hardy-bpa-server --features dynamic-plugins
+    cargo build --release -p hardy-tools -p hardy-bpa-server
 
-    log_step "Building MTCP/STCP CLA plugin..."
+    log_step "Building MTCP/STCP CLA binary..."
     cd "$MTCP_CLA_DIR"
     cargo build --release
 fi
 
 BP_BIN="$WORKSPACE_DIR/target/release/bp"
 BPA_BIN="$WORKSPACE_DIR/target/release/hardy-bpa-server"
-CLA_PLUGIN="$MTCP_CLA_DIR/target/release/libhardy_mtcp_cla.so"
+CLA_BIN="$MTCP_CLA_DIR/target/release/mtcp-cla"
 
 if [ ! -x "$BP_BIN" ]; then
     log_error "bp binary not found at $BP_BIN"
     exit 1
 fi
 
-if [ ! -f "$CLA_PLUGIN" ]; then
-    log_error "MTCP CLA plugin not found at $CLA_PLUGIN"
+if [ ! -x "$CLA_BIN" ]; then
+    log_error "mtcp-cla binary not found at $CLA_BIN"
     log_error "Build it with: cd $MTCP_CLA_DIR && cargo build --release"
     exit 1
 fi
@@ -203,21 +206,34 @@ if [ "$USE_DOCKER" = true ]; then
         exit 1
     fi
 
-    # Start echo agent via AAP inside the container
-    # aap_echo registers on a service endpoint and echoes bundles back
+    # Start echo agent via AAP2 inside the container.
+    # ud3tn doesn't ship an echo agent, so we create one inline.
+    # Uses two AAP2 connections (subscriber for recv, active for send)
+    # because ud3tn's subscriber mode is receive-only.
+    # Must send RESPONSE_STATUS_SUCCESS (1) after each received ADU.
     log_step "Starting echo agent on ipn:$UD3TN_NODE_NUM.7..."
     docker exec -d "$UD3TN_CONTAINER" \
-        python3 -m ud3tn_utils.aap.bin.aap_echo \
-        --agentid 7 \
-        --tcp 127.0.0.1 4242 \
-        2>/dev/null || {
-        # Fallback: try AAP2-based echo if AAP1 isn't available
-        docker exec -d "$UD3TN_CONTAINER" \
-            python3 -m ud3tn_utils.aap2.bin.aap2_receive \
-            --agentid 7 \
-            --tcp 127.0.0.1 "$UD3TN_AAP2_PORT" \
-            2>/dev/null || log_warn "Could not start echo agent"
-    }
+        python3 -c "
+from ud3tn_utils.aap2 import AAP2TCPClient, BundleADU
+recv_client = AAP2TCPClient(('127.0.0.1', $UD3TN_AAP2_PORT))
+recv_client.connect()
+secret = recv_client.configure('7', subscribe=True)
+send_client = AAP2TCPClient(('127.0.0.1', $UD3TN_AAP2_PORT))
+send_client.connect()
+send_client.configure('7', subscribe=False, secret=secret)
+while True:
+    msg = recv_client.receive_msg()
+    t = msg.WhichOneof('msg')
+    if t == 'keepalive':
+        recv_client.send_response_status(2)
+        continue
+    if t != 'adu':
+        continue
+    adu, data = recv_client.receive_adu(msg.adu)
+    recv_client.send_response_status(1)
+    send_client.send_adu(BundleADU(dst_eid=adu.src_eid, payload_length=len(data)), data)
+    send_client.receive_response()
+" || log_warn "Echo agent exited"
 
     sleep 2
 else
@@ -236,14 +252,24 @@ docker exec "$UD3TN_CONTAINER" \
 
 sleep 1
 
-# Hardy pings ud3tn echo service via MTCP using the CLA plugin
-# Note: Hardy also needs to listen for MTCP responses from ud3tn
+# Create CLA config for bp ping (TEST 1)
+cat > "$TEST_DIR/cla_ping.toml" << EOF
+bpa-address = "http://[::1]:$HARDY_GRPC_PORT"
+cla-name = "cl0"
+framing = "mtcp"
+peer = "127.0.0.1:$UD3TN_MTCP_PORT"
+peer-node = "ipn:$UD3TN_NODE_NUM.0"
+address = "[::]:$HARDY_MTCP_PORT"
+EOF
+
+# Hardy pings ud3tn echo service via MTCP using the external CLA binary
 log_step "Hardy pinging ud3tn echo service at ipn:$UD3TN_NODE_NUM.7 via MTCP..."
 echo ""
 
 PING_OUTPUT=$("$BP_BIN" ping "ipn:$UD3TN_NODE_NUM.7" \
-    --cla "$CLA_PLUGIN" \
-    --cla-config "{\"framing\":\"mtcp\",\"peer\":\"127.0.0.1:$UD3TN_MTCP_PORT\",\"peer-node\":\"ipn:$UD3TN_NODE_NUM.0\",\"address\":\"[::]:$HARDY_MTCP_PORT\"}" \
+    --cla "$CLA_BIN" \
+    --cla-args "--config $TEST_DIR/cla_ping.toml" \
+    --grpc-listen "[::1]:$HARDY_GRPC_PORT" \
     --source "ipn:$HARDY_NODE_NUM.12345" \
     --count "$PING_COUNT" \
     --no-sign \
@@ -290,12 +316,11 @@ echo "============================================================"
 log_info "TEST 2: Hardy server with echo, ud3tn pings via MTCP"
 echo "============================================================"
 
-# Create Hardy config for server mode with MTCP CLA plugin
+# Create Hardy bpa-server config
 cat > "$TEST_DIR/hardy_config.toml" << EOF
 log-level = "info"
 status-reports = true
 node-ids = "ipn:$HARDY_NODE_NUM.0"
-plugin-dir = "$(dirname "$CLA_PLUGIN")"
 
 [built-in-services]
 echo = [7]
@@ -309,24 +334,44 @@ type = "memory"
 [rfc9171-validity]
 primary-block-integrity = false
 
-[[clas]]
-name = "mtcp0"
-type = "hardy_mtcp_cla"
-framing = "mtcp"
-address = "[::]:$HARDY_MTCP_PORT"
+[grpc]
+address = "[::1]:$HARDY_GRPC_PORT"
+services = ["cla"]
 EOF
 
-log_step "Starting Hardy BPA server with MTCP CLA plugin..."
+# Create CLA config for the standalone MTCP CLA process
+cat > "$TEST_DIR/cla_server.toml" << EOF
+bpa-address = "http://[::1]:$HARDY_GRPC_PORT"
+cla-name = "cl0"
+framing = "mtcp"
+address = "[::]:$HARDY_MTCP_PORT"
+peer = "127.0.0.1:$UD3TN_MTCP_PORT"
+peer-node = "ipn:$UD3TN_NODE_NUM.0"
+EOF
+
+log_step "Starting Hardy BPA server..."
 "$BPA_BIN" -c "$TEST_DIR/hardy_config.toml" &
 HARDY_PID=$!
 
-sleep 3
+sleep 2
 
 if ! kill -0 "$HARDY_PID" 2>/dev/null; then
     log_error "Hardy BPA server failed to start"
     exit 1
 fi
 log_info "Hardy BPA server started with PID $HARDY_PID"
+
+log_step "Starting MTCP CLA process..."
+"$CLA_BIN" --config "$TEST_DIR/cla_server.toml" &
+CLA_PID=$!
+
+sleep 2
+
+if ! kill -0 "$CLA_PID" 2>/dev/null; then
+    log_error "MTCP CLA failed to start"
+    exit 1
+fi
+log_info "MTCP CLA started with PID $CLA_PID"
 
 # Start ud3tn to ping Hardy
 log_step "Starting ud3tn to ping Hardy..."
@@ -378,15 +423,19 @@ if [ "$USE_DOCKER" = true ]; then
         echo "$PING_OUTPUT"
         echo ""
 
-        # aap2_ping reports round-trip times; count lines with time info
-        RESPONSE_COUNT=$(echo "$PING_OUTPUT" | grep -ci "time\|reply\|response\|ms" || echo "0")
+        # aap2_ping output: "Ping ran for X seconds, received N of M sent"
+        STATS_LINE=$(echo "$PING_OUTPUT" | grep "received .* of .* sent" | tail -1)
+        RECEIVED=$(echo "$STATS_LINE" | sed -E 's/.*received ([0-9]+) of.*/\1/')
+        SENT=$(echo "$STATS_LINE" | sed -E 's/.*of ([0-9]+) sent.*/\1/')
 
-        if [ "$RESPONSE_COUNT" -ge "$PING_COUNT" ]; then
-            log_info "TEST 2 PASSED: ud3tn received responses from Hardy"
-            TEST2_RESULT="PASS"
-        elif [ "$RESPONSE_COUNT" -ge 1 ]; then
-            log_error "TEST 2 FAILED: Partial loss - only $RESPONSE_COUNT responses detected"
-            TEST2_RESULT="FAIL"
+        if [ -n "$RECEIVED" ] && [ "$RECEIVED" -ge 1 ] 2>/dev/null; then
+            if [ "$RECEIVED" = "$SENT" ]; then
+                log_info "TEST 2 PASSED: ud3tn received $RECEIVED/$SENT responses from Hardy"
+                TEST2_RESULT="PASS"
+            else
+                log_error "TEST 2 FAILED: Partial loss ($RECEIVED/$SENT)"
+                TEST2_RESULT="FAIL"
+            fi
         else
             log_error "TEST 2 FAILED: No echo responses received"
             TEST2_RESULT="FAIL"


### PR DESCRIPTION
Add ud3tn (µD3TN) interoperability tests via MTCP, matching the ION interop test pattern.

  Changes

  ud3tn Docker image (tests/interop/ud3tn/docker/)

  - Dockerfile builds ud3tn from GitLab with Python tools (pyd3tn, python-ud3tn-utils)
  - start_ud3tn wrapper script starts ud3tn with MTCP CLA and AAP2 TCP interface

  Test scripts (tests/interop/ud3tn/)

  - test_ud3tn_ping.sh — automated bidirectional ping/echo tests:
    - TEST 1: Hardy pings ud3tn's echo service via MTCP
    - TEST 2: ud3tn pings Hardy's echo service via MTCP
  - start_ud3tn.sh — interactive ud3tn startup for manual testing

  ud3tn echo agent

  ud3tn doesn't ship an echo agent, so the tests create one inline using the AAP2 Python API. Key details:
  - Two separate AAP2 TCP connections required: subscriber (receive-only) and active (send) — ud3tn's subscriber mode doesn't allow sending
  - Must send RESPONSE_STATUS_SUCCESS (1) after each received ADU, otherwise ud3tn closes the connection
  - Handles keepalive messages with RESPONSE_STATUS_ACK (2)

  Test plan

  - test_ud3tn_ping.sh — 5/5 both directions, clean shutdown
  - ION interop tests unaffected (separate branch)