### PR TITLE
Add proper metrics collection to the BPA

### DIFF
--- a/async/src/bounded_task_pool.rs
+++ b/async/src/bounded_task_pool.rs
@@ -66,7 +66,6 @@ use crate::task_pool::TaskPool;
 #[derive(Clone)]
 pub struct BoundedTaskPool {
     inner: TaskPool,
-    max_concurrent: usize,
     semaphore: Arc<tokio::sync::Semaphore>,
 }
 
@@ -86,17 +85,10 @@ impl BoundedTaskPool {
     /// let pool = BoundedTaskPool::new(core::num::NonZeroUsize::new(8).unwrap());
     /// ```
     pub fn new(max_concurrent: core::num::NonZeroUsize) -> Self {
-        let max: usize = max_concurrent.into();
         Self {
             inner: TaskPool::new(),
-            max_concurrent: max,
-            semaphore: Arc::new(tokio::sync::Semaphore::new(max)),
+            semaphore: Arc::new(tokio::sync::Semaphore::new(max_concurrent.into())),
         }
-    }
-
-    /// Returns the number of tasks currently active (holding permits).
-    pub fn active_tasks(&self) -> usize {
-        self.max_concurrent - self.semaphore.available_permits()
     }
 
     /// Spawns a task, waiting for a permit if at capacity.

--- a/async/src/bounded_task_pool.rs
+++ b/async/src/bounded_task_pool.rs
@@ -66,6 +66,7 @@ use crate::task_pool::TaskPool;
 #[derive(Clone)]
 pub struct BoundedTaskPool {
     inner: TaskPool,
+    max_concurrent: usize,
     semaphore: Arc<tokio::sync::Semaphore>,
 }
 
@@ -85,10 +86,17 @@ impl BoundedTaskPool {
     /// let pool = BoundedTaskPool::new(core::num::NonZeroUsize::new(8).unwrap());
     /// ```
     pub fn new(max_concurrent: core::num::NonZeroUsize) -> Self {
+        let max: usize = max_concurrent.into();
         Self {
             inner: TaskPool::new(),
-            semaphore: Arc::new(tokio::sync::Semaphore::new(max_concurrent.into())),
+            max_concurrent: max,
+            semaphore: Arc::new(tokio::sync::Semaphore::new(max)),
         }
+    }
+
+    /// Returns the number of tasks currently active (holding permits).
+    pub fn active_tasks(&self) -> usize {
+        self.max_concurrent - self.semaphore.available_permits()
     }
 
     /// Spawns a task, waiting for a permit if at capacity.

--- a/bpa/src/bpa.rs
+++ b/bpa/src/bpa.rs
@@ -15,7 +15,7 @@ use crate::routes::{self, RoutingAgent};
 use crate::services::Service;
 use crate::services::registry::Registry as ServiceRegistry;
 use crate::storage::Store;
-use crate::{Arc, services};
+use crate::{Arc, otel_metrics, services};
 
 /// Trait for registering CLAs, services, and applications with a BPA.
 ///
@@ -242,6 +242,8 @@ impl Bpa {
 
     #[cfg_attr(feature = "instrument", instrument(skip(self)))]
     pub fn start(&self, recover_storage: bool) {
+        otel_metrics::init();
+
         // Start the store
         self.store.start(self.dispatcher.clone(), recover_storage);
 

--- a/bpa/src/cla/registry.rs
+++ b/bpa/src/cla/registry.rs
@@ -232,6 +232,7 @@ impl Registry {
             // Remove RIB entries for all EIDs associated with this address
             for node_id in node_ids {
                 self.rib.remove_forward(node_id, peer_id).await;
+                metrics::gauge!("bpa.fib.entries", "cla" => cla.name.clone()).decrement(1.0);
             }
             // Remove from peer table (stops forwarding, signals drain)
             self.peers.remove(peer_id).await;
@@ -274,10 +275,9 @@ impl Registry {
             return false;
         }
 
-        debug!(
-            "Added new peer {peer_id}: [{node_ids:?}] at {cla_addr} via CLA {}",
-            cla.name
-        );
+        let cla_name = cla.name.clone();
+
+        debug!("Added new peer {peer_id}: [{node_ids:?}] at {cla_addr} via CLA {cla_name}");
 
         // Start the peer polling the queue
         peer.start(
@@ -295,6 +295,7 @@ impl Registry {
         // Neighbours (empty node_ids) get no RIB entry — BP-ARP will resolve them later.
         for node_id in node_ids {
             self.rib.add_forward(node_id.clone(), peer_id).await;
+            metrics::gauge!("bpa.fib.entries", "cla" => cla_name.clone()).increment(1.0);
         }
 
         true
@@ -308,6 +309,7 @@ impl Registry {
         self.peers.remove(peer_id).await;
         for node_id in node_ids {
             self.rib.remove_forward(node_id, peer_id).await;
+            metrics::gauge!("bpa.fib.entries", "cla" => cla.name.clone()).decrement(1.0);
         }
 
         debug!("Removed peer {peer_id}");

--- a/bpa/src/cla/registry.rs
+++ b/bpa/src/cla/registry.rs
@@ -147,6 +147,10 @@ impl Registry {
         // sync::spin::Mutex::lock() returns guard directly (no Result)
         let clas = self.clas.lock().drain().map(|(_, v)| v).collect::<Vec<_>>();
 
+        if !clas.is_empty() {
+            metrics::gauge!("bpa.cla.registered").decrement(clas.len() as f64);
+        }
+
         for cla in clas {
             self.unregister_cla(cla).await;
         }
@@ -183,6 +187,8 @@ impl Registry {
             .clone()
         };
 
+        metrics::gauge!("bpa.cla.registered").increment(1.0);
+
         // Register that the CLA is a handler for the address type
         if let Some(address_type) = address_type {
             self.rib.add_address_type(address_type, cla.clone());
@@ -208,6 +214,7 @@ impl Registry {
         let cla = self.clas.lock().remove(&cla.name);
 
         if let Some(cla) = cla {
+            metrics::gauge!("bpa.cla.registered").decrement(1.0);
             self.unregister_cla(cla).await;
         }
     }

--- a/bpa/src/dispatcher/admin.rs
+++ b/bpa/src/dispatcher/admin.rs
@@ -4,11 +4,14 @@ use hardy_bpv7::status_report::AdministrativeRecord;
 impl Dispatcher {
     #[cfg_attr(feature = "instrument", instrument(skip_all,fields(bundle.id = %bundle.bundle.id)))]
     pub(super) async fn administrative_bundle(&self, mut bundle: bundle::Bundle, data: Bytes) {
+        metrics::counter!("bpa.admin_record.received").increment(1);
+
         // This is a bundle for an Admin Endpoint
         if !bundle.bundle.flags.is_admin_record {
             debug!(
                 "Received a bundle for an administrative endpoint that isn't marked as an administrative record"
             );
+            metrics::counter!("bpa.admin_record.unknown").increment(1);
             return self
                 .drop_bundle(bundle, Some(ReasonCode::BlockUnintelligible))
                 .await;
@@ -36,11 +39,30 @@ impl Dispatcher {
         match hardy_cbor::decode::parse(data.as_ref()) {
             Err(e) => {
                 debug!("Failed to parse administrative record: {e}");
+                metrics::counter!("bpa.admin_record.unknown").increment(1);
                 self.drop_bundle(bundle, Some(ReasonCode::BlockUnintelligible))
                     .await
             }
             Ok(AdministrativeRecord::BundleStatusReport(report)) => {
                 debug!("Received administrative record: {report:?}");
+
+                // Count each assertion type present in the report
+                if report.received.is_some() {
+                    metrics::counter!("bpa.status_report.received", "type" => "reception")
+                        .increment(1);
+                }
+                if report.forwarded.is_some() {
+                    metrics::counter!("bpa.status_report.received", "type" => "forwarding")
+                        .increment(1);
+                }
+                if report.delivered.is_some() {
+                    metrics::counter!("bpa.status_report.received", "type" => "delivery")
+                        .increment(1);
+                }
+                if report.deleted.is_some() {
+                    metrics::counter!("bpa.status_report.received", "type" => "deletion")
+                        .increment(1);
+                }
 
                 // Find a live service to notify
                 match self.rib.find_local(&report.bundle_id.source) {

--- a/bpa/src/dispatcher/admin.rs
+++ b/bpa/src/dispatcher/admin.rs
@@ -111,10 +111,15 @@ impl Dispatcher {
                                 )
                                 .await;
                         }
-                        self.drop_bundle(bundle, None).await;
+
+                        // Just delete the bundle, there's no required counters or reporting
+                        self.delete_bundle(bundle).await;
                     }
                     Some(_) => {
-                        self.drop_bundle(bundle, None).await;
+                        // TODO:  This match case can be removed when we fix Service registration
+
+                        // Just delete the bundle, there's no required counters or reporting
+                        self.delete_bundle(bundle).await;
                     }
                     None => {
                         let desired = bundle::BundleStatus::WaitingForService {

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -264,7 +264,7 @@ impl Dispatcher {
                 &self.processing_pool,
             )
             .await
-            // TODO: Replace trace_expect with proper error handling and bpa.filter.error metric
+            // TODO: Replace trace_expect with proper error handling
             .trace_expect("Ingress filter execution failed")
         {
             filters::registry::ExecResult::Continue(mutation, mut bundle, data) => {

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -206,9 +206,6 @@ impl Dispatcher {
     pub(super) async fn ingest_bundle(self: &Arc<Self>, bundle: bundle::Bundle, data: Bytes) {
         metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
 
-        metrics::gauge!("bpa.processing_pool.active")
-            .set(self.processing_pool.active_tasks() as f64);
-
         let dispatcher = self.clone();
         hardy_async::spawn!(self.processing_pool, "ingest_bundle", async move {
             dispatcher.ingest_bundle_inner(bundle, data).await
@@ -321,8 +318,6 @@ impl Dispatcher {
                 continue;
             }
 
-            metrics::gauge!("bpa.processing_pool.active")
-                .set(self.processing_pool.active_tasks() as f64);
             let dispatcher = self.clone();
             hardy_async::spawn!(self.processing_pool, "process_bundle", async move {
                 if let Some(data) = dispatcher.load_data(&bundle).await {
@@ -416,8 +411,6 @@ impl Dispatcher {
                                 continue;
                             }
 
-                            metrics::gauge!("bpa.processing_pool.active")
-                                .set(self.processing_pool.active_tasks() as f64);
                             let dispatcher = dispatcher.clone();
                             hardy_async::spawn!(self.processing_pool, "poll_waiting_dispatcher", async move {
                                 if let Some(data) = dispatcher.load_data(&bundle).await {

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -185,6 +185,7 @@ impl Dispatcher {
         if reason.is_some() {
             // Invalid bundle — never entered the pipeline, just clean up
             self.store.tombstone_metadata(&bundle.bundle.id).await;
+            metrics::counter!("bpa.bundle.received.dropped").increment(1);
         } else {
             // Spawn into processing pool for rate limiting
             self.ingest_bundle(bundle, data).await;
@@ -203,8 +204,11 @@ impl Dispatcher {
     /// Because this returns before the Ingress filter completes, bundles remain
     /// in `New` status until `ingest_bundle_inner()` checkpoints to `Dispatching`.
     pub(super) async fn ingest_bundle(self: &Arc<Self>, bundle: bundle::Bundle, data: Bytes) {
+        metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
+
         metrics::gauge!("bpa.processing_pool.active")
             .set(self.processing_pool.active_tasks() as f64);
+
         let dispatcher = self.clone();
         hardy_async::spawn!(self.processing_pool, "ingest_bundle", async move {
             dispatcher.ingest_bundle_inner(bundle, data).await
@@ -279,7 +283,9 @@ impl Dispatcher {
                     bundle.metadata.storage_name = Some(new_storage_name);
                 }
                 // Always checkpoint to Dispatching (crash safety)
+                metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).decrement(1.0);
                 bundle.metadata.status = bundle::BundleStatus::Dispatching;
+                metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
                 self.store.update_metadata(&bundle).await;
                 (bundle, data)
             }

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -25,12 +25,17 @@ impl Dispatcher {
     ) -> cla::Result<()> {
         // TODO: Really should not return errors when the bundle content is garbage - it's not the CLAs responsibility to fix it!
 
+        // Count every bundle received from a CLA, before any validation
+        metrics::counter!("bpa.bundle.received").increment(1);
+        metrics::counter!("bpa.bundle.received.bytes").increment(data.len() as u64);
+
         // Capture received_at as soon as possible
         let received_at = time::OffsetDateTime::now_utc();
 
         // Do a fast pre-check
         match data.first() {
             None => {
+                metrics::counter!("bpa.bundle.received.dropped").increment(1);
                 return Err(hardy_bpv7::Error::InvalidCBOR(
                     hardy_cbor::decode::Error::NeedMoreData(1),
                 )
@@ -38,6 +43,7 @@ impl Dispatcher {
             }
             Some(0x06) => {
                 debug!("Data looks like a BPv6 bundle");
+                metrics::counter!("bpa.bundle.received.dropped").increment(1);
                 return Err(hardy_bpv7::Error::InvalidCBOR(
                     hardy_cbor::decode::Error::IncorrectType(
                         "BPv7 bundle".to_string(),
@@ -53,6 +59,7 @@ impl Dispatcher {
                     data.len(),
                     &data[..data.len().min(32)]
                 );
+                metrics::counter!("bpa.bundle.received.dropped").increment(1);
                 return Err(hardy_bpv7::Error::InvalidCBOR(
                     hardy_cbor::decode::Error::IncorrectType(
                         "BPv7 bundle".to_string(),
@@ -65,11 +72,15 @@ impl Dispatcher {
 
         // Parse the bundle
         let (bundle, reason, report_unsupported) =
-            match hardy_bpv7::bundle::RewrittenBundle::parse(&data, self.key_provider())? {
-                hardy_bpv7::bundle::RewrittenBundle::Valid {
+            match hardy_bpv7::bundle::RewrittenBundle::parse(&data, self.key_provider()) {
+                Err(e) => {
+                    metrics::counter!("bpa.bundle.received.dropped").increment(1);
+                    return Err(e.into());
+                }
+                Ok(hardy_bpv7::bundle::RewrittenBundle::Valid {
                     bundle,
                     report_unsupported,
-                } => (
+                }) => (
                     bundle::Bundle {
                         metadata: bundle::BundleMetadata {
                             storage_name: Some(self.store.save_data(&data).await),
@@ -87,12 +98,12 @@ impl Dispatcher {
                     None,
                     report_unsupported,
                 ),
-                hardy_bpv7::bundle::RewrittenBundle::Rewritten {
+                Ok(hardy_bpv7::bundle::RewrittenBundle::Rewritten {
                     bundle,
                     new_data,
                     report_unsupported,
                     non_canonical: _,
-                } => {
+                }) => {
                     debug!("Received bundle has been rewritten");
 
                     data = Bytes::from(new_data);
@@ -117,11 +128,11 @@ impl Dispatcher {
                         report_unsupported,
                     )
                 }
-                hardy_bpv7::bundle::RewrittenBundle::Invalid {
+                Ok(hardy_bpv7::bundle::RewrittenBundle::Invalid {
                     bundle,
                     reason,
                     error,
-                } => {
+                }) => {
                     debug!("Invalid bundle received: {error}");
 
                     // Don't bother saving the bundle data, it's garbage
@@ -147,6 +158,7 @@ impl Dispatcher {
 
         if !self.store.insert_metadata(&bundle).await {
             // Bundle with matching id already exists in the metadata store
+            metrics::counter!("bpa.bundle.received.duplicate").increment(1);
 
             // TODO: There may be custody transfer signalling that needs to happen here
 
@@ -170,6 +182,7 @@ impl Dispatcher {
 
         if reason.is_some() {
             // Not valid, drop it
+            metrics::counter!("bpa.bundle.received.dropped").increment(1);
             self.drop_bundle(bundle, reason).await;
         } else {
             // Spawn into processing pool for rate limiting

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -268,9 +268,6 @@ impl Dispatcher {
             .trace_expect("Ingress filter execution failed")
         {
             filters::registry::ExecResult::Continue(mutation, mut bundle, data) => {
-                if mutation.bundle || mutation.metadata {
-                    metrics::counter!("bpa.filter.modified", "hook" => "ingress").increment(1);
-                }
                 // Persist any bundle data mutations
                 if mutation.bundle {
                     let new_storage_name = self.store.save_data(&data).await;
@@ -285,7 +282,6 @@ impl Dispatcher {
                 (bundle, data)
             }
             filters::registry::ExecResult::Drop(bundle, reason) => {
-                metrics::counter!("bpa.filter.filtered", "hook" => "ingress").increment(1);
                 return self.drop_bundle(bundle, reason).await;
             }
         };

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -297,6 +297,17 @@ impl Dispatcher {
         self.process_bundle(bundle, data).await;
     }
 
+    /// Queue a bundle for dispatch processing
+    pub(super) async fn dispatch_bundle(&self, mut bundle: bundle::Bundle) {
+        self.store
+            .update_status(&mut bundle, &bundle::BundleStatus::Dispatching)
+            .await;
+
+        if self.dispatch_tx.send(bundle).await.is_err() {
+            debug!("Dispatch queue closed, bundle dropped");
+        }
+    }
+
     /// Consumer task for the dispatch queue
     pub(super) async fn run_dispatch_queue(
         self: Arc<Self>,

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -172,7 +172,9 @@ impl Dispatcher {
         // Report we have received the bundle
         self.report_bundle_reception(
             &bundle,
-            if report_unsupported {
+            if let Some(reason) = &reason {
+                *reason
+            } else if report_unsupported {
                 ReasonCode::BlockUnsupported
             } else {
                 ReasonCode::NoAdditionalInformation
@@ -181,8 +183,8 @@ impl Dispatcher {
         .await;
 
         if reason.is_some() {
-            // Not valid, drop it
-            self.drop_bundle(bundle, reason).await;
+            // Invalid bundle — never entered the pipeline, just clean up
+            self.store.tombstone_metadata(&bundle.bundle.id).await;
         } else {
             // Spawn into processing pool for rate limiting
             self.ingest_bundle(bundle, data).await;

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -291,17 +291,6 @@ impl Dispatcher {
         self.process_bundle(bundle, data).await;
     }
 
-    /// Queue a bundle for dispatch processing
-    pub(super) async fn dispatch_bundle(&self, mut bundle: bundle::Bundle) {
-        self.store
-            .update_status(&mut bundle, &bundle::BundleStatus::Dispatching)
-            .await;
-
-        if self.dispatch_tx.send(bundle).await.is_err() {
-            debug!("Dispatch queue closed, bundle dropped");
-        }
-    }
-
     /// Consumer task for the dispatch queue
     pub(super) async fn run_dispatch_queue(
         self: Arc<Self>,

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -182,7 +182,6 @@ impl Dispatcher {
 
         if reason.is_some() {
             // Not valid, drop it
-            metrics::counter!("bpa.bundle.received.dropped").increment(1);
             self.drop_bundle(bundle, reason).await;
         } else {
             // Spawn into processing pool for rate limiting
@@ -326,7 +325,9 @@ impl Dispatcher {
                     dispatcher.process_bundle(bundle, data).await;
                 } else {
                     // Bundle data was deleted while queued
-                    dispatcher.drop_bundle(bundle, None).await;
+                    dispatcher
+                        .drop_bundle(bundle, Some(ReasonCode::DepletedStorage))
+                        .await;
                 }
             })
             .await;
@@ -419,7 +420,7 @@ impl Dispatcher {
                                     dispatcher.process_bundle(bundle, data).await
                                 } else {
                                     // Bundle data was deleted sometime while we waited, drop the bundle
-                                    dispatcher.drop_bundle(bundle, None).await
+                                    dispatcher.drop_bundle(bundle, Some(ReasonCode::DepletedStorage)).await
                                 }
                             }).await;
                         }

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -252,9 +252,13 @@ impl Dispatcher {
                 &self.processing_pool,
             )
             .await
+            // TODO: Replace trace_expect with proper error handling and bpa.filter.error metric
             .trace_expect("Ingress filter execution failed")
         {
             filters::registry::ExecResult::Continue(mutation, mut bundle, data) => {
+                if mutation.bundle || mutation.metadata {
+                    metrics::counter!("bpa.filter.modified", "hook" => "ingress").increment(1);
+                }
                 // Persist any bundle data mutations
                 if mutation.bundle {
                     let new_storage_name = self.store.save_data(&data).await;
@@ -269,6 +273,7 @@ impl Dispatcher {
                 (bundle, data)
             }
             filters::registry::ExecResult::Drop(bundle, reason) => {
+                metrics::counter!("bpa.filter.filtered", "hook" => "ingress").increment(1);
                 return self.drop_bundle(bundle, reason).await;
             }
         };

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -189,6 +189,8 @@ impl Dispatcher {
     /// Because this returns before the Ingress filter completes, bundles remain
     /// in `New` status until `ingest_bundle_inner()` checkpoints to `Dispatching`.
     pub(super) async fn ingest_bundle(self: &Arc<Self>, bundle: bundle::Bundle, data: Bytes) {
+        metrics::gauge!("bpa.processing_pool.active")
+            .set(self.processing_pool.active_tasks() as f64);
         let dispatcher = self.clone();
         hardy_async::spawn!(self.processing_pool, "ingest_bundle", async move {
             dispatcher.ingest_bundle_inner(bundle, data).await
@@ -298,6 +300,8 @@ impl Dispatcher {
                 continue;
             }
 
+            metrics::gauge!("bpa.processing_pool.active")
+                .set(self.processing_pool.active_tasks() as f64);
             let dispatcher = self.clone();
             hardy_async::spawn!(self.processing_pool, "process_bundle", async move {
                 if let Some(data) = dispatcher.load_data(&bundle).await {
@@ -389,6 +393,8 @@ impl Dispatcher {
                                 continue;
                             }
 
+                            metrics::gauge!("bpa.processing_pool.active")
+                                .set(self.processing_pool.active_tasks() as f64);
                             let dispatcher = dispatcher.clone();
                             hardy_async::spawn!(self.processing_pool, "poll_waiting_dispatcher", async move {
                                 if let Some(data) = dispatcher.load_data(&bundle).await {

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -42,7 +42,7 @@ impl Dispatcher {
                 &self.processing_pool,
             )
             .await
-            // TODO: Replace trace_expect with proper error handling and bpa.filter.error metric
+            // TODO: Replace trace_expect with proper error handling
             .trace_expect("Egress filter execution failed")
         {
             filters::registry::ExecResult::Continue(_mutation, bundle, data) => (bundle, data),

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -45,14 +45,8 @@ impl Dispatcher {
             // TODO: Replace trace_expect with proper error handling and bpa.filter.error metric
             .trace_expect("Egress filter execution failed")
         {
-            filters::registry::ExecResult::Continue(mutation, bundle, data) => {
-                if mutation.bundle || mutation.metadata {
-                    metrics::counter!("bpa.filter.modified", "hook" => "egress").increment(1);
-                }
-                (bundle, data)
-            }
+            filters::registry::ExecResult::Continue(_mutation, bundle, data) => (bundle, data),
             filters::registry::ExecResult::Drop(bundle, reason) => {
-                metrics::counter!("bpa.filter.filtered", "hook" => "egress").increment(1);
                 return self.drop_bundle(bundle, reason).await;
             }
         };

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -72,7 +72,7 @@ impl Dispatcher {
                 );
             }
             Err(e) => {
-                metrics::counter!("bpa.bundle.forwarded.failed").increment(1);
+                metrics::counter!("bpa.bundle.forwarding.failed").increment(1);
                 debug!("Failed to forward bundle to peer {peer}: {e}, clearing queue assignment");
             }
         }

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -42,10 +42,17 @@ impl Dispatcher {
                 &self.processing_pool,
             )
             .await
+            // TODO: Replace trace_expect with proper error handling and bpa.filter.error metric
             .trace_expect("Egress filter execution failed")
         {
-            filters::registry::ExecResult::Continue(_mutation, bundle, data) => (bundle, data),
+            filters::registry::ExecResult::Continue(mutation, bundle, data) => {
+                if mutation.bundle || mutation.metadata {
+                    metrics::counter!("bpa.filter.modified", "hook" => "egress").increment(1);
+                }
+                (bundle, data)
+            }
             filters::registry::ExecResult::Drop(bundle, reason) => {
+                metrics::counter!("bpa.filter.filtered", "hook" => "egress").increment(1);
                 return self.drop_bundle(bundle, reason).await;
             }
         };

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -62,8 +62,11 @@ impl Dispatcher {
             Ok(cla::ForwardBundleResult::Sent) => {
                 metrics::counter!("bpa.bundle.forwarded").increment(1);
                 self.report_bundle_forwarded(&bundle).await;
-                self.drop_bundle(bundle, None).await;
-                return;
+
+                // Don't use drop_bundle() as we do not want to count the Drop as a 'dropped bundle'
+                self.report_bundle_deletion(&bundle, ReasonCode::NoAdditionalInformation)
+                    .await;
+                return self.delete_bundle(bundle).await;
             }
             Ok(cla::ForwardBundleResult::NoNeighbour) => {
                 // The neighbour has gone, kill the queue

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -60,6 +60,7 @@ impl Dispatcher {
         // And pass to CLA
         match cla.forward(queue, cla_addr, data).await {
             Ok(cla::ForwardBundleResult::Sent) => {
+                metrics::counter!("bpa.bundle.forwarded").increment(1);
                 self.report_bundle_forwarded(&bundle).await;
                 self.drop_bundle(bundle, None).await;
                 return;
@@ -71,6 +72,7 @@ impl Dispatcher {
                 );
             }
             Err(e) => {
+                metrics::counter!("bpa.bundle.forwarded.failed").increment(1);
                 debug!("Failed to forward bundle to peer {peer}: {e}, clearing queue assignment");
             }
         }

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -13,7 +13,9 @@ impl Dispatcher {
         // Get bundle data from store, now we know we need it!
         let Some(data) = self.load_data(&bundle).await else {
             // Bundle data was deleted sometime during processing
-            return;
+            return self
+                .drop_bundle(bundle, Some(ReasonCode::DepletedStorage))
+                .await;
         };
 
         // Increment Hop Count, etc...

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -248,6 +248,7 @@ impl Dispatcher {
             }
         }
 
+        metrics::counter!("bpa.bundle.delivered").increment(1);
         self.report_bundle_delivery(&bundle).await;
         self.drop_bundle(bundle, None).await
     }

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -178,7 +178,7 @@ impl Dispatcher {
                 &self.processing_pool,
             )
             .await
-            // TODO: Replace trace_expect with proper error handling and bpa.filter.error metric
+            // TODO: Replace trace_expect with proper error handling
             .trace_expect("Deliver filter execution failed")
         {
             filters::registry::ExecResult::Continue(_mutation, bundle, data) => (bundle, data),

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -24,19 +24,12 @@ impl Dispatcher {
             )
             .await
             .inspect_err(|_e| {
-                metrics::counter!("bpa.filter.error", "hook" => "originate").increment(1);
                 error!("Originate filter execution failed");
             })? {
-            filters::registry::ExecResult::Continue(mutation, bundle, data) => {
-                if mutation.bundle || mutation.metadata {
-                    metrics::counter!("bpa.filter.modified", "hook" => "originate").increment(1);
-                }
+            filters::registry::ExecResult::Continue(_mutation, bundle, data) => {
                 Ok(Some((bundle, data)))
             }
-            filters::registry::ExecResult::Drop(_bundle, _reason) => {
-                metrics::counter!("bpa.filter.filtered", "hook" => "originate").increment(1);
-                Ok(None)
-            }
+            filters::registry::ExecResult::Drop(_bundle, _reason) => Ok(None),
         }
     }
 
@@ -188,14 +181,8 @@ impl Dispatcher {
             // TODO: Replace trace_expect with proper error handling and bpa.filter.error metric
             .trace_expect("Deliver filter execution failed")
         {
-            filters::registry::ExecResult::Continue(mutation, bundle, data) => {
-                if mutation.bundle || mutation.metadata {
-                    metrics::counter!("bpa.filter.modified", "hook" => "deliver").increment(1);
-                }
-                (bundle, data)
-            }
+            filters::registry::ExecResult::Continue(_mutation, bundle, data) => (bundle, data),
             filters::registry::ExecResult::Drop(bundle, reason) => {
-                metrics::counter!("bpa.filter.filtered", "hook" => "deliver").increment(1);
                 return self.drop_bundle(bundle, reason).await;
             }
         };

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -23,12 +23,20 @@ impl Dispatcher {
                 &self.processing_pool,
             )
             .await
-            .inspect_err(|_e| error!("Originate filter execution failed"))?
-        {
-            filters::registry::ExecResult::Continue(_mutation, bundle, data) => {
+            .inspect_err(|_e| {
+                metrics::counter!("bpa.filter.error", "hook" => "originate").increment(1);
+                error!("Originate filter execution failed");
+            })? {
+            filters::registry::ExecResult::Continue(mutation, bundle, data) => {
+                if mutation.bundle || mutation.metadata {
+                    metrics::counter!("bpa.filter.modified", "hook" => "originate").increment(1);
+                }
                 Ok(Some((bundle, data)))
             }
-            filters::registry::ExecResult::Drop(_bundle, _reason) => Ok(None),
+            filters::registry::ExecResult::Drop(_bundle, _reason) => {
+                metrics::counter!("bpa.filter.filtered", "hook" => "originate").increment(1);
+                Ok(None)
+            }
         }
     }
 
@@ -174,10 +182,17 @@ impl Dispatcher {
                 &self.processing_pool,
             )
             .await
+            // TODO: Replace trace_expect with proper error handling and bpa.filter.error metric
             .trace_expect("Deliver filter execution failed")
         {
-            filters::registry::ExecResult::Continue(_mutation, bundle, data) => (bundle, data),
+            filters::registry::ExecResult::Continue(mutation, bundle, data) => {
+                if mutation.bundle || mutation.metadata {
+                    metrics::counter!("bpa.filter.modified", "hook" => "deliver").increment(1);
+                }
+                (bundle, data)
+            }
             filters::registry::ExecResult::Drop(bundle, reason) => {
+                metrics::counter!("bpa.filter.filtered", "hook" => "deliver").increment(1);
                 return self.drop_bundle(bundle, reason).await;
             }
         };

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -250,6 +250,10 @@ impl Dispatcher {
 
         metrics::counter!("bpa.bundle.delivered").increment(1);
         self.report_bundle_delivery(&bundle).await;
-        self.drop_bundle(bundle, None).await
+
+        // Don't use drop_bundle() as we do not want to count the Drop as a 'dropped bundle'
+        self.report_bundle_deletion(&bundle, ReasonCode::NoAdditionalInformation)
+            .await;
+        self.delete_bundle(bundle).await
     }
 }

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -146,6 +146,9 @@ impl Dispatcher {
         metrics::counter!("bpa.bundle.originated").increment(1);
         metrics::counter!("bpa.bundle.originated.bytes").increment(data.len() as u64);
 
+        // TODO: Originated bundles should skip ingress filter and call dispatch_bundle()
+        // directly. This requires storing with Dispatching status (not New) so that
+        // restart recovery doesn't re-run the ingress filter on originated bundles.
         let bundle_id = bundle.bundle.id.clone();
         self.ingest_bundle(bundle, data).await;
         Ok(bundle_id)

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -150,6 +150,9 @@ impl Dispatcher {
             return Err(services::Error::DuplicateBundle);
         }
 
+        metrics::counter!("bpa.bundle.originated").increment(1);
+        metrics::counter!("bpa.bundle.originated.bytes").increment(data.len() as u64);
+
         let bundle_id = bundle.bundle.id.clone();
         self.ingest_bundle(bundle, data).await;
         Ok(bundle_id)

--- a/bpa/src/dispatcher/mod.rs
+++ b/bpa/src/dispatcher/mod.rs
@@ -138,7 +138,9 @@ impl Dispatcher {
         if let Some(storage_name) = &bundle.metadata.storage_name {
             self.store.delete_data(storage_name).await;
         }
-        self.store.tombstone_metadata(&bundle.bundle.id).await
+        self.store.tombstone_metadata(&bundle.bundle.id).await;
+
+        metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).decrement(1.0);
     }
 
     pub async fn poll_service_waiting(self: &Arc<Self>, source: &Eid) {

--- a/bpa/src/dispatcher/mod.rs
+++ b/bpa/src/dispatcher/mod.rs
@@ -125,6 +125,7 @@ impl Dispatcher {
     #[cfg_attr(feature = "instrument", instrument(skip(self, bundle)))]
     pub async fn drop_bundle(&self, bundle: bundle::Bundle, reason: Option<ReasonCode>) {
         if let Some(reason) = reason {
+            metrics::counter!("bpa.bundle.dropped", "reason" => crate::otel_metrics::reason_label(&reason)).increment(1);
             self.report_bundle_deletion(&bundle, reason).await;
         }
 
@@ -132,7 +133,7 @@ impl Dispatcher {
     }
 
     #[cfg_attr(feature = "instrument", instrument(skip(self, bundle)))]
-    pub async fn delete_bundle(&self, bundle: bundle::Bundle) {
+    async fn delete_bundle(&self, bundle: bundle::Bundle) {
         // Delete the bundle from the bundle store
         if let Some(storage_name) = &bundle.metadata.storage_name {
             self.store.delete_data(storage_name).await;
@@ -152,7 +153,9 @@ impl Dispatcher {
                 if let Some(data) = dispatcher.load_data(&bundle).await {
                     dispatcher.ingest_bundle(bundle, data).await;
                 } else {
-                    dispatcher.drop_bundle(bundle, None).await;
+                    dispatcher
+                        .drop_bundle(bundle, Some(ReasonCode::DepletedStorage))
+                        .await;
                 }
             }
         });

--- a/bpa/src/dispatcher/mod.rs
+++ b/bpa/src/dispatcher/mod.rs
@@ -150,15 +150,7 @@ impl Dispatcher {
 
         join!(self.store.poll_service_waiting(source.clone(), tx), async {
             while let Ok(bundle) = rx.recv_async().await {
-                let dispatcher = dispatcher.clone();
-
-                if let Some(data) = dispatcher.load_data(&bundle).await {
-                    dispatcher.ingest_bundle(bundle, data).await;
-                } else {
-                    dispatcher
-                        .drop_bundle(bundle, Some(ReasonCode::DepletedStorage))
-                        .await;
-                }
+                dispatcher.dispatch_bundle(bundle).await;
             }
         });
     }

--- a/bpa/src/dispatcher/reassemble.rs
+++ b/bpa/src/dispatcher/reassemble.rs
@@ -45,6 +45,8 @@ impl Dispatcher {
         let bundle = Bundle { metadata, bundle };
         self.store.insert_metadata(&bundle).await;
 
+        metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
+
         // Box::pin breaks the type recursion; call inner directly (already in pool)
         Box::pin(self.ingest_bundle_inner(bundle, data)).await;
     }

--- a/bpa/src/dispatcher/reassemble.rs
+++ b/bpa/src/dispatcher/reassemble.rs
@@ -24,9 +24,11 @@ impl Dispatcher {
         };
 
         let metadata = BundleMetadata {
-            storage_name: Some(storage_name),
+            storage_name: Some(storage_name.clone()),
             ..Default::default()
         };
+
+        // TODO:  This check isn't enough, and really we need to feed the bundle back into the bottom half of Dispatcher::receive_bundle
 
         let parsed = ParsedBundle::parse(&data, self.key_provider());
         let Ok(ParsedBundle { bundle, .. }) = parsed else {
@@ -36,14 +38,19 @@ impl Dispatcher {
             // TODO: Report this as a reception failure for all the fragments
             // TODO: Wrap damaged bundle in "Junk Bundle Payload" for lost+found
 
-            if let Some(storage_name) = metadata.storage_name {
-                self.store.delete_data(&storage_name).await;
-            }
-            return;
+            return self.store.delete_data(&storage_name).await;
         };
 
+        metrics::counter!("bpa.bundle.reassembled").increment(1);
+
         let bundle = Bundle { metadata, bundle };
-        self.store.insert_metadata(&bundle).await;
+        if !self.store.insert_metadata(&bundle).await {
+            // Bundle with matching id already exists in the metadata store
+            metrics::counter!("bpa.bundle.received.duplicate").increment(1);
+
+            // Drop the stored data and do not process further
+            return self.store.delete_data(&storage_name).await;
+        }
 
         metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
 

--- a/bpa/src/dispatcher/reassemble.rs
+++ b/bpa/src/dispatcher/reassemble.rs
@@ -30,6 +30,7 @@ impl Dispatcher {
 
         let parsed = ParsedBundle::parse(&data, self.key_provider());
         let Ok(ParsedBundle { bundle, .. }) = parsed else {
+            metrics::counter!("bpa.bundle.reassembly.failed").increment(1);
             debug!("Reassembled bundle is invalid: {}", parsed.unwrap_err());
 
             // TODO: Report this as a reception failure for all the fragments

--- a/bpa/src/dispatcher/report.rs
+++ b/bpa/src/dispatcher/report.rs
@@ -15,6 +15,7 @@ impl Dispatcher {
         // Check if a report is requested
         if bundle.bundle.flags.receipt_report_requested {
             debug!("Reporting bundle reception to {}", &bundle.bundle.report_to);
+            metrics::counter!("bpa.status_report.sent", "type" => "reception").increment(1);
 
             self.dispatch_status_report(
                 hardy_cbor::encode::emit(&AdministrativeRecord::BundleStatusReport(
@@ -48,6 +49,7 @@ impl Dispatcher {
                 "Reporting bundle as forwarded to {}",
                 &bundle.bundle.report_to
             );
+            metrics::counter!("bpa.status_report.sent", "type" => "forwarding").increment(1);
 
             self.dispatch_status_report(
                 hardy_cbor::encode::emit(&AdministrativeRecord::BundleStatusReport(
@@ -77,6 +79,7 @@ impl Dispatcher {
         // Check if a report is requested
         if bundle.bundle.flags.delivery_report_requested {
             debug!("Reporting bundle delivery to {}", &bundle.bundle.report_to);
+            metrics::counter!("bpa.status_report.sent", "type" => "delivery").increment(1);
 
             // Create a bundle report
             self.dispatch_status_report(
@@ -105,6 +108,7 @@ impl Dispatcher {
         // Check if a report is requested
         if bundle.bundle.flags.delete_report_requested {
             debug!("Reporting bundle deletion to {}", &bundle.bundle.report_to);
+            metrics::counter!("bpa.status_report.sent", "type" => "deletion").increment(1);
 
             // Create a bundle report
             self.dispatch_status_report(

--- a/bpa/src/dispatcher/report.rs
+++ b/bpa/src/dispatcher/report.rs
@@ -167,6 +167,8 @@ impl Dispatcher {
                 return;
             }
 
+            metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
+
             // Just fire the report off now - it ensures sequential reporting (ish)
             Box::pin(self.ingest_bundle_inner(bundle, data)).await
         }

--- a/bpa/src/dispatcher/restart.rs
+++ b/bpa/src/dispatcher/restart.rs
@@ -101,6 +101,9 @@ impl Dispatcher {
             }) => {
                 warn!("Bundle in non-canonical format found: {storage_name}");
 
+                // Remove the previous from bundle_storage
+                self.store.delete_data(&storage_name).await;
+
                 // Check if the metadata_storage knows about this bundle
                 let exists = if let Some(metadata) = self.store.confirm_exists(&bundle.id).await {
                     if metadata.storage_name.as_ref() != Some(&storage_name) {
@@ -115,8 +118,6 @@ impl Dispatcher {
                             );
                         }
 
-                        // Remove spurious duplicate
-                        self.store.delete_data(&storage_name).await;
                         metrics::counter!("bpa.restart.duplicate").increment(1);
                         return;
                     }
@@ -128,9 +129,6 @@ impl Dispatcher {
                 // Write the rewritten bundle now for safety
                 let data = Bytes::from(new_data);
                 let new_storage_name = self.store.save_data(&data).await;
-
-                // Remove the previous from bundle_storage
-                self.store.delete_data(&storage_name).await;
 
                 let bundle = bundle::Bundle {
                     metadata: bundle::BundleMetadata {
@@ -178,8 +176,12 @@ impl Dispatcher {
             }) => {
                 warn!("Invalid bundle found: {storage_name}, {error}");
 
+                // Remove it from bundle_storage, it shouldn't be there
+                self.store.delete_data(&storage_name).await;
+                metrics::counter!("bpa.restart.junk").increment(1);
+
                 // Check if the metadata_storage knows about this bundle
-                let exists = if let Some(metadata) = self.store.confirm_exists(&bundle.id).await {
+                if let Some(metadata) = self.store.confirm_exists(&bundle.id).await {
                     if metadata.storage_name.as_ref() != Some(&storage_name) {
                         if metadata.storage_name.is_none() {
                             warn!("Invalid copy of processed bundle data found: {storage_name}");
@@ -189,39 +191,24 @@ impl Dispatcher {
                                 metadata.storage_name.as_ref()
                             );
                         }
+                    } else {
+                        // Previously accepted bundle — send deletion report and tombstone
+                        let bundle = bundle::Bundle {
+                            metadata: bundle::BundleMetadata {
+                                read_only: bundle::ReadOnlyMetadata {
+                                    received_at: file_time,
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            },
+                            bundle,
+                        };
 
-                        // Remove spurious duplicate
-                        self.store.delete_data(&storage_name).await;
-                        metrics::counter!("bpa.restart.duplicate").increment(1);
-                        return;
+                        metrics::counter!("bpa.bundle.dropped", "reason" => crate::otel_metrics::reason_label(&reason)).increment(1);
+                        self.report_bundle_deletion(&bundle, reason).await;
+                        self.store.tombstone_metadata(&bundle.bundle.id).await;
                     }
-                    true
-                } else {
-                    false
-                };
-
-                // Remove it from bundle_storage, it shouldn't be there
-                self.store.delete_data(&storage_name).await;
-
-                if !exists {
-                    // Never knew about this bundle — nothing to report or clean up
-                    return;
                 }
-
-                // Previously accepted bundle — send deletion report and tombstone
-                let bundle = bundle::Bundle {
-                    metadata: bundle::BundleMetadata {
-                        read_only: bundle::ReadOnlyMetadata {
-                            received_at: file_time,
-                            ..Default::default()
-                        },
-                        ..Default::default()
-                    },
-                    bundle,
-                };
-
-                self.report_bundle_deletion(&bundle, reason).await;
-                self.store.tombstone_metadata(&bundle.bundle.id).await;
             }
             Err(e) => {
                 // Parse failed badly, no idea who to report to

--- a/bpa/src/dispatcher/restart.rs
+++ b/bpa/src/dispatcher/restart.rs
@@ -45,19 +45,24 @@ impl Dispatcher {
                             bundle::BundleStatus::Dispatching => {
                                 // Ingress filter done - enqueue for routing
                                 let bundle = bundle::Bundle { metadata, bundle };
-                                if self.dispatch_tx.send(bundle).await.is_err() {
-                                    debug!("Dispatch queue closed, bundle dropped");
-                                }
+                                metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
+                                self.dispatch_bundle(bundle).await;
                             }
-                            bundle::BundleStatus::WaitingForService { service: _ } => {
-                                let bundle = bundle::Bundle { metadata, bundle };
-                                self.ingest_bundle(bundle, data).await;
+                            bundle::BundleStatus::ForwardPending { .. } => {
+                                // Peer ID is stale after restart — reset to Waiting
+                                let mut bundle = bundle::Bundle { metadata, bundle };
+                                metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
+                                self.store
+                                    .update_status(&mut bundle, &bundle::BundleStatus::Waiting)
+                                    .await;
                             }
                             // Other statuses are handled by their respective recovery mechanisms:
-                            // - ForwardPending: CLA peer queue recovery
                             // - Waiting: poll_waiting recovery
+                            // - WaitingForService: poll_service_waiting on service re-registration
                             // - AduFragment: fragment reassembly polling
-                            _ => {}
+                            _ => {
+                                metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&metadata.status)).increment(1.0);
+                            }
                         }
                     }
                 } else {

--- a/bpa/src/dispatcher/restart.rs
+++ b/bpa/src/dispatcher/restart.rs
@@ -45,7 +45,9 @@ impl Dispatcher {
                             bundle::BundleStatus::Dispatching => {
                                 // Ingress filter done - enqueue for routing
                                 let bundle = bundle::Bundle { metadata, bundle };
-                                self.dispatch_bundle(bundle).await;
+                                if self.dispatch_tx.send(bundle).await.is_err() {
+                                    debug!("Dispatch queue closed, bundle dropped");
+                                }
                             }
                             bundle::BundleStatus::WaitingForService { service: _ } => {
                                 let bundle = bundle::Bundle { metadata, bundle };

--- a/bpa/src/dispatcher/restart.rs
+++ b/bpa/src/dispatcher/restart.rs
@@ -203,8 +203,12 @@ impl Dispatcher {
                 // Remove it from bundle_storage, it shouldn't be there
                 self.store.delete_data(&storage_name).await;
 
-                // Whatever we have in the store isn't correct
+                if !exists {
+                    // Never knew about this bundle — nothing to report or clean up
+                    return;
+                }
 
+                // Previously accepted bundle — send deletion report and tombstone
                 let bundle = bundle::Bundle {
                     metadata: bundle::BundleMetadata {
                         read_only: bundle::ReadOnlyMetadata {
@@ -216,26 +220,8 @@ impl Dispatcher {
                     bundle,
                 };
 
-                if !exists {
-                    // Save the metadata
-                    self.store.insert_metadata(&bundle).await;
-
-                    // Report we have received the bundle
-                    self.report_bundle_reception(
-                        &bundle,
-                        hardy_bpv7::status_report::ReasonCode::NoAdditionalInformation,
-                    )
-                    .await;
-                } else {
-                    // Replace the metadata
-                    self.store.update_metadata(&bundle).await;
-                }
-
-                // Drop the 'new' bundle
-                self.drop_bundle(bundle, Some(reason)).await;
-
-                // Report the bundle as an orphan
-                metrics::counter!("bpa.restart.orphan").increment(1);
+                self.report_bundle_deletion(&bundle, reason).await;
+                self.store.tombstone_metadata(&bundle.bundle.id).await;
             }
             Err(e) => {
                 // Parse failed badly, no idea who to report to

--- a/bpa/src/dispatcher/restart.rs
+++ b/bpa/src/dispatcher/restart.rs
@@ -1,5 +1,4 @@
 use super::*;
-use storage::recover::RestartResult;
 
 impl Dispatcher {
     #[cfg_attr(feature = "instrument", instrument(skip(self)))]
@@ -7,10 +6,11 @@ impl Dispatcher {
         self: &Arc<Self>,
         storage_name: Arc<str>,
         file_time: time::OffsetDateTime,
-    ) -> RestartResult {
+    ) {
         let Some(data) = self.store.load_data(&storage_name).await else {
             // Data has gone while we were restarting
-            return RestartResult::Missing;
+            metrics::counter!("bpa.restart.lost").increment(1);
+            return;
         };
 
         // Parse the bundle (again, just in case we have changed policies etc)
@@ -33,7 +33,7 @@ impl Dispatcher {
 
                         // Remove spurious duplicate
                         self.store.delete_data(&storage_name).await;
-                        RestartResult::Duplicate
+                        metrics::counter!("bpa.restart.duplicate").increment(1);
                     } else {
                         // Resume processing based on checkpoint status
                         match &metadata.status {
@@ -41,24 +41,21 @@ impl Dispatcher {
                                 // Ingress filter not yet complete - run full ingestion
                                 let bundle = bundle::Bundle { metadata, bundle };
                                 self.ingest_bundle(bundle, data).await;
-                                RestartResult::Valid
                             }
                             bundle::BundleStatus::Dispatching => {
                                 // Ingress filter done - enqueue for routing
                                 let bundle = bundle::Bundle { metadata, bundle };
                                 self.dispatch_bundle(bundle).await;
-                                RestartResult::Valid
                             }
                             bundle::BundleStatus::WaitingForService { service: _ } => {
                                 let bundle = bundle::Bundle { metadata, bundle };
                                 self.ingest_bundle(bundle, data).await;
-                                RestartResult::Valid
                             }
                             // Other statuses are handled by their respective recovery mechanisms:
                             // - ForwardPending: CLA peer queue recovery
                             // - Waiting: poll_waiting recovery
                             // - AduFragment: fragment reassembly polling
-                            _ => RestartResult::Valid,
+                            _ => {}
                         }
                     }
                 } else {
@@ -93,7 +90,7 @@ impl Dispatcher {
                     self.ingest_bundle(bundle, data).await;
 
                     // Report the bundle as an orphan
-                    RestartResult::Orphan
+                    metrics::counter!("bpa.restart.orphan").increment(1);
                 }
             }
             Ok(hardy_bpv7::bundle::RewrittenBundle::Rewritten {
@@ -120,7 +117,8 @@ impl Dispatcher {
 
                         // Remove spurious duplicate
                         self.store.delete_data(&storage_name).await;
-                        return RestartResult::Duplicate;
+                        metrics::counter!("bpa.restart.duplicate").increment(1);
+                        return;
                     }
                     true
                 } else {
@@ -171,7 +169,7 @@ impl Dispatcher {
                 self.ingest_bundle(bundle, data).await;
 
                 // Report the bundle as an orphan
-                RestartResult::Orphan
+                metrics::counter!("bpa.restart.orphan").increment(1);
             }
             Ok(hardy_bpv7::bundle::RewrittenBundle::Invalid {
                 bundle,
@@ -194,7 +192,8 @@ impl Dispatcher {
 
                         // Remove spurious duplicate
                         self.store.delete_data(&storage_name).await;
-                        return RestartResult::Duplicate;
+                        metrics::counter!("bpa.restart.duplicate").increment(1);
+                        return;
                     }
                     true
                 } else {
@@ -236,7 +235,7 @@ impl Dispatcher {
                 self.drop_bundle(bundle, Some(reason)).await;
 
                 // Report the bundle as an orphan
-                RestartResult::Orphan
+                metrics::counter!("bpa.restart.orphan").increment(1);
             }
             Err(e) => {
                 // Parse failed badly, no idea who to report to
@@ -246,7 +245,7 @@ impl Dispatcher {
 
                 // Drop the bundle
                 self.store.delete_data(&storage_name).await;
-                RestartResult::Junk
+                metrics::counter!("bpa.restart.junk").increment(1);
             }
         }
     }

--- a/bpa/src/filters/mod.rs
+++ b/bpa/src/filters/mod.rs
@@ -82,6 +82,17 @@ pub enum Hook {
     Egress,
 }
 
+impl Hook {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Hook::Ingress => "ingress",
+            Hook::Deliver => "deliver",
+            Hook::Originate => "originate",
+            Hook::Egress => "egress",
+        }
+    }
+}
+
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Hook {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/bpa/src/filters/registry.rs
+++ b/bpa/src/filters/registry.rs
@@ -56,25 +56,35 @@ impl Registry {
         let mut inner = self.inner.write();
 
         match hook {
-            Hook::Ingress => inner.ingress.add_filter(name, filter, after),
-            Hook::Deliver => inner.deliver.add_filter(name, filter, after),
-            Hook::Originate => inner.originate.add_filter(name, filter, after),
-            Hook::Egress => inner.egress.add_filter(name, filter, after),
+            Hook::Ingress => inner.ingress.add_filter(name, filter, after)?,
+            Hook::Deliver => inner.deliver.add_filter(name, filter, after)?,
+            Hook::Originate => inner.originate.add_filter(name, filter, after)?,
+            Hook::Egress => inner.egress.add_filter(name, filter, after)?,
         }
+
+        metrics::gauge!("bpa.filter.registered", "hook" => hook.label()).increment(1.0);
+        Ok(())
     }
 
     // Removes a filter by name from the specified hook.
     // Returns Ok(Some(filter)) if found and removed, Ok(None) if not found,
     // or Err(HasDependants) if other filters depend on it.
     pub fn unregister(&self, hook: Hook, name: &str) -> Result<Option<Filter>, Error> {
+        let hook_label = hook.label();
         let mut inner = self.inner.write();
 
-        match hook {
-            Hook::Ingress => inner.ingress.remove_filter(name),
-            Hook::Deliver => inner.deliver.remove_filter(name),
-            Hook::Originate => inner.originate.remove_filter(name),
-            Hook::Egress => inner.egress.remove_filter(name),
+        let result = match hook {
+            Hook::Ingress => inner.ingress.remove_filter(name)?,
+            Hook::Deliver => inner.deliver.remove_filter(name)?,
+            Hook::Originate => inner.originate.remove_filter(name)?,
+            Hook::Egress => inner.egress.remove_filter(name)?,
+        };
+
+        if result.is_some() {
+            metrics::gauge!("bpa.filter.registered", "hook" => hook_label).decrement(1.0);
         }
+
+        Ok(result)
     }
 
     // Executes the filter chain for the specified hook on the given bundle.
@@ -95,6 +105,8 @@ impl Registry {
             + Clone
             + Send,
     {
+        let hook_label = hook.label();
+
         let prepared = {
             let inner = self.inner.read();
             match hook {
@@ -104,6 +116,23 @@ impl Registry {
                 Hook::Egress => inner.egress.prepare(),
             }
         };
-        prepared.exec(pool, bundle, data, key_provider).await
+
+        let result = prepared.exec(pool, bundle, data, key_provider).await;
+
+        match &result {
+            Ok(ExecResult::Continue(mutation, _, _)) => {
+                if mutation.bundle || mutation.metadata {
+                    metrics::counter!("bpa.filter.modified", "hook" => hook_label).increment(1);
+                }
+            }
+            Ok(ExecResult::Drop(_, _)) => {
+                metrics::counter!("bpa.filter.filtered", "hook" => hook_label).increment(1);
+            }
+            Err(_) => {
+                metrics::counter!("bpa.filter.error", "hook" => hook_label).increment(1);
+            }
+        }
+
+        result
     }
 }

--- a/bpa/src/lib.rs
+++ b/bpa/src/lib.rs
@@ -37,6 +37,7 @@ See the [hardy-bpv7 documentation](https://docs.rs/hardy-bpv7) for detailed inst
 extern crate alloc;
 
 mod dispatcher;
+mod otel_metrics;
 mod rib;
 
 pub mod bpa;

--- a/bpa/src/otel_metrics.rs
+++ b/bpa/src/otel_metrics.rs
@@ -59,7 +59,7 @@ pub fn init() {
         "Bundles forwarded via CLA"
     );
     metrics::describe_counter!(
-        "bpa.bundle.forwarded.failed",
+        "bpa.bundle.forwarding.failed",
         metrics::Unit::Count,
         "Bundle forward attempts that failed (CLA error)"
     );

--- a/bpa/src/otel_metrics.rs
+++ b/bpa/src/otel_metrics.rs
@@ -1,0 +1,269 @@
+use hardy_bpv7::status_report::ReasonCode;
+
+/// Initialise all BPA metric descriptions.
+///
+/// Call once during `Bpa::start()`. Descriptions are registered with the global
+/// `metrics` recorder so that OTEL instruments are created with correct units
+/// and descriptions on first use.
+pub fn init() {
+    // -- A. Bundle Reception (CLA ingress) --
+    metrics::describe_counter!(
+        "bpa.bundle.received",
+        metrics::Unit::Count,
+        "Bundles received from CLAs"
+    );
+    metrics::describe_counter!(
+        "bpa.bundle.received.bytes",
+        metrics::Unit::Bytes,
+        "Total bytes of bundle data received from CLAs"
+    );
+    metrics::describe_counter!(
+        "bpa.bundle.received.dropped",
+        metrics::Unit::Count,
+        "Bundles dropped at reception (invalid CBOR, BPv6, parse failure)"
+    );
+    metrics::describe_counter!(
+        "bpa.bundle.received.duplicate",
+        metrics::Unit::Count,
+        "Bundles dropped as duplicates at reception"
+    );
+
+    // -- B. Bundle Origination (service/app ingress) --
+    metrics::describe_counter!(
+        "bpa.bundle.originated",
+        metrics::Unit::Count,
+        "Bundles originated by local services"
+    );
+    metrics::describe_counter!(
+        "bpa.bundle.originated.bytes",
+        metrics::Unit::Bytes,
+        "Total bytes of bundle data originated by local services"
+    );
+
+    // -- C. Bundle Status Gauges --
+    metrics::describe_gauge!(
+        "bpa.bundle.status",
+        metrics::Unit::Count,
+        "Live bundles by pipeline state"
+    );
+
+    // -- D. Bundle Lifecycle Events --
+    metrics::describe_counter!(
+        "bpa.bundle.delivered",
+        metrics::Unit::Count,
+        "Bundles delivered to local services"
+    );
+    metrics::describe_counter!(
+        "bpa.bundle.forwarded",
+        metrics::Unit::Count,
+        "Bundles forwarded via CLA"
+    );
+    metrics::describe_counter!(
+        "bpa.bundle.forwarded.failed",
+        metrics::Unit::Count,
+        "Bundle forward attempts that failed (CLA error)"
+    );
+    metrics::describe_counter!(
+        "bpa.bundle.deleted",
+        metrics::Unit::Count,
+        "Bundles deleted (by reason code)"
+    );
+    metrics::describe_counter!(
+        "bpa.bundle.reassembled",
+        metrics::Unit::Count,
+        "Fragments successfully reassembled into whole bundles"
+    );
+    metrics::describe_counter!(
+        "bpa.bundle.reassembly.failed",
+        metrics::Unit::Count,
+        "Reassembly failures (reconstituted bundle invalid)"
+    );
+    metrics::describe_counter!(
+        "bpa.bundle.expired",
+        metrics::Unit::Count,
+        "Bundles expired by the reaper"
+    );
+
+    // -- E. Filters --
+    metrics::describe_counter!(
+        "bpa.filter.filtered",
+        metrics::Unit::Count,
+        "Bundles dropped by filters (by hook)"
+    );
+    metrics::describe_counter!(
+        "bpa.filter.modified",
+        metrics::Unit::Count,
+        "Bundles modified by filters (by hook)"
+    );
+    metrics::describe_counter!(
+        "bpa.filter.error",
+        metrics::Unit::Count,
+        "Filter execution errors (by hook)"
+    );
+
+    // -- F. Administrative Records --
+    metrics::describe_counter!(
+        "bpa.admin_record.received",
+        metrics::Unit::Count,
+        "Administrative record bundles received"
+    );
+    metrics::describe_counter!(
+        "bpa.admin_record.unknown",
+        metrics::Unit::Count,
+        "Administrative records that could not be processed"
+    );
+    metrics::describe_counter!(
+        "bpa.status_report.sent",
+        metrics::Unit::Count,
+        "Status reports sent (by type)"
+    );
+    metrics::describe_counter!(
+        "bpa.status_report.received",
+        metrics::Unit::Count,
+        "Status reports received (by type)"
+    );
+
+    // -- G. Storage --
+    metrics::describe_counter!(
+        "bpa.store.cache.hits",
+        metrics::Unit::Count,
+        "Bundle data cache hits"
+    );
+    metrics::describe_counter!(
+        "bpa.store.cache.misses",
+        metrics::Unit::Count,
+        "Bundle data cache misses"
+    );
+    metrics::describe_counter!(
+        "bpa.store.cache.oversized",
+        metrics::Unit::Count,
+        "Bundles that bypassed the cache due to size"
+    );
+
+    // -- G. In-memory storage backends --
+    metrics::describe_gauge!(
+        "bpa.mem_store.bundles",
+        metrics::Unit::Count,
+        "Bundle data entries in memory storage"
+    );
+    metrics::describe_gauge!(
+        "bpa.mem_store.bytes",
+        metrics::Unit::Bytes,
+        "Bytes used by in-memory bundle storage"
+    );
+    metrics::describe_counter!(
+        "bpa.mem_store.evictions",
+        metrics::Unit::Count,
+        "LRU evictions from in-memory bundle storage"
+    );
+    metrics::describe_gauge!(
+        "bpa.mem_metadata.entries",
+        metrics::Unit::Count,
+        "Metadata entries in memory storage"
+    );
+    metrics::describe_gauge!(
+        "bpa.mem_metadata.tombstones",
+        metrics::Unit::Count,
+        "Tombstone entries in memory metadata storage"
+    );
+
+    // -- H. Registries --
+    metrics::describe_gauge!(
+        "bpa.cla.registered",
+        metrics::Unit::Count,
+        "Currently registered CLAs"
+    );
+    metrics::describe_gauge!(
+        "bpa.service.registered",
+        metrics::Unit::Count,
+        "Currently registered services"
+    );
+    metrics::describe_gauge!(
+        "bpa.filter.registered",
+        metrics::Unit::Count,
+        "Currently registered filters (by hook)"
+    );
+    metrics::describe_gauge!(
+        "bpa.rib.agents",
+        metrics::Unit::Count,
+        "Currently registered routing agents"
+    );
+    metrics::describe_gauge!(
+        "bpa.rib.entries",
+        metrics::Unit::Count,
+        "RIB entries from routing agents (by source)"
+    );
+    metrics::describe_gauge!(
+        "bpa.fib.entries",
+        metrics::Unit::Count,
+        "FIB entries from CLA peers (by CLA)"
+    );
+
+    // -- I. Restart/Recovery --
+    metrics::describe_counter!(
+        "bpa.restart.lost",
+        metrics::Unit::Count,
+        "Lost bundles discovered during restart"
+    );
+    metrics::describe_counter!(
+        "bpa.restart.duplicate",
+        metrics::Unit::Count,
+        "Duplicate bundles discovered during restart"
+    );
+    metrics::describe_counter!(
+        "bpa.restart.orphan",
+        metrics::Unit::Count,
+        "Orphaned bundles discovered during restart"
+    );
+    metrics::describe_counter!(
+        "bpa.restart.junk",
+        metrics::Unit::Count,
+        "Junk data discovered during restart"
+    );
+
+    // -- J. Performance --
+    metrics::describe_gauge!(
+        "bpa.processing_pool.active",
+        metrics::Unit::Count,
+        "Active tasks in the bounded processing pool"
+    );
+}
+
+/// Convert an optional ReasonCode to a static label string for the `"reason"` label
+/// on `bpa.bundle.deleted`.
+pub fn reason_label(reason: Option<&ReasonCode>) -> &'static str {
+    match reason {
+        None => "none",
+        Some(ReasonCode::NoAdditionalInformation) => "no_info",
+        Some(ReasonCode::LifetimeExpired) => "lifetime_expired",
+        Some(ReasonCode::ForwardedOverUnidirectionalLink) => "unidirectional",
+        Some(ReasonCode::TransmissionCanceled) => "canceled",
+        Some(ReasonCode::DepletedStorage) => "depleted_storage",
+        Some(ReasonCode::DestinationEndpointIDUnavailable) => "dest_unavailable",
+        Some(ReasonCode::NoKnownRouteToDestinationFromHere) => "no_route",
+        Some(ReasonCode::NoTimelyContactWithNextNodeOnRoute) => "no_contact",
+        Some(ReasonCode::BlockUnintelligible) => "block_unintelligible",
+        Some(ReasonCode::HopLimitExceeded) => "hop_limit",
+        Some(ReasonCode::TrafficPared) => "traffic_pared",
+        Some(ReasonCode::BlockUnsupported) => "block_unsupported",
+        Some(ReasonCode::MissingSecurityOperation) => "missing_security",
+        Some(ReasonCode::UnknownSecurityOperation) => "unknown_security",
+        Some(ReasonCode::UnexpectedSecurityOperation) => "unexpected_security",
+        Some(ReasonCode::FailedSecurityOperation) => "failed_security",
+        Some(ReasonCode::ConflictingSecurityOperation) => "conflicting_security",
+        Some(ReasonCode::Unassigned(_)) => "unassigned",
+    }
+}
+
+/// Convert a BundleStatus to a static label string for the `"state"` label
+/// on `bpa.bundle.status`.
+pub fn status_label(status: &crate::bundle::BundleStatus) -> &'static str {
+    match status {
+        crate::bundle::BundleStatus::New => "new",
+        crate::bundle::BundleStatus::Dispatching => "dispatching",
+        crate::bundle::BundleStatus::ForwardPending { .. } => "forward_pending",
+        crate::bundle::BundleStatus::AduFragment { .. } => "fragment",
+        crate::bundle::BundleStatus::Waiting => "waiting",
+        crate::bundle::BundleStatus::WaitingForService { .. } => "waiting_for_service",
+    }
+}

--- a/bpa/src/otel_metrics.rs
+++ b/bpa/src/otel_metrics.rs
@@ -64,9 +64,9 @@ pub fn init() {
         "Bundle forward attempts that failed (CLA error)"
     );
     metrics::describe_counter!(
-        "bpa.bundle.deleted",
+        "bpa.bundle.dropped",
         metrics::Unit::Count,
-        "Bundles deleted (by reason code)"
+        "Bundles dropped (by reason code)"
     );
     metrics::describe_counter!(
         "bpa.bundle.reassembled",
@@ -77,11 +77,6 @@ pub fn init() {
         "bpa.bundle.reassembly.failed",
         metrics::Unit::Count,
         "Reassembly failures (reconstituted bundle invalid)"
-    );
-    metrics::describe_counter!(
-        "bpa.bundle.expired",
-        metrics::Unit::Count,
-        "Bundles expired by the reaper"
     );
 
     // -- E. Filters --
@@ -230,28 +225,27 @@ pub fn init() {
 }
 
 /// Convert an optional ReasonCode to a static label string for the `"reason"` label
-/// on `bpa.bundle.deleted`.
-pub fn reason_label(reason: Option<&ReasonCode>) -> &'static str {
+/// on `bpa.bundle.dropped`.
+pub fn reason_label(reason: &ReasonCode) -> &'static str {
     match reason {
-        None => "none",
-        Some(ReasonCode::NoAdditionalInformation) => "no_info",
-        Some(ReasonCode::LifetimeExpired) => "lifetime_expired",
-        Some(ReasonCode::ForwardedOverUnidirectionalLink) => "unidirectional",
-        Some(ReasonCode::TransmissionCanceled) => "canceled",
-        Some(ReasonCode::DepletedStorage) => "depleted_storage",
-        Some(ReasonCode::DestinationEndpointIDUnavailable) => "dest_unavailable",
-        Some(ReasonCode::NoKnownRouteToDestinationFromHere) => "no_route",
-        Some(ReasonCode::NoTimelyContactWithNextNodeOnRoute) => "no_contact",
-        Some(ReasonCode::BlockUnintelligible) => "block_unintelligible",
-        Some(ReasonCode::HopLimitExceeded) => "hop_limit",
-        Some(ReasonCode::TrafficPared) => "traffic_pared",
-        Some(ReasonCode::BlockUnsupported) => "block_unsupported",
-        Some(ReasonCode::MissingSecurityOperation) => "missing_security",
-        Some(ReasonCode::UnknownSecurityOperation) => "unknown_security",
-        Some(ReasonCode::UnexpectedSecurityOperation) => "unexpected_security",
-        Some(ReasonCode::FailedSecurityOperation) => "failed_security",
-        Some(ReasonCode::ConflictingSecurityOperation) => "conflicting_security",
-        Some(ReasonCode::Unassigned(_)) => "unassigned",
+        ReasonCode::NoAdditionalInformation => "no_info",
+        ReasonCode::LifetimeExpired => "lifetime_expired",
+        ReasonCode::ForwardedOverUnidirectionalLink => "unidirectional",
+        ReasonCode::TransmissionCanceled => "canceled",
+        ReasonCode::DepletedStorage => "depleted_storage",
+        ReasonCode::DestinationEndpointIDUnavailable => "dest_unavailable",
+        ReasonCode::NoKnownRouteToDestinationFromHere => "no_route",
+        ReasonCode::NoTimelyContactWithNextNodeOnRoute => "no_contact",
+        ReasonCode::BlockUnintelligible => "block_unintelligible",
+        ReasonCode::HopLimitExceeded => "hop_limit",
+        ReasonCode::TrafficPared => "traffic_pared",
+        ReasonCode::BlockUnsupported => "block_unsupported",
+        ReasonCode::MissingSecurityOperation => "missing_security",
+        ReasonCode::UnknownSecurityOperation => "unknown_security",
+        ReasonCode::UnexpectedSecurityOperation => "unexpected_security",
+        ReasonCode::FailedSecurityOperation => "failed_security",
+        ReasonCode::ConflictingSecurityOperation => "conflicting_security",
+        ReasonCode::Unassigned(_) => "unassigned",
     }
 }
 

--- a/bpa/src/otel_metrics.rs
+++ b/bpa/src/otel_metrics.rs
@@ -215,13 +215,6 @@ pub fn init() {
         metrics::Unit::Count,
         "Junk data discovered during restart"
     );
-
-    // -- J. Performance --
-    metrics::describe_gauge!(
-        "bpa.processing_pool.active",
-        metrics::Unit::Count,
-        "Active tasks in the bounded processing pool"
-    );
 }
 
 /// Convert an optional ReasonCode to a static label string for the `"reason"` label

--- a/bpa/src/otel_metrics.rs
+++ b/bpa/src/otel_metrics.rs
@@ -253,7 +253,7 @@ pub fn reason_label(reason: &ReasonCode) -> &'static str {
 /// on `bpa.bundle.status`.
 pub fn status_label(status: &crate::bundle::BundleStatus) -> &'static str {
     match status {
-        crate::bundle::BundleStatus::New => "new",
+        crate::bundle::BundleStatus::New => "received",
         crate::bundle::BundleStatus::Dispatching => "dispatching",
         crate::bundle::BundleStatus::ForwardPending { .. } => "forward_pending",
         crate::bundle::BundleStatus::AduFragment { .. } => "fragment",

--- a/bpa/src/rib/agent.rs
+++ b/bpa/src/rib/agent.rs
@@ -74,6 +74,8 @@ impl Rib {
             e.insert(Arc::new(Agent { agent, name })).clone()
         };
 
+        metrics::gauge!("bpa.rib.agents").increment(1.0);
+
         let node_ids: Vec<NodeId> = (&*self.node_ids).into();
 
         agent
@@ -94,6 +96,7 @@ impl Rib {
         let agent = self.agents.lock().remove(&agent.name);
 
         if let Some(agent) = agent {
+            metrics::gauge!("bpa.rib.agents").decrement(1.0);
             agent.agent.on_unregister().await;
             self.remove_by_source(&agent.name).await;
             info!("Unregistered routing agent: {}", agent.name);
@@ -107,6 +110,10 @@ impl Rib {
             .drain()
             .map(|(_, v)| v)
             .collect::<Vec<_>>();
+
+        if !agents.is_empty() {
+            metrics::gauge!("bpa.rib.agents").decrement(agents.len() as f64);
+        }
 
         for agent in agents {
             agent.agent.on_unregister().await;

--- a/bpa/src/rib/local.rs
+++ b/bpa/src/rib/local.rs
@@ -77,6 +77,8 @@ impl LocalInner {
 }
 
 impl Rib {
+    // TODO: Add batched variants of add_local/remove_local that take a slice,
+    // acquire the write lock once, and call notify_updated() once per batch.
     async fn add_local(&self, pattern: EidPattern, action: Action) -> bool {
         debug!("Adding local route {pattern} => {action}");
 

--- a/bpa/src/rib/route.rs
+++ b/bpa/src/rib/route.rs
@@ -63,6 +63,7 @@ impl Rib {
             }
 
             debug!("Adding route {pattern} => {action}, priority {priority}, source '{source}'");
+            metrics::gauge!("bpa.rib.entries", "source" => source.clone()).increment(1.0);
 
             // Start walking through the route table starting at this priority to find impacted routes
             let mut vias = HashSet::new();
@@ -124,6 +125,7 @@ impl Rib {
         }
 
         debug!("Removed route {pattern} => {action}, priority {priority}, source '{source}'");
+        metrics::gauge!("bpa.rib.entries", "source" => source.to_string()).decrement(1.0);
 
         // See if we are removing a Via
         if let routes::Action::Via(to) = action
@@ -136,9 +138,10 @@ impl Rib {
     }
 
     pub async fn remove_by_source(&self, source: &str) {
-        let vias = {
+        let (vias, removed_count) = {
             let mut inner = self.inner.write();
             let mut vias = HashSet::new();
+            let mut removed_count = 0u64;
 
             inner.routes.retain(|_priority, patterns| {
                 patterns.retain(|_pattern, actions| {
@@ -147,6 +150,7 @@ impl Rib {
                             if let routes::Action::Via(to) = &entry.action {
                                 vias.insert(to.clone());
                             }
+                            removed_count += 1;
                             false
                         } else {
                             true
@@ -156,8 +160,13 @@ impl Rib {
                 });
                 !patterns.is_empty()
             });
-            vias
+            (vias, removed_count)
         };
+
+        if removed_count > 0 {
+            metrics::gauge!("bpa.rib.entries", "source" => source.to_string())
+                .decrement(removed_count as f64);
+        }
 
         if vias.is_empty() {
             return;

--- a/bpa/src/services/registry.rs
+++ b/bpa/src/services/registry.rs
@@ -203,6 +203,10 @@ impl Registry {
             .map(|(_, v)| v)
             .collect::<Vec<_>>();
 
+        if !services.is_empty() {
+            metrics::gauge!("bpa.service.registered").decrement(services.len() as f64);
+        }
+
         for service in services {
             self.unregister_service(service).await
         }
@@ -413,6 +417,7 @@ impl Registry {
         };
 
         info!("Registered new service: {service_id}");
+        metrics::gauge!("bpa.service.registered").increment(1.0);
 
         // Add local service to RIB
         self.rib
@@ -444,6 +449,7 @@ impl Registry {
         let service = self.services.lock().remove(&service.service_id);
 
         if let Some(service) = service {
+            metrics::gauge!("bpa.service.registered").decrement(1.0);
             self.unregister_service(service).await
         }
     }

--- a/bpa/src/storage/adu_reassembly.rs
+++ b/bpa/src/storage/adu_reassembly.rs
@@ -44,6 +44,7 @@ impl Store {
         for (bundle_id, storage_name, _) in fragments.adus.values() {
             self.delete_data(storage_name).await;
             self.tombstone_metadata(bundle_id).await;
+            metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&status)).decrement(1.0);
         }
 
         // TODO: It would be good to capture the aggregate received at value across all the fragments, and use that as the received_at for the reassembled bundle

--- a/bpa/src/storage/bundle_mem.rs
+++ b/bpa/src/storage/bundle_mem.rs
@@ -118,7 +118,11 @@ impl BundleStorage for BundleMemStorage {
                     break;
                 };
                 inner.capacity = inner.capacity.saturating_sub(d.len());
+                metrics::counter!("bpa.mem_store.evictions").increment(1);
             }
+
+            metrics::gauge!("bpa.mem_store.bundles").set(inner.cache.len() as f64);
+            metrics::gauge!("bpa.mem_store.bytes").set(inner.capacity as f64);
 
             return Ok(storage_name.into());
         }
@@ -128,6 +132,8 @@ impl BundleStorage for BundleMemStorage {
         let mut inner = self.inner.lock();
         if let Some((_, d)) = inner.cache.pop(storage_name) {
             inner.capacity = inner.capacity.saturating_sub(d.len());
+            metrics::gauge!("bpa.mem_store.bundles").set(inner.cache.len() as f64);
+            metrics::gauge!("bpa.mem_store.bytes").set(inner.capacity as f64);
         }
         Ok(())
     }

--- a/bpa/src/storage/metadata_mem.rs
+++ b/bpa/src/storage/metadata_mem.rs
@@ -36,6 +36,51 @@ impl MetadataMemStorage {
 
         Self { entries }
     }
+
+    /// Account for an entry leaving the LRU (eviction or replacement).
+    fn on_remove(value: &Option<Bundle>) {
+        match value {
+            Some(_) => metrics::gauge!("bpa.mem_metadata.entries").decrement(1.0),
+            None => metrics::gauge!("bpa.mem_metadata.tombstones").decrement(1.0),
+        }
+    }
+
+    /// Account for an entry entering the LRU.
+    fn on_add(value: &Option<Bundle>) {
+        match value {
+            Some(_) => metrics::gauge!("bpa.mem_metadata.entries").increment(1.0),
+            None => metrics::gauge!("bpa.mem_metadata.tombstones").increment(1.0),
+        }
+    }
+
+    /// Insert or replace a value in the LRU, updating metrics for all transitions:
+    /// added, replaced, evicted.
+    fn put(&self, key: Id, value: Option<Bundle>) -> Result<()> {
+        let prev = { self.entries.lock().put(key, value.clone()) };
+        if let Some(prev) = prev {
+            Self::on_remove(&prev);
+        }
+        Self::on_add(&value);
+        Ok(())
+    }
+
+    /// Insert a new entry only if the key is absent. Returns false if already present.
+    /// Accounts for LRU eviction of a different entry.
+    fn push(&self, key: Id, value: Option<Bundle>) -> Result<bool> {
+        let evicted = {
+            let mut entries = self.entries.lock();
+            if entries.get(&key).is_some() {
+                return Ok(false);
+            }
+            entries.push(key, value.clone()).map(|e| e.1)
+        };
+
+        if let Some(evicted) = evicted {
+            Self::on_remove(&evicted);
+        }
+        Self::on_add(&value);
+        Ok(true)
+    }
 }
 
 #[async_trait]
@@ -45,28 +90,11 @@ impl MetadataStorage for MetadataMemStorage {
     }
 
     async fn insert(&self, bundle: &Bundle) -> Result<bool> {
-        let mut entries = self.entries.lock();
-        if entries.get(&bundle.bundle.id).is_some() {
-            Ok(false)
-        } else {
-            if let Some((_, evicted)) = entries.push(bundle.bundle.id.clone(), Some(bundle.clone()))
-            {
-                // A different entry was evicted due to LRU capacity
-                match evicted {
-                    Some(_) => metrics::gauge!("bpa.mem_metadata.entries").decrement(1.0),
-                    None => metrics::gauge!("bpa.mem_metadata.tombstones").decrement(1.0),
-                }
-            }
-            metrics::gauge!("bpa.mem_metadata.entries").increment(1.0);
-            Ok(true)
-        }
+        self.push(bundle.bundle.id.clone(), Some(bundle.clone()))
     }
 
     async fn replace(&self, bundle: &Bundle) -> Result<()> {
-        self.entries
-            .lock()
-            .put(bundle.bundle.id.clone(), Some(bundle.clone()));
-        Ok(())
+        self.put(bundle.bundle.id.clone(), Some(bundle.clone()))
     }
 
     async fn update_status(&self, bundle: &Bundle) -> Result<()> {
@@ -74,10 +102,7 @@ impl MetadataStorage for MetadataMemStorage {
     }
 
     async fn tombstone(&self, bundle_id: &Id) -> Result<()> {
-        self.entries.lock().put(bundle_id.clone(), None);
-        metrics::gauge!("bpa.mem_metadata.entries").decrement(1.0);
-        metrics::gauge!("bpa.mem_metadata.tombstones").increment(1.0);
-        Ok(())
+        self.put(bundle_id.clone(), None)
     }
 
     async fn start_recovery(&self) {

--- a/bpa/src/storage/metadata_mem.rs
+++ b/bpa/src/storage/metadata_mem.rs
@@ -49,7 +49,15 @@ impl MetadataStorage for MetadataMemStorage {
         if entries.get(&bundle.bundle.id).is_some() {
             Ok(false)
         } else {
-            entries.put(bundle.bundle.id.clone(), Some(bundle.clone()));
+            if let Some((_, evicted)) = entries.push(bundle.bundle.id.clone(), Some(bundle.clone()))
+            {
+                // A different entry was evicted due to LRU capacity
+                match evicted {
+                    Some(_) => metrics::gauge!("bpa.mem_metadata.entries").decrement(1.0),
+                    None => metrics::gauge!("bpa.mem_metadata.tombstones").decrement(1.0),
+                }
+            }
+            metrics::gauge!("bpa.mem_metadata.entries").increment(1.0);
             Ok(true)
         }
     }
@@ -67,6 +75,8 @@ impl MetadataStorage for MetadataMemStorage {
 
     async fn tombstone(&self, bundle_id: &Id) -> Result<()> {
         self.entries.lock().put(bundle_id.clone(), None);
+        metrics::gauge!("bpa.mem_metadata.entries").decrement(1.0);
+        metrics::gauge!("bpa.mem_metadata.tombstones").increment(1.0);
         Ok(())
     }
 

--- a/bpa/src/storage/metadata_mem.rs
+++ b/bpa/src/storage/metadata_mem.rs
@@ -85,15 +85,15 @@ impl MetadataStorage for MetadataMemStorage {
         Ok(())
     }
 
-    async fn reset_peer_queue(&self, peer: u32) -> Result<bool> {
-        let mut updated = false;
+    async fn reset_peer_queue(&self, peer: u32) -> Result<u64> {
+        let mut updated = 0;
         for (_, v) in self.entries.lock().iter_mut() {
             if let Some(v) = v
                 && let BundleStatus::ForwardPending { peer: p, queue: _ } = v.metadata.status
                 && p == peer
             {
                 v.metadata.status = BundleStatus::Waiting;
-                updated = true;
+                updated += 1;
             }
         }
         Ok(updated)

--- a/bpa/src/storage/mod.rs
+++ b/bpa/src/storage/mod.rs
@@ -149,8 +149,8 @@ pub trait MetadataStorage: Send + Sync {
     ///
     /// # Returns
     ///
-    /// A `Result` containing a boolean indicating whether any bundles were reset.
-    async fn reset_peer_queue(&self, peer: u32) -> Result<bool>;
+    /// A `Result` containing the number of bundles that were reset.
+    async fn reset_peer_queue(&self, peer: u32) -> Result<u64>;
 
     /// Returns the next `limit` bundles, not of status `BundleStatus::New`, ordered by expiry.
     /// The receiver will hang up when it has enough bundles.

--- a/bpa/src/storage/reaper.rs
+++ b/bpa/src/storage/reaper.rs
@@ -150,7 +150,6 @@ impl Store {
                     .await
                     .inspect_err(|e| error!("Failed to get metadata from store: {e}"))
                 {
-                    metrics::counter!("bpa.bundle.expired").increment(1);
                     dispatcher
                         .drop_bundle(
                             bundle,

--- a/bpa/src/storage/reaper.rs
+++ b/bpa/src/storage/reaper.rs
@@ -150,6 +150,7 @@ impl Store {
                     .await
                     .inspect_err(|e| error!("Failed to get metadata from store: {e}"))
                 {
+                    metrics::counter!("bpa.bundle.expired").increment(1);
                     dispatcher
                         .drop_bundle(
                             bundle,

--- a/bpa/src/storage/recover.rs
+++ b/bpa/src/storage/recover.rs
@@ -1,14 +1,6 @@
 use super::*;
 use futures::{FutureExt, join, select_biased};
 
-pub enum RestartResult {
-    Missing,
-    Duplicate,
-    Valid,
-    Orphan,
-    Junk,
-}
-
 impl Store {
     pub fn recover(self: &Arc<Self>, dispatcher: &Arc<dispatcher::Dispatcher>) {
         // Start the store - this can take a while as the store is walked
@@ -17,33 +9,6 @@ impl Store {
         hardy_async::spawn!(self.tasks, "store_check_task", async move {
             // Start the store - this can take a while as the store is walked
             info!("Starting store consistency check...");
-
-            // Set up the metrics
-            metrics::describe_counter!(
-                "restart_lost_bundles",
-                metrics::Unit::Count,
-                "Total number of lost bundles discovered during storage restart"
-            );
-            metrics::describe_counter!(
-                "restart_duplicate_bundles",
-                metrics::Unit::Count,
-                "Total number of duplicate bundles discovered during storage restart"
-            );
-            metrics::describe_counter!(
-                "restart_valid_bundles",
-                metrics::Unit::Count,
-                "Total number of valid bundles discovered during storage restart"
-            );
-            metrics::describe_counter!(
-                "restart_orphan_bundles",
-                metrics::Unit::Count,
-                "Total number of orphaned bundles discovered during storage restart"
-            );
-            metrics::describe_counter!(
-                "restart_junk_bundles",
-                metrics::Unit::Count,
-                "Total number of junk bundles discovered during storage restart"
-            );
 
             store.start_metadata_storage_recovery().await;
 
@@ -86,13 +51,7 @@ impl Store {
                                 break;
                             }
                             Ok(r) => {
-                                match dispatcher.restart_bundle(r.0, r.1).await {
-                                    RestartResult::Missing => metrics::counter!("restart_lost_bundles").increment(1),
-                                    RestartResult::Duplicate => metrics::counter!("restart_duplicate_bundles").increment(1),
-                                    RestartResult::Valid => metrics::counter!("restart_valid_bundles").increment(1),
-                                    RestartResult::Orphan => metrics::counter!("restart_orphan_bundles").increment(1),
-                                    RestartResult::Junk => metrics::counter!("restart_junk_bundles").increment(1),
-                                }
+                                dispatcher.restart_bundle(r.0, r.1).await;
                             }
                         },
                         _ = cancel_token.cancelled().fuse() => {
@@ -124,7 +83,7 @@ impl Store {
                         bundle = rx.recv_async().fuse() => match bundle {
                             Err(_) => break,
                             Ok(bundle) => {
-                                metrics::counter!("restart_orphan_bundles").increment(1);
+                                metrics::counter!("bpa.restart.orphan").increment(1);
 
                                 // The data associated with `bundle` has gone!
                                 dispatcher.report_bundle_deletion(

--- a/bpa/src/storage/store.rs
+++ b/bpa/src/storage/store.rs
@@ -223,10 +223,13 @@ impl Store {
 
     #[cfg_attr(feature = "instrument", instrument(skip_all))]
     pub async fn reset_peer_queue(&self, peer: u32) -> bool {
-        self.metadata_storage
+        let reset = self
+            .metadata_storage
             .reset_peer_queue(peer)
             .await
-            .trace_expect("Failed to reset peer queue")
+            .trace_expect("Failed to reset peer queue");
+
+        reset != 0
     }
 }
 

--- a/bpa/src/storage/store.rs
+++ b/bpa/src/storage/store.rs
@@ -201,6 +201,9 @@ impl Store {
     #[cfg_attr(feature = "instrument", instrument(skip(self, bundle),fields(bundle.id = %bundle.bundle.id)))]
     pub async fn update_status(&self, bundle: &mut bundle::Bundle, status: &bundle::BundleStatus) {
         if bundle.metadata.status != *status {
+            metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).decrement(1.0);
+            metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(status)).increment(1.0);
+
             bundle.metadata.status = status.clone();
             self.metadata_storage
                 .update_status(bundle)
@@ -232,6 +235,13 @@ impl Store {
             .reset_peer_queue(peer)
             .await
             .trace_expect("Failed to reset peer queue");
+
+        if reset > 0 {
+            metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle::BundleStatus::ForwardPending { peer, queue: None }))
+                .decrement(reset as f64);
+            metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle::BundleStatus::Waiting))
+                .increment(reset as f64);
+        }
 
         reset != 0
     }

--- a/bpa/src/storage/store.rs
+++ b/bpa/src/storage/store.rs
@@ -85,8 +85,10 @@ impl Store {
     pub async fn load_data(&self, storage_name: &str) -> Option<Bytes> {
         if let Some(cache) = &self.bundle_cache {
             if let Some(data) = cache.lru.lock().get(storage_name) {
+                metrics::counter!("bpa.store.cache.hits").increment(1);
                 return Some(data.clone());
             }
+            metrics::counter!("bpa.store.cache.misses").increment(1);
         }
 
         let data = self
@@ -119,6 +121,8 @@ impl Store {
         if let Some(cache) = &self.bundle_cache {
             if data.len() < cache.max_bundle_size {
                 cache.lru.lock().put(storage_name.clone(), data.clone());
+            } else {
+                metrics::counter!("bpa.store.cache.oversized").increment(1);
             }
         }
 

--- a/postgres-storage/src/storage.rs
+++ b/postgres-storage/src/storage.rs
@@ -487,7 +487,7 @@ impl storage::MetadataStorage for Storage {
     }
 
     #[cfg_attr(feature = "instrument", instrument(skip(self)))]
-    async fn reset_peer_queue(&self, peer: u32) -> storage::Result<bool> {
+    async fn reset_peer_queue(&self, peer: u32) -> storage::Result<u64> {
         let rows = sqlx::query(
             "UPDATE metadata
              SET status   = $2,
@@ -503,7 +503,7 @@ impl storage::MetadataStorage for Storage {
         .await?
         .rows_affected();
 
-        Ok(rows > 0)
+        Ok(rows)
     }
 
     #[cfg_attr(feature = "instrument", instrument(skip(self, tx)))]

--- a/sqlite-storage/src/storage.rs
+++ b/sqlite-storage/src/storage.rs
@@ -477,7 +477,7 @@ impl storage::MetadataStorage for Storage {
     }
 
     #[cfg_attr(feature = "instrument", instrument(skip(self)))]
-    async fn reset_peer_queue(&self, peer: u32) -> storage::Result<bool> {
+    async fn reset_peer_queue(&self, peer: u32) -> storage::Result<u64> {
         // Ensure status codes match
         debug_assert!(
             from_status(&BundleStatus::Waiting).0 == 1,
@@ -496,7 +496,7 @@ impl storage::MetadataStorage for Storage {
                 "UPDATE bundles SET status_code = 1, status_param1 = NULL, status_param2 = NULL WHERE status_code = 2 AND status_param1 = ?1",
             )?
             .execute((Some(peer),))
-            .map(|c| c > 0)
+            .map(|c| c as u64)
             .map_err(Into::into)
         })
         .await

--- a/tests/storage/src/metadata_suite.rs
+++ b/tests/storage/src/metadata_suite.rs
@@ -381,9 +381,9 @@ pub async fn meta_11_reset_peer_queue(store: Arc<dyn MetadataStorage>) {
     assert!(store.insert(&bundle_b).await.unwrap());
 
     let changed = store.reset_peer_queue(100).await.unwrap();
-    assert!(
-        changed,
-        "reset_peer_queue should return true when bundles were reset"
+    assert_eq!(
+        changed, 1,
+        "reset_peer_queue should return 1 when bundles were reset"
     );
 
     let got_a = store.get(&bundle_a.bundle.id).await.unwrap().unwrap();


### PR DESCRIPTION
Summary
                                                                                                                                                                                                                                                                             
  Add OpenTelemetry metrics instrumentation across the BPA crate, covering bundle reception, origination, pipeline status tracking, storage caching, registry gauges, and filter execution. Several correctness issues in the dispatcher were discovered and fixed during instrumentation.                                                                                                                                                                                                                                                           
  
  Metrics Added                                                                                                                                                                                                                                                              
                                                            
  Counters:                                                                                                                                                                                                                                   
  - bpa.bundle.received, bpa.bundle.received.bytes, bpa.bundle.received.dropped, bpa.bundle.received.duplicate
  - bpa.bundle.originated, bpa.bundle.originated.bytes                                                                                                                                                                                                                       
  - bpa.bundle.delivered, bpa.bundle.forwarded, bpa.bundle.forwarding.failed, bpa.bundle.dropped (with reason label)
  - bpa.bundle.reassembled, bpa.bundle.reassembly.failed                                                                                                                                                                                                                     
  - bpa.admin_record.received, bpa.admin_record.unknown                                                                                                                                                                                                                      
  - bpa.status_report.sent (with type label), bpa.status_report.received (with type label)                                                                                                                                                                                   
  - bpa.filter.filtered, bpa.filter.modified, bpa.filter.error (with hook label)                                                                                                                                                                                             
  - bpa.store.cache.hits, bpa.store.cache.misses, bpa.store.cache.oversized                                                                                                                                                                                                  
  - bpa.mem_store.evictions                                                                                                                                                                                                                                                  
  - bpa.restart.lost, bpa.restart.duplicate, bpa.restart.orphan, bpa.restart.junk                                                                                                                                                                                            
                                                                                                                                                                                                                                                                             
  Gauges:                                                                                                                                                                                                                                              
  - bpa.bundle.status (with state label: new/dispatching/forward_pending/fragment/waiting/waiting_for_service)                                                                                                                                                               
  - bpa.processing_pool.active                                                                                                                                                                                                                                               
  - bpa.mem_store.bundles, bpa.mem_store.bytes              
  - bpa.mem_metadata.entries, bpa.mem_metadata.tombstones                                                                                                                                                                                                                    
  - bpa.cla.registered, bpa.service.registered, bpa.filter.registered (with hook label)                                                                                                                                                                                      
  - bpa.rib.agents, bpa.rib.entries (with source label), bpa.fib.entries (with cla label)                                                                                                                                                                                    
                                                                                                                                                                                                                                                                             
  Infrastructure                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                             
  - New otel_metrics.rs with centralised metric descriptions, reason_label() and status_label() helpers                                                                                                                                                                      
  - Hook::label() helper on the filter Hook enum                                                                                                                                                                                                                             
  - Filter metrics (filtered/modified/error) centralised in Registry::exec() — removed from all 4 call sites                                                                                                                                                                 
  - metadata_mem.rs uses push() instead of put() for eviction-safe gauge counting                                                                                                                                                                                            
  - FIB entries counted per add_forward/remove_forward (per node_id), not per peer                                                                                                                                                                                           
  - delete_bundle() made private — all pipeline exits flow through it or drop_bundle()                                                                                                                                                                                       
  - RestartResult enum removed — metrics emitted directly at each decision point                                                                                                                                                                                             
                                                                                                                                                                                                                                                                             
  Bug Fixes                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                             
  - forward_bundle() depleted storage: silently returned on missing bundle data instead of dropping — now calls drop_bundle(DepletedStorage)                                                                                                                                 
  - dispatch_listeners()/poll_waiting depleted storage: called drop_bundle(None) instead of drop_bundle(DepletedStorage) — reason now correctly reported
  - receive_bundle() invalid bundles: was calling drop_bundle() for bundles that never entered the pipeline. Now sends reception report with actual reason code and tombstones directly — no deletion report for bundles that were never accepted                            
  - poll_service_waiting(): was calling ingest_bundle() which re-runs the ingress filter on bundles that already passed it. Now calls dispatch_bundle() to go straight to routing                                                                                            
  - Restart WaitingForService: same fix — dispatch_bundle() instead of ingest_bundle()                                                                                                                                                                                       
  - Restart ForwardPending: peer IDs are stale after restart. Now resets to Waiting so bundles are re-routed when CLAs re-register                                                                                                                                           
  - Restart Invalid bundles: no longer inserts metadata just to immediately drop it. !exists path exits early; exists path sends deletion report and tombstones directly                                                                                                     
  - admin.rs status report delivery: was calling drop_bundle(None) which sends no deletion report. Now calls delete_bundle() directly since the bundle is consumed, not dropped