### PR TITLE
ci: enable S3 storage in Docker image and skip workflows on non-code changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,13 @@ name: Docker
 on:
   push:
     branches: ["main"]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - "**/Dockerfile"
+      - ".github/workflows/docker.yml"
+      - "proto/**"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - image: hardy-bpa-server
             dockerfile: ./bpa-server/Dockerfile
-            build-args: CARGO_ARGS=--features hardy-bpa-server/sqlite-storage,hardy-bpa-server/postgres-storage
+            build-args: CARGO_ARGS=--features hardy-bpa-server/sqlite-storage,hardy-bpa-server/postgres-storage,hardy-bpa-server/s3-storage
           - image: hardy-tcpclv4-server
             dockerfile: ./tcpclv4-server/Dockerfile
             build-args: ""

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,13 @@ name: Rust
 on:
   pull_request:
     branches: ["main"]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/rust.yml"
+      - "proto/**"
+      - "tests/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
- Enable s3-storage feature in the Docker CI build for **hardy-bpa-server**
- Add path filters to `rust.yml` and `docker.yml` so they only run when Rust source, Cargo files, Dockerfiles, or protobuf definitions change 