### PR TITLE
feat: add bp tools Docker image, CI workflow, and troubleshooting guide

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,110 @@
+name: Tools
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "tools/**"
+      - "bpa/**"
+      - "bpv7/**"
+      - "cbor/**"
+      - "proto/**"
+      - "tcpclv4/**"
+      - "async/**"
+      - "patches/**"
+      - "Cargo.lock"
+      - ".github/workflows/tools.yml"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Login to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/bp
+          tags: |
+            type=sha
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: "."
+          file: ./tools/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/bp:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/bp:buildcache,mode=max
+          platforms: linux/amd64,linux/arm64
+
+  binaries:
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: bp-linux-amd64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact: bp-linux-arm64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact: bp-macos-amd64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: bp-macos-arm64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install cross-compilation deps (Linux ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu protobuf-compiler libprotobuf-dev
+
+      - name: Install protobuf (Linux x86_64)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev
+
+      - name: Install protobuf (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: brew install protobuf
+
+      - name: Build
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: cargo build --release -p hardy-tools --bin bp --target ${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: target/${{ matrix.target }}/release/bp

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,55 @@
+# Troubleshooting
+
+## BPA Server
+
+### `Failed to connect to Postgres metadata store: Migration(VersionMissing(1))`
+
+The database has not been migrated yet. The server defaults to validation-only mode
+and will not run migrations unless explicitly told to.
+
+Pass the `-u` flag on first start (or after upgrading):
+
+```bash
+hardy-bpa-server -u
+```
+
+In Docker Compose:
+
+```yaml
+services:
+  hardy:
+    image: ghcr.io/ricktaylor/hardy/hardy-bpa-server:latest
+    command: ["-u"]
+```
+
+The flag is safe to leave permanently — migrations are idempotent.
+
+## BP Tools
+
+### `Failed to parse peer address 'hostname:4556': invalid socket address syntax`
+
+The `bp` binary expects an IP address, not a hostname. Use the numeric address instead:
+
+```bash
+# Won't work
+bp ping ipn:1.7 localhost:4556
+bp ping ipn:1.7 hardy:4556
+
+# Works
+bp ping ipn:1.7 127.0.0.1:4556
+bp ping ipn:1.7 192.168.1.10:4556
+```
+
+### Running `bp` via Docker
+
+Use `--network host` to reach services on the host:
+
+```bash
+docker run --rm --network host ghcr.io/ricktaylor/hardy/bp:latest ping ipn:1.7 127.0.0.1:4556
+```
+
+Or use the compose network name to reach services by container IP:
+
+```bash
+docker run --rm --network <network_name> ghcr.io/ricktaylor/hardy/bp:latest ping ipn:1.7 <container-ip>:4556
+```

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -40,6 +40,8 @@ bp ping ipn:1.7 127.0.0.1:4556
 bp ping ipn:1.7 192.168.1.10:4556
 ```
 
+See [bp-ping(1)](tools/docs/bp-ping.1.md) for full usage documentation.
+
 ### Running `bp` via Docker
 
 Use `--network host` to reach services on the host:

--- a/tcpclv4-server/Dockerfile
+++ b/tcpclv4-server/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=planner /build/recipe.json recipe.json
 # (a local stub to resolve a links="sqlite3" conflict). It must be present before
 # cargo chef cook so the resolver can find it.
 COPY patches/ patches/
-RUN cargo chef cook --release --recipe-path recipe.json $CARGO_ARGS
+RUN cargo chef cook --release --recipe-path recipe.json -p hardy-tcpclv4-server $CARGO_ARGS
 COPY . .
 RUN cargo build --release --bin hardy-tcpclv4-server $CARGO_ARGS
 

--- a/tests/compose.ping-tests.yml
+++ b/tests/compose.ping-tests.yml
@@ -7,7 +7,7 @@ services:
   ping-tests:
     build:
       context: .
-      dockerfile: tests/Dockerfile.tools
+      dockerfile: tools/Dockerfile
     image: hardy-ping-tests:latest
     depends_on:
       hardy:

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -17,15 +17,16 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 COPY --from=planner /build/recipe.json recipe.json
 COPY patches/ patches/
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p hardy-tools
 COPY . .
 RUN cargo build --release -p hardy-tools
 
 # ── Stage 4: runtime ──────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
         ca-certificates \
         netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /build/target/release/bp /usr/local/bin/bp
-ENTRYPOINT ["/bin/bash", "-c"]
+ENTRYPOINT ["/usr/local/bin/bp"]


### PR DESCRIPTION
Package the bp CLI as a Docker image with CI for publishing to GHCR and building platform binaries. And, fixes unnecessary dependency compilation in two Dockerfiles and adds a troubleshooting guide. 