### PR TITLE
Remove Option<> from drop_bundle - use delete instead

### DIFF
--- a/bpa/src/dispatcher/admin.rs
+++ b/bpa/src/dispatcher/admin.rs
@@ -13,7 +13,7 @@ impl Dispatcher {
             );
             metrics::counter!("bpa.admin_record.unknown").increment(1);
             return self
-                .drop_bundle(bundle, Some(ReasonCode::BlockUnintelligible))
+                .drop_bundle(bundle, ReasonCode::BlockUnintelligible)
                 .await;
         }
 
@@ -30,7 +30,7 @@ impl Dispatcher {
             Err(e) => {
                 debug!("Received an invalid administrative record: {e}");
                 return self
-                    .drop_bundle(bundle, Some(ReasonCode::BlockUnintelligible))
+                    .drop_bundle(bundle, ReasonCode::BlockUnintelligible)
                     .await;
             }
             Ok(data) => data,
@@ -40,7 +40,7 @@ impl Dispatcher {
             Err(e) => {
                 debug!("Failed to parse administrative record: {e}");
                 metrics::counter!("bpa.admin_record.unknown").increment(1);
-                self.drop_bundle(bundle, Some(ReasonCode::BlockUnintelligible))
+                self.drop_bundle(bundle, ReasonCode::BlockUnintelligible)
                     .await
             }
             Ok(AdministrativeRecord::BundleStatusReport(report)) => {

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -257,12 +257,6 @@ impl Dispatcher {
     /// Consumer task for the dispatch queue
     pub(super) async fn run_dispatch_queue(self: Arc<Self>, dispatch_rx: storage::Receiver) {
         while let Ok(Some(bundle)) = dispatch_rx.recv_async().await {
-            if bundle.has_expired() {
-                debug!("Bundle lifetime has expired while queued");
-                self.drop_bundle(bundle, ReasonCode::LifetimeExpired).await;
-                continue;
-            }
-
             let dispatcher = self.clone();
             hardy_async::spawn!(self.processing_pool, "process_bundle", async move {
                 if let Some(data) = dispatcher.load_data(&bundle).await {
@@ -364,12 +358,6 @@ impl Dispatcher {
                             let Ok(bundle) = bundle else {
                                 break;
                             };
-
-                            if bundle.has_expired() {
-                                debug!("Bundle lifetime has expired");
-                                self.drop_bundle(bundle, ReasonCode::LifetimeExpired).await;
-                                continue;
-                            }
 
                             let dispatcher = dispatcher.clone();
                             hardy_async::spawn!(self.processing_pool, "poll_waiting_dispatcher", async move {

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -269,8 +269,8 @@ impl Dispatcher {
                     dispatcher
                         .process_bundle(bundle, data, dispatcher.cla_registry())
                         .await;
-                } else {
-                    // Bundle data was deleted while queued
+                } else if !bundle.has_expired() {
+                    // Bundle data was deleted while queued - not reaped
                     dispatcher
                         .drop_bundle(bundle, ReasonCode::DepletedStorage)
                         .await;
@@ -375,8 +375,8 @@ impl Dispatcher {
                             hardy_async::spawn!(self.processing_pool, "poll_waiting_dispatcher", async move {
                                 if let Some(data) = dispatcher.load_data(&bundle).await {
                                     dispatcher.process_bundle(bundle, data, dispatcher.cla_registry()).await
-                                } else {
-                                    // Bundle data was deleted sometime while we waited, drop the bundle
+                                } else if !bundle.has_expired() {
+                                    // Bundle data was deleted while queued - not reaped
                                     dispatcher.drop_bundle(bundle, ReasonCode::DepletedStorage).await
                                 }
                             }).await;

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -228,7 +228,11 @@ impl Dispatcher {
                 (bundle, data)
             }
             Ok(filter::ExecResult::Drop(bundle, reason)) => {
-                return self.drop_bundle(bundle, reason).await;
+                if let Some(reason) = reason {
+                    return self.drop_bundle(bundle, reason).await;
+                } else {
+                    return self.delete_bundle(bundle).await;
+                }
             }
             Err(e) => {
                 error!("Ingress filter execution failed: {e}");
@@ -255,8 +259,7 @@ impl Dispatcher {
         while let Ok(Some(bundle)) = dispatch_rx.recv_async().await {
             if bundle.has_expired() {
                 debug!("Bundle lifetime has expired while queued");
-                self.drop_bundle(bundle, Some(ReasonCode::LifetimeExpired))
-                    .await;
+                self.drop_bundle(bundle, ReasonCode::LifetimeExpired).await;
                 continue;
             }
 
@@ -269,7 +272,7 @@ impl Dispatcher {
                 } else {
                     // Bundle data was deleted while queued
                     dispatcher
-                        .drop_bundle(bundle, Some(ReasonCode::DepletedStorage))
+                        .drop_bundle(bundle, ReasonCode::DepletedStorage)
                         .await;
                 }
             })
@@ -303,8 +306,13 @@ impl Dispatcher {
         // Perform RIB lookup (sets bundle.metadata.next_hop for Forward results)
         match self.rib.find(&mut bundle) {
             Some(rib::FindResult::Drop(reason)) => {
-                debug!("Routing lookup indicates bundle should be dropped: {reason:?}");
-                self.drop_bundle(bundle, reason).await
+                if let Some(reason) = reason {
+                    debug!("Routing lookup indicates bundle should be dropped: {reason:?}");
+                    self.drop_bundle(bundle, reason).await
+                } else {
+                    debug!("Routing lookup indicates bundle should be dropped without reason");
+                    self.delete_bundle(bundle).await
+                }
             }
             Some(rib::FindResult::AdminEndpoint) => {
                 // The bundle is for the Administrative Endpoint
@@ -359,7 +367,7 @@ impl Dispatcher {
 
                             if bundle.has_expired() {
                                 debug!("Bundle lifetime has expired");
-                                self.drop_bundle(bundle, Some(ReasonCode::LifetimeExpired)).await;
+                                self.drop_bundle(bundle, ReasonCode::LifetimeExpired).await;
                                 continue;
                             }
 
@@ -369,7 +377,7 @@ impl Dispatcher {
                                     dispatcher.process_bundle(bundle, data, dispatcher.cla_registry()).await
                                 } else {
                                     // Bundle data was deleted sometime while we waited, drop the bundle
-                                    dispatcher.drop_bundle(bundle, Some(ReasonCode::DepletedStorage)).await
+                                    dispatcher.drop_bundle(bundle, ReasonCode::DepletedStorage).await
                                 }
                             }).await;
                         }

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -12,8 +12,11 @@ impl Dispatcher {
     ) {
         // Get bundle data from store, now we know we need it!
         let Some(data) = self.load_data(&bundle).await else {
-            // Bundle data was deleted sometime during processing
-            return self.drop_bundle(bundle, ReasonCode::DepletedStorage).await;
+            if !bundle.has_expired() {
+                // Bundle data was deleted while queued - not reaped
+                self.drop_bundle(bundle, ReasonCode::DepletedStorage).await;
+            }
+            return;
         };
 
         // Increment Hop Count, etc...

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -13,9 +13,7 @@ impl Dispatcher {
         // Get bundle data from store, now we know we need it!
         let Some(data) = self.load_data(&bundle).await else {
             // Bundle data was deleted sometime during processing
-            return self
-                .drop_bundle(bundle, Some(ReasonCode::DepletedStorage))
-                .await;
+            return self.drop_bundle(bundle, ReasonCode::DepletedStorage).await;
         };
 
         // Increment Hop Count, etc...
@@ -50,7 +48,11 @@ impl Dispatcher {
         {
             Ok(filter::ExecResult::Continue(_, bundle, data)) => (bundle, data),
             Ok(filter::ExecResult::Drop(bundle, reason)) => {
-                return self.drop_bundle(bundle, reason).await;
+                if let Some(reason) = reason {
+                    return self.drop_bundle(bundle, reason).await;
+                } else {
+                    return self.delete_bundle(bundle).await;
+                }
             }
             Err(e) => {
                 error!("Egress filter execution failed: {e}");

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -182,7 +182,11 @@ impl Dispatcher {
         {
             Ok(filter::ExecResult::Continue(_, bundle, data)) => (bundle, data),
             Ok(filter::ExecResult::Drop(bundle, reason)) => {
-                return self.drop_bundle(bundle, reason).await;
+                if let Some(reason) = reason {
+                    return self.drop_bundle(bundle, reason).await;
+                } else {
+                    return self.delete_bundle(bundle).await;
+                }
             }
             Err(e) => {
                 error!("Deliver filter execution failed: {e}");
@@ -216,7 +220,7 @@ impl Dispatcher {
                             // TODO: This is where we can wrap the damaged bundle in a "Junk Bundle Payload" and forward it to a 'lost+found' endpoint.  For now we just drop it.
 
                             return self
-                                .drop_bundle(bundle, Some(ReasonCode::BlockUnintelligible))
+                                .drop_bundle(bundle, ReasonCode::BlockUnintelligible)
                                 .await;
                         }
                         Ok(hardy_bpv7::block::Payload::Borrowed(_)) => {

--- a/bpa/src/dispatcher/mod.rs
+++ b/bpa/src/dispatcher/mod.rs
@@ -121,21 +121,13 @@ impl Dispatcher {
             .as_ref()
             .trace_expect("Bundle without storage_name reached load_data");
 
-        if let Some(data) = self.store.load_data(storage_name).await {
-            Some(data)
-        } else {
-            self.store.tombstone_metadata(&bundle.bundle.id).await;
-            None
-        }
+        self.store.load_data(storage_name).await
     }
 
     #[cfg_attr(feature = "instrument", instrument(skip(self, bundle)))]
-    pub async fn drop_bundle(&self, bundle: bundle::Bundle, reason: Option<ReasonCode>) {
-        if let Some(reason) = reason {
-            metrics::counter!("bpa.bundle.dropped", "reason" => crate::otel_metrics::reason_label(&reason)).increment(1);
-            self.report_bundle_deletion(&bundle, reason).await;
-        }
-
+    pub async fn drop_bundle(&self, bundle: bundle::Bundle, reason: ReasonCode) {
+        metrics::counter!("bpa.bundle.dropped", "reason" => crate::otel_metrics::reason_label(&reason)).increment(1);
+        self.report_bundle_deletion(&bundle, reason).await;
         self.delete_bundle(bundle).await
     }
 

--- a/bpa/src/dispatcher/restart.rs
+++ b/bpa/src/dispatcher/restart.rs
@@ -8,8 +8,8 @@ impl Dispatcher {
         file_time: time::OffsetDateTime,
     ) {
         let Some(data) = self.store.load_data(&storage_name).await else {
-            // Data has gone while we were restarting
-            metrics::counter!("bpa.restart.lost").increment(1);
+            // Data has gone while we were restarting - the reaper hasn't started, so this is data loss.
+            // This is safe as the metadata restart will report it if it's in the metadata store
             return;
         };
 

--- a/bpa/src/otel_metrics.rs
+++ b/bpa/src/otel_metrics.rs
@@ -196,11 +196,6 @@ pub fn init() {
 
     // -- I. Restart/Recovery --
     metrics::describe_counter!(
-        "bpa.restart.lost",
-        metrics::Unit::Count,
-        "Lost bundles discovered during restart"
-    );
-    metrics::describe_counter!(
         "bpa.restart.duplicate",
         metrics::Unit::Count,
         "Duplicate bundles discovered during restart"

--- a/bpa/src/storage/reaper.rs
+++ b/bpa/src/storage/reaper.rs
@@ -173,7 +173,7 @@ impl Reaper {
                     dispatcher
                         .drop_bundle(
                             bundle,
-                            Some(hardy_bpv7::status_report::ReasonCode::LifetimeExpired),
+                            hardy_bpv7::status_report::ReasonCode::LifetimeExpired,
                         )
                         .await;
                 }

--- a/docs/user-docs/operations/observability.md
+++ b/docs/user-docs/operations/observability.md
@@ -126,7 +126,6 @@ Metrics are exported every 60 seconds to the collector.
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `bpa.restart.lost` | counter | Bundles lost during recovery (missing from both stores) |
 | `bpa.restart.duplicate` | counter | Duplicate bundles found during recovery |
 | `bpa.restart.orphan` | counter | Bundle data without matching metadata |
 | `bpa.restart.junk` | counter | Unreadable data cleaned up during recovery |


### PR DESCRIPTION
Rationalize the use of `drop_bundle` to mean "Drop with a status code" and `delete_bundle` to mean "Just get rid of the bundle silently".

This changes no logic, it just makes it absolutely clear what is happening