### PR TITLE
Add zero-copy support to Editor and use in Parser

### DIFF
--- a/bpa/src/dispatcher/admin.rs
+++ b/bpa/src/dispatcher/admin.rs
@@ -3,7 +3,7 @@ use hardy_bpv7::status_report::AdministrativeRecord;
 
 impl Dispatcher {
     #[cfg_attr(feature = "instrument", instrument(skip_all,fields(bundle.id = %bundle.bundle.id)))]
-    pub(super) async fn administrative_bundle(&self, mut bundle: bundle::Bundle, data: Bytes) {
+    pub(super) async fn administrative_bundle(&self, mut bundle: bundle::Bundle) {
         metrics::counter!("bpa.admin_record.received").increment(1);
 
         // This is a bundle for an Admin Endpoint
@@ -16,6 +16,14 @@ impl Dispatcher {
                 .drop_bundle(bundle, ReasonCode::BlockUnintelligible)
                 .await;
         }
+
+        let Some(data) = self.load_data(&bundle).await else {
+            if !bundle.has_expired() {
+                // Bundle data was deleted while queued - not reaped
+                self.drop_bundle(bundle, ReasonCode::DepletedStorage).await;
+            }
+            return;
+        };
 
         let payload_result = {
             let key_source = self.key_source(&bundle.bundle, &data);

--- a/bpa/src/dispatcher/admin.rs
+++ b/bpa/src/dispatcher/admin.rs
@@ -3,7 +3,7 @@ use hardy_bpv7::status_report::AdministrativeRecord;
 
 impl Dispatcher {
     #[cfg_attr(feature = "instrument", instrument(skip_all,fields(bundle.id = %bundle.bundle.id)))]
-    pub(super) async fn administrative_bundle(&self, mut bundle: bundle::Bundle) {
+    pub(super) async fn administrative_bundle(&self, bundle: bundle::Bundle) {
         metrics::counter!("bpa.admin_record.received").increment(1);
 
         // This is a bundle for an Admin Endpoint
@@ -17,11 +17,7 @@ impl Dispatcher {
                 .await;
         }
 
-        let Some(data) = self.load_data(&bundle).await else {
-            if !bundle.has_expired() {
-                // Bundle data was deleted while queued - not reaped
-                self.drop_bundle(bundle, ReasonCode::DepletedStorage).await;
-            }
+        let Some((mut bundle, data)) = self.load_data_or_drop(bundle).await else {
             return;
         };
 

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -3,6 +3,255 @@ use futures::{FutureExt, join, select_biased};
 use hardy_bpv7::status_report::ReasonCode;
 
 impl Dispatcher {
+    /// Entry point for bundles received from CLAs.
+    ///
+    /// Parses the CBOR-encoded bundle, validates the format, stores bundle data,
+    /// inserts initial metadata with `New` status, and queues for ingestion.
+    ///
+    /// # Bundle State
+    ///
+    /// - Initial status: `New`
+    /// - Next: `ingest_bundle()` → Ingress filter → `Dispatching`
+    ///
+    /// See [Bundle State Machine Design](../../docs/bundle_state_machine_design.md)
+    /// for the complete state transition diagram.
+    #[cfg_attr(feature = "instrument", instrument(skip_all))]
+    pub async fn receive_bundle(
+        self: &Arc<Self>,
+        mut data: Bytes,
+        ingress_cla: Option<Arc<str>>,
+        ingress_peer_node: Option<hardy_bpv7::eid::NodeId>,
+        ingress_peer_addr: Option<cla::ClaAddress>,
+    ) -> cla::Result<()> {
+        // TODO: Really should not return errors when the bundle content is garbage - it's not the CLAs responsibility to fix it!
+
+        // Count every bundle received from a CLA, before any validation
+        metrics::counter!("bpa.bundle.received").increment(1);
+        metrics::counter!("bpa.bundle.received.bytes").increment(data.len() as u64);
+
+        // Capture received_at as soon as possible
+        let received_at = time::OffsetDateTime::now_utc();
+
+        // Fast pre-check: reject empty, BPv6, and non-CBOR-array data
+        if let Err(e) = crate::cbor::precheck(&data) {
+            metrics::counter!("bpa.bundle.received.dropped").increment(1);
+            return Err(e.into());
+        }
+
+        // Parse the bundle
+        let (bundle, reason, report_unsupported) =
+            match hardy_bpv7::bundle::RewrittenBundle::parse(&data, self.key_provider()) {
+                Err(e) => {
+                    metrics::counter!("bpa.bundle.received.dropped").increment(1);
+                    return Err(e.into());
+                }
+                Ok(hardy_bpv7::bundle::RewrittenBundle::Valid {
+                    bundle,
+                    report_unsupported,
+                }) => (
+                    bundle::Bundle {
+                        metadata: bundle::BundleMetadata {
+                            storage_name: Some(self.store.save_data(data.clone()).await),
+                            read_only: bundle::ReadOnlyMetadata {
+                                received_at,
+                                ingress_peer_node,
+                                ingress_peer_addr,
+                                ingress_cla,
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        },
+                        bundle,
+                    },
+                    None,
+                    report_unsupported,
+                ),
+                Ok(hardy_bpv7::bundle::RewrittenBundle::Rewritten {
+                    bundle,
+                    new_data,
+                    report_unsupported,
+                    non_canonical: _,
+                }) => {
+                    debug!("Received bundle has been rewritten");
+
+                    data = match data.try_into_mut() {
+                        Ok(buf) => {
+                            let mut vec = buf.into();
+                            hardy_bpv7::editor::Chunk::flatten_inplace(new_data, &mut vec);
+                            Bytes::from(vec)
+                        }
+                        Err(original) => {
+                            Bytes::from(hardy_bpv7::editor::Chunk::flatten(new_data, &original))
+                        }
+                    };
+                    let storage_name = Some(self.store.save_data(data.clone()).await);
+
+                    (
+                        bundle::Bundle {
+                            metadata: bundle::BundleMetadata {
+                                storage_name,
+                                read_only: bundle::ReadOnlyMetadata {
+                                    received_at,
+                                    ingress_peer_node,
+                                    ingress_peer_addr,
+                                    ingress_cla,
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            },
+                            bundle,
+                        },
+                        None,
+                        report_unsupported,
+                    )
+                }
+                Ok(hardy_bpv7::bundle::RewrittenBundle::Invalid {
+                    bundle,
+                    reason,
+                    error,
+                }) => {
+                    debug!("Invalid bundle received: {error}");
+
+                    // Don't bother saving the bundle data, it's garbage
+                    (
+                        bundle::Bundle {
+                            metadata: bundle::BundleMetadata {
+                                read_only: bundle::ReadOnlyMetadata {
+                                    received_at,
+                                    ingress_peer_node,
+                                    ingress_peer_addr,
+                                    ingress_cla,
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            },
+                            bundle,
+                        },
+                        Some(reason),
+                        false,
+                    )
+                }
+            };
+
+        if !self.store.insert_metadata(&bundle).await {
+            // Bundle with matching id already exists in the metadata store
+            metrics::counter!("bpa.bundle.received.duplicate").increment(1);
+
+            // TODO: There may be custody transfer signalling that needs to happen here
+
+            // Drop the stored data and do not process further
+            if let Some(storage_name) = &bundle.metadata.storage_name {
+                self.store.delete_data(storage_name).await;
+            }
+            return Ok(());
+        }
+
+        // Report we have received the bundle
+        self.report_bundle_reception(
+            &bundle,
+            if let Some(reason) = &reason {
+                *reason
+            } else if report_unsupported {
+                ReasonCode::BlockUnsupported
+            } else {
+                ReasonCode::NoAdditionalInformation
+            },
+        )
+        .await;
+
+        if reason.is_some() {
+            // Invalid bundle — never entered the pipeline, just clean up
+            self.store.tombstone_metadata(&bundle.bundle.id).await;
+            metrics::counter!("bpa.bundle.received.dropped").increment(1);
+        } else {
+            // Spawn into processing pool for rate limiting
+            self.ingest_bundle(bundle, data).await;
+        }
+        Ok(())
+    }
+
+    /// Spawn bundle ingestion into the processing pool for rate limiting.
+    ///
+    /// This is a rate-limiting wrapper that spawns `ingest_bundle_inner()` into
+    /// the bounded processing pool. The function returns once the task *starts*,
+    /// not when it completes.
+    ///
+    /// # Crash Safety
+    ///
+    /// Because this returns before the Ingress filter completes, bundles remain
+    /// in `New` status until `ingest_bundle_inner()` checkpoints to `Dispatching`.
+    pub(super) async fn ingest_bundle(self: &Arc<Self>, bundle: bundle::Bundle, data: Bytes) {
+        metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
+
+        let dispatcher = self.clone();
+        hardy_async::spawn!(self.processing_pool, "ingest_bundle", async move {
+            dispatcher.ingest_bundle_inner(bundle, data).await
+        })
+        .await;
+    }
+
+    /// Core bundle ingestion logic: validation, Ingress filter, and checkpoint.
+    ///
+    /// # Processing Steps
+    ///
+    /// 1. Validate lifetime (drop if expired)
+    /// 2. Validate hop count (drop if exceeded)
+    /// 3. Execute Ingress filter hook
+    /// 4. Persist any filter mutations (crash-safe ordering)
+    /// 5. **Checkpoint**: Transition status to `Dispatching`
+    /// 6. Call `process_bundle()` for routing decision
+    ///
+    /// # Crash Safety
+    ///
+    /// The checkpoint to `Dispatching` is always persisted after the Ingress
+    /// filter completes. On restart, bundles in `New` status re-run from step 1,
+    /// while bundles in `Dispatching` skip directly to routing.
+    ///
+    /// See [Filter Subsystem Design](../../docs/filter_subsystem_design.md) for
+    /// filter execution details.
+    #[cfg_attr(feature = "instrument", instrument(skip_all,fields(bundle.id = %bundle.bundle.id)))]
+    pub(super) async fn ingest_bundle_inner(&self, mut bundle: bundle::Bundle, mut data: Bytes) {
+        // Ingress filter hook (includes bundle-validity: flags, lifetime, hop-count)
+        (bundle, data) = match self
+            .filter_engine
+            .exec(
+                filter::Hook::Ingress,
+                bundle,
+                data,
+                self.key_provider(),
+                &self.processing_pool,
+            )
+            .await
+        {
+            Ok(filter::ExecResult::Continue(mutation, mut bundle, data)) => {
+                if mutation.data {
+                    if let Some(storage_name) = &bundle.metadata.storage_name {
+                        self.store.replace_data(storage_name, data.clone()).await;
+                    }
+                }
+                // Always checkpoint to Dispatching (crash safety)
+                metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).decrement(1.0);
+                bundle.metadata.status = bundle::BundleStatus::Dispatching;
+                metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
+                self.store.update_metadata(&bundle).await;
+                (bundle, data)
+            }
+            Ok(filter::ExecResult::Drop(bundle, reason)) => {
+                if let Some(reason) = reason {
+                    return self.drop_bundle(bundle, reason).await;
+                } else {
+                    return self.delete_bundle(bundle).await;
+                }
+            }
+            Err(e) => {
+                error!("Ingress filter execution failed: {e}");
+                return;
+            }
+        };
+
+        self.process_bundle(bundle, data, self.cla_registry()).await;
+    }
+
     /// Queue a bundle for dispatch processing.
     /// The caller must ensure the bundle status is already `Dispatching`.
     pub(super) async fn dispatch_bundle(&self, bundle: bundle::Bundle) {

--- a/bpa/src/dispatcher/dispatch.rs
+++ b/bpa/src/dispatcher/dispatch.rs
@@ -1,257 +1,7 @@
 use super::*;
 use futures::{FutureExt, join, select_biased};
-use hardy_bpv7::status_report::ReasonCode;
 
 impl Dispatcher {
-    /// Entry point for bundles received from CLAs.
-    ///
-    /// Parses the CBOR-encoded bundle, validates the format, stores bundle data,
-    /// inserts initial metadata with `New` status, and queues for ingestion.
-    ///
-    /// # Bundle State
-    ///
-    /// - Initial status: `New`
-    /// - Next: `ingest_bundle()` → Ingress filter → `Dispatching`
-    ///
-    /// See [Bundle State Machine Design](../../docs/bundle_state_machine_design.md)
-    /// for the complete state transition diagram.
-    #[cfg_attr(feature = "instrument", instrument(skip_all))]
-    pub async fn receive_bundle(
-        self: &Arc<Self>,
-        mut data: Bytes,
-        ingress_cla: Option<Arc<str>>,
-        ingress_peer_node: Option<hardy_bpv7::eid::NodeId>,
-        ingress_peer_addr: Option<cla::ClaAddress>,
-    ) -> cla::Result<()> {
-        // TODO: Really should not return errors when the bundle content is garbage - it's not the CLAs responsibility to fix it!
-
-        // Count every bundle received from a CLA, before any validation
-        metrics::counter!("bpa.bundle.received").increment(1);
-        metrics::counter!("bpa.bundle.received.bytes").increment(data.len() as u64);
-
-        // Capture received_at as soon as possible
-        let received_at = time::OffsetDateTime::now_utc();
-
-        // Fast pre-check: reject empty, BPv6, and non-CBOR-array data
-        if let Err(e) = crate::cbor::precheck(&data) {
-            metrics::counter!("bpa.bundle.received.dropped").increment(1);
-            return Err(e.into());
-        }
-
-        // Parse the bundle
-        let (bundle, reason, report_unsupported) =
-            match hardy_bpv7::bundle::RewrittenBundle::parse(&data, self.key_provider()) {
-                Err(e) => {
-                    metrics::counter!("bpa.bundle.received.dropped").increment(1);
-                    return Err(e.into());
-                }
-                Ok(hardy_bpv7::bundle::RewrittenBundle::Valid {
-                    bundle,
-                    report_unsupported,
-                }) => (
-                    bundle::Bundle {
-                        metadata: bundle::BundleMetadata {
-                            storage_name: Some(self.store.save_data(data.clone()).await),
-                            read_only: bundle::ReadOnlyMetadata {
-                                received_at,
-                                ingress_peer_node,
-                                ingress_peer_addr,
-                                ingress_cla,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        },
-                        bundle,
-                    },
-                    None,
-                    report_unsupported,
-                ),
-                Ok(hardy_bpv7::bundle::RewrittenBundle::Rewritten {
-                    bundle,
-                    new_data,
-                    report_unsupported,
-                    non_canonical: _,
-                }) => {
-                    debug!("Received bundle has been rewritten");
-
-                    data = match data.try_into_mut() {
-                        Ok(buf) => {
-                            let mut vec = buf.into();
-                            hardy_bpv7::editor::Chunk::flatten_inplace(new_data, &mut vec);
-                            Bytes::from(vec)
-                        }
-                        Err(original) => {
-                            Bytes::from(hardy_bpv7::editor::Chunk::flatten(new_data, &original))
-                        }
-                    };
-                    let storage_name = Some(self.store.save_data(data.clone()).await);
-
-                    (
-                        bundle::Bundle {
-                            metadata: bundle::BundleMetadata {
-                                storage_name,
-                                read_only: bundle::ReadOnlyMetadata {
-                                    received_at,
-                                    ingress_peer_node,
-                                    ingress_peer_addr,
-                                    ingress_cla,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            },
-                            bundle,
-                        },
-                        None,
-                        report_unsupported,
-                    )
-                }
-                Ok(hardy_bpv7::bundle::RewrittenBundle::Invalid {
-                    bundle,
-                    reason,
-                    error,
-                }) => {
-                    debug!("Invalid bundle received: {error}");
-
-                    // Don't bother saving the bundle data, it's garbage
-                    (
-                        bundle::Bundle {
-                            metadata: bundle::BundleMetadata {
-                                read_only: bundle::ReadOnlyMetadata {
-                                    received_at,
-                                    ingress_peer_node,
-                                    ingress_peer_addr,
-                                    ingress_cla,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            },
-                            bundle,
-                        },
-                        Some(reason),
-                        false,
-                    )
-                }
-            };
-
-        if !self.store.insert_metadata(&bundle).await {
-            // Bundle with matching id already exists in the metadata store
-            metrics::counter!("bpa.bundle.received.duplicate").increment(1);
-
-            // TODO: There may be custody transfer signalling that needs to happen here
-
-            // Drop the stored data and do not process further
-            if let Some(storage_name) = &bundle.metadata.storage_name {
-                self.store.delete_data(storage_name).await;
-            }
-            return Ok(());
-        }
-
-        // Report we have received the bundle
-        self.report_bundle_reception(
-            &bundle,
-            if let Some(reason) = &reason {
-                *reason
-            } else if report_unsupported {
-                ReasonCode::BlockUnsupported
-            } else {
-                ReasonCode::NoAdditionalInformation
-            },
-        )
-        .await;
-
-        if reason.is_some() {
-            // Invalid bundle — never entered the pipeline, just clean up
-            self.store.tombstone_metadata(&bundle.bundle.id).await;
-            metrics::counter!("bpa.bundle.received.dropped").increment(1);
-        } else {
-            // Spawn into processing pool for rate limiting
-            self.ingest_bundle(bundle, data).await;
-        }
-        Ok(())
-    }
-
-    /// Spawn bundle ingestion into the processing pool for rate limiting.
-    ///
-    /// This is a rate-limiting wrapper that spawns `ingest_bundle_inner()` into
-    /// the bounded processing pool. The function returns once the task *starts*,
-    /// not when it completes.
-    ///
-    /// # Crash Safety
-    ///
-    /// Because this returns before the Ingress filter completes, bundles remain
-    /// in `New` status until `ingest_bundle_inner()` checkpoints to `Dispatching`.
-    pub(super) async fn ingest_bundle(self: &Arc<Self>, bundle: bundle::Bundle, data: Bytes) {
-        metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
-
-        let dispatcher = self.clone();
-        hardy_async::spawn!(self.processing_pool, "ingest_bundle", async move {
-            dispatcher.ingest_bundle_inner(bundle, data).await
-        })
-        .await;
-    }
-
-    /// Core bundle ingestion logic: validation, Ingress filter, and checkpoint.
-    ///
-    /// # Processing Steps
-    ///
-    /// 1. Validate lifetime (drop if expired)
-    /// 2. Validate hop count (drop if exceeded)
-    /// 3. Execute Ingress filter hook
-    /// 4. Persist any filter mutations (crash-safe ordering)
-    /// 5. **Checkpoint**: Transition status to `Dispatching`
-    /// 6. Call `process_bundle()` for routing decision
-    ///
-    /// # Crash Safety
-    ///
-    /// The checkpoint to `Dispatching` is always persisted after the Ingress
-    /// filter completes. On restart, bundles in `New` status re-run from step 1,
-    /// while bundles in `Dispatching` skip directly to routing.
-    ///
-    /// See [Filter Subsystem Design](../../docs/filter_subsystem_design.md) for
-    /// filter execution details.
-    #[cfg_attr(feature = "instrument", instrument(skip_all,fields(bundle.id = %bundle.bundle.id)))]
-    pub(super) async fn ingest_bundle_inner(&self, mut bundle: bundle::Bundle, mut data: Bytes) {
-        // Ingress filter hook (includes bundle-validity: flags, lifetime, hop-count)
-        (bundle, data) = match self
-            .filter_engine
-            .exec(
-                filter::Hook::Ingress,
-                bundle,
-                data,
-                self.key_provider(),
-                &self.processing_pool,
-            )
-            .await
-        {
-            Ok(filter::ExecResult::Continue(mutation, mut bundle, data)) => {
-                if mutation.data {
-                    if let Some(storage_name) = &bundle.metadata.storage_name {
-                        self.store.replace_data(storage_name, data.clone()).await;
-                    }
-                }
-                // Always checkpoint to Dispatching (crash safety)
-                metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).decrement(1.0);
-                bundle.metadata.status = bundle::BundleStatus::Dispatching;
-                metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
-                self.store.update_metadata(&bundle).await;
-                (bundle, data)
-            }
-            Ok(filter::ExecResult::Drop(bundle, reason)) => {
-                if let Some(reason) = reason {
-                    return self.drop_bundle(bundle, reason).await;
-                } else {
-                    return self.delete_bundle(bundle).await;
-                }
-            }
-            Err(e) => {
-                error!("Ingress filter execution failed: {e}");
-                return;
-            }
-        };
-
-        self.process_bundle(bundle, data, self.cla_registry()).await;
-    }
-
     /// Queue a bundle for dispatch processing.
     /// The caller must ensure the bundle status is already `Dispatching`.
     pub(super) async fn dispatch_bundle(&self, bundle: bundle::Bundle) {
@@ -270,16 +20,9 @@ impl Dispatcher {
         while let Ok(Some(bundle)) = dispatch_rx.recv_async().await {
             let dispatcher = self.clone();
             hardy_async::spawn!(self.processing_pool, "process_bundle", async move {
-                if let Some(data) = dispatcher.load_data(&bundle).await {
-                    dispatcher
-                        .process_bundle(bundle, data, dispatcher.cla_registry())
-                        .await;
-                } else if !bundle.has_expired() {
-                    // Bundle data was deleted while queued - not reaped
-                    dispatcher
-                        .drop_bundle(bundle, ReasonCode::DepletedStorage)
-                        .await;
-                }
+                dispatcher
+                    .process_bundle(bundle, dispatcher.cla_registry())
+                    .await;
             })
             .await;
         }
@@ -288,6 +31,10 @@ impl Dispatcher {
     }
 
     /// Routing decision hub: determines bundle disposition based on RIB lookup.
+    ///
+    /// Bundle data is loaded lazily — only the `AdminEndpoint` and `Deliver`
+    /// paths need it immediately. `Forward` defers loading to `forward_bundle`
+    /// (after dequeue from the peer's backpressure channel).
     ///
     /// # Route Results
     ///
@@ -305,7 +52,6 @@ impl Dispatcher {
     pub(super) async fn process_bundle(
         &self,
         mut bundle: bundle::Bundle,
-        data: Bytes,
         cla_registry: &cla::registry::ClaRegistry,
     ) {
         // Perform RIB lookup (sets bundle.metadata.next_hop for Forward results)
@@ -319,10 +65,7 @@ impl Dispatcher {
                     self.delete_bundle(bundle).await
                 }
             }
-            Some(rib::FindResult::AdminEndpoint) => {
-                // The bundle is for the Administrative Endpoint
-                self.administrative_bundle(bundle, data).await
-            }
+            Some(rib::FindResult::AdminEndpoint) => self.administrative_bundle(bundle).await,
             Some(rib::FindResult::Deliver(service)) => {
                 // Check for reassembly
                 if bundle.bundle.id.fragment_info.is_some() {
@@ -330,7 +73,7 @@ impl Dispatcher {
                     self.reassemble(bundle).await
                 } else {
                     // Bundle is for a local service
-                    self.deliver_bundle(service, bundle, data).await
+                    self.deliver_bundle(service, bundle).await
                 }
             }
             Some(rib::FindResult::Forward(peer)) => {
@@ -372,12 +115,7 @@ impl Dispatcher {
 
                             let dispatcher = dispatcher.clone();
                             hardy_async::spawn!(self.processing_pool, "poll_waiting_dispatcher", async move {
-                                if let Some(data) = dispatcher.load_data(&bundle).await {
-                                    dispatcher.process_bundle(bundle, data, dispatcher.cla_registry()).await
-                                } else if !bundle.has_expired() {
-                                    // Bundle data was deleted while queued - not reaped
-                                    dispatcher.drop_bundle(bundle, ReasonCode::DepletedStorage).await
-                                }
+                                dispatcher.process_bundle(bundle, dispatcher.cla_registry()).await
                             }).await;
                         }
                         _ = cancel_token.cancelled().fuse() => {

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -8,14 +8,10 @@ impl Dispatcher {
         peer: u32,
         queue: Option<u32>,
         cla_addr: &cla::ClaAddress,
-        mut bundle: bundle::Bundle,
+        bundle: bundle::Bundle,
     ) {
         // Get bundle data from store, now we know we need it!
-        let Some(data) = self.load_data(&bundle).await else {
-            if !bundle.has_expired() {
-                // Bundle data was deleted while queued - not reaped
-                self.drop_bundle(bundle, ReasonCode::DepletedStorage).await;
-            }
+        let Some((mut bundle, data)) = self.load_data_or_drop(bundle).await else {
             return;
         };
 

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -21,7 +21,7 @@ impl Dispatcher {
 
         // Increment Hop Count, etc...
         // We ignore the fact that a new bundle has been created, as it makes no difference below
-        let data = match self.update_extension_blocks(&bundle, &data) {
+        let data = match self.update_extension_blocks(&bundle, data) {
             Err(e) => {
                 warn!("Failed to update extension blocks: {e}");
                 self.store
@@ -43,7 +43,7 @@ impl Dispatcher {
             .exec(
                 filter::Hook::Egress,
                 bundle,
-                Bytes::from(data),
+                data,
                 self.key_provider(),
                 &self.processing_pool,
             )
@@ -93,10 +93,10 @@ impl Dispatcher {
     fn update_extension_blocks(
         &self,
         bundle: &bundle::Bundle,
-        source_data: &[u8],
-    ) -> Result<Box<[u8]>, hardy_bpv7::editor::Error> {
+        source_data: Bytes,
+    ) -> Result<Bytes, hardy_bpv7::editor::Error> {
         // Previous Node Block
-        let mut editor = hardy_bpv7::editor::Editor::new(&bundle.bundle, source_data)
+        let mut editor = hardy_bpv7::editor::Editor::new(&bundle.bundle, &source_data)
             .insert_block(hardy_bpv7::block::Type::PreviousNode)
             .map_err(|(_, e)| e)?
             .with_flags(hardy_bpv7::block::Flags {
@@ -153,6 +153,19 @@ impl Dispatcher {
                 .rebuild();
         }
 
-        editor.rebuild()
+        let chunks = editor.rebuild()?;
+
+        // Try to modify the source buffer in place if exclusively owned
+        match source_data.try_into_mut() {
+            Ok(buf) => {
+                let mut vec = buf.into();
+                hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut vec);
+                Ok(Bytes::from(vec))
+            }
+            Err(source_data) => Ok(Bytes::from(hardy_bpv7::editor::Chunk::flatten(
+                chunks,
+                &source_data,
+            ))),
+        }
     }
 }

--- a/bpa/src/dispatcher/ingress.rs
+++ b/bpa/src/dispatcher/ingress.rs
@@ -103,7 +103,17 @@ impl Dispatcher {
                 }) => {
                     debug!("Received bundle has been rewritten");
 
-                    data = Bytes::from(new_data);
+                    data = match data.try_into_mut() {
+                        Ok(buf) => {
+                            let mut vec = buf.into();
+                            hardy_bpv7::editor::Chunk::flatten_inplace(new_data, &mut vec);
+                            Bytes::from(vec)
+                        }
+                        Err(original) => {
+                            Bytes::from(hardy_bpv7::editor::Chunk::flatten(new_data, &original))
+                        }
+                    };
+
                     if let Some(storage_name) = &metadata.storage_name {
                         self.store.replace_data(storage_name, data.clone()).await;
                     } else {
@@ -186,11 +196,11 @@ impl Dispatcher {
     // See [Filter Subsystem Design](../../docs/filter_subsystem_design.md) for
     // filter execution details.
     #[cfg_attr(feature = "instrument", instrument(skip_all,fields(bundle.id = %bundle.bundle.id)))]
-    pub(super) async fn ingress_bundle(&self, mut bundle: bundle::Bundle, mut data: Bytes) {
+    pub(super) async fn ingress_bundle(&self, bundle: bundle::Bundle, data: Bytes) {
         metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
 
         // Ingress filter hook (includes bundle-validity: flags, lifetime, hop-count)
-        (bundle, data) = match self
+        match self
             .filter_engine
             .exec(
                 filter::Hook::Ingress,
@@ -204,27 +214,25 @@ impl Dispatcher {
             .trace_expect("Ingress filter execution failed")
         {
             filter::ExecResult::Continue(mutation, mut bundle, data) => {
-                if mutation.data {
-                    if let Some(storage_name) = &bundle.metadata.storage_name {
-                        self.store.replace_data(storage_name, data.clone()).await;
-                    }
+                if mutation.data
+                    && let Some(storage_name) = &bundle.metadata.storage_name
+                {
+                    self.store.replace_data(storage_name, data.clone()).await;
                 }
+
                 // Always checkpoint to Dispatching (crash safety)
                 metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).decrement(1.0);
                 bundle.metadata.status = bundle::BundleStatus::Dispatching;
                 metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&bundle.metadata.status)).increment(1.0);
                 self.store.update_metadata(&bundle).await;
-                (bundle, data)
-            }
-            filter::ExecResult::Drop(bundle, reason) => {
-                if let Some(reason) = reason {
-                    return self.drop_bundle(bundle, reason).await;
-                } else {
-                    return self.delete_bundle(bundle).await;
-                }
-            }
-        };
 
-        self.process_bundle(bundle, data, self.cla_registry()).await;
+                // Hand off to dispatch queue for fan-out via processing pool
+                self.dispatch_bundle(bundle).await
+            }
+            filter::ExecResult::Drop(bundle, Some(reason)) => {
+                self.drop_bundle(bundle, reason).await
+            }
+            filter::ExecResult::Drop(bundle, None) => self.delete_bundle(bundle).await,
+        }
     }
 }

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -174,8 +174,15 @@ impl Dispatcher {
         &self,
         service: Arc<services::registry::Service>,
         bundle: bundle::Bundle,
-        data: Bytes,
     ) {
+        let Some(data) = self.load_data(&bundle).await else {
+            if !bundle.has_expired() {
+                // Bundle data was deleted while queued - not reaped
+                self.drop_bundle(bundle, ReasonCode::DepletedStorage).await;
+            }
+            return;
+        };
+
         // Deliver filter hook
         let (bundle, data) = match self
             .filter_engine

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -96,8 +96,16 @@ impl Dispatcher {
         let checked = hardy_bpv7::bundle::CheckedBundle::parse(&data, self.key_provider())?;
 
         // Use rewritten data if canonicalization was needed
-        let (bundle, data) = if let Some(new_data) = checked.new_data {
-            (checked.bundle, Bytes::from(new_data))
+        let (bundle, data) = if let Some(chunks) = checked.new_data {
+            let data = match data.try_into_mut() {
+                Ok(buf) => {
+                    let mut vec = buf.into();
+                    hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut vec);
+                    Bytes::from(vec)
+                }
+                Err(original) => Bytes::from(hardy_bpv7::editor::Chunk::flatten(chunks, &original)),
+            };
+            (checked.bundle, data)
         } else {
             (checked.bundle, data)
         };

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -175,11 +175,7 @@ impl Dispatcher {
         service: Arc<services::registry::Service>,
         bundle: bundle::Bundle,
     ) {
-        let Some(data) = self.load_data(&bundle).await else {
-            if !bundle.has_expired() {
-                // Bundle data was deleted while queued - not reaped
-                self.drop_bundle(bundle, ReasonCode::DepletedStorage).await;
-            }
+        let Some((bundle, data)) = self.load_data_or_drop(bundle).await else {
             return;
         };
 

--- a/bpa/src/dispatcher/mod.rs
+++ b/bpa/src/dispatcher/mod.rs
@@ -119,10 +119,7 @@ impl Dispatcher {
     /// bundles are left for the reaper to handle (it will drop them with
     /// `LifetimeExpired`).
     #[cfg_attr(feature = "instrument", instrument(skip_all))]
-    async fn load_data_or_drop(
-        &self,
-        bundle: bundle::Bundle,
-    ) -> Option<(bundle::Bundle, Bytes)> {
+    async fn load_data_or_drop(&self, bundle: bundle::Bundle) -> Option<(bundle::Bundle, Bytes)> {
         let storage_name = bundle
             .metadata
             .storage_name

--- a/bpa/src/dispatcher/mod.rs
+++ b/bpa/src/dispatcher/mod.rs
@@ -114,15 +114,31 @@ impl Dispatcher {
         self.tasks.shutdown().await;
     }
 
+    /// Load bundle data, dropping the bundle with `DepletedStorage` if the
+    /// data is missing and the bundle has not yet expired. Expired-and-missing
+    /// bundles are left for the reaper to handle (it will drop them with
+    /// `LifetimeExpired`).
     #[cfg_attr(feature = "instrument", instrument(skip_all))]
-    async fn load_data(&self, bundle: &bundle::Bundle) -> Option<Bytes> {
+    async fn load_data_or_drop(
+        &self,
+        bundle: bundle::Bundle,
+    ) -> Option<(bundle::Bundle, Bytes)> {
         let storage_name = bundle
             .metadata
             .storage_name
             .as_ref()
-            .trace_expect("Bundle without storage_name reached load_data");
+            .trace_expect("Bundle without storage_name reached load_data_or_drop");
 
-        self.store.load_data(storage_name).await
+        match self.store.load_data(storage_name).await {
+            Some(data) => Some((bundle, data)),
+            None => {
+                if !bundle.has_expired() {
+                    // Bundle data was deleted while queued - not reaped
+                    self.drop_bundle(bundle, ReasonCode::DepletedStorage).await;
+                }
+                None
+            }
+        }
     }
 
     #[cfg_attr(feature = "instrument", instrument(skip(self, bundle)))]

--- a/bpa/src/filter/chain.rs
+++ b/bpa/src/filter/chain.rs
@@ -247,11 +247,14 @@ impl Level {
                         mutation.metadata = true;
                         bundle.metadata.writable = writable;
                     }
-                    if let Some(new_data) = new_data {
+                    if let Some(mut new_data) = new_data {
                         debug!("WriteFilter rewrote bundle data");
                         mutation.data = true;
                         let parsed = CheckedBundle::parse(&new_data, key_provider)?;
-                        *data = Bytes::from(parsed.new_data.map(Vec::from).unwrap_or(new_data));
+                        if let Some(chunks) = parsed.new_data {
+                            hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut new_data);
+                        }
+                        *data = Bytes::from(new_data);
                         bundle.bundle = parsed.bundle;
                     }
                 }

--- a/bpa/src/storage/adu_reassembly.rs
+++ b/bpa/src/storage/adu_reassembly.rs
@@ -178,13 +178,30 @@ impl Store {
             .total_adu_length;
 
         // Reassemble payload by writing each fragment at its ADU offset.
-        // Iteration order does not matter. Each fragment is placed by offset.
-        // TODO: There's a lot of mem copies going on here!
+        // Fragment 0's data is already in old_data — copy its payload first,
+        // then load remaining fragments. This avoids reloading fragment 0
+        // (load_data takes from storage, so a second load would return None).
         let adu_len = total_adu_length as usize;
         let mut new_data: Vec<u8> = vec![0; adu_len];
         let mut bytes_written: u64 = 0;
 
+        // Copy fragment 0's payload from old_data (already loaded)
+        {
+            let len = first.2.len();
+            if len > adu_len {
+                debug!("Fragment 0 extends beyond total ADU length: {}", first.0);
+                return None;
+            }
+            new_data[..len].copy_from_slice(&old_data[first.2.clone()]);
+            bytes_written = bytes_written.saturating_add(len as u64);
+        }
+
         for (bundle_id, storage_name, payload) in results.adus.values() {
+            // Skip fragment 0 — already copied above
+            if *storage_name == first.1 {
+                continue;
+            }
+
             let fi = bundle_id
                 .fragment_info
                 .as_ref()

--- a/bpa/src/storage/adu_reassembly.rs
+++ b/bpa/src/storage/adu_reassembly.rs
@@ -2,7 +2,7 @@ use core::ops::Range;
 
 use futures::{FutureExt, join, select_biased};
 use hardy_bpv7::bundle::Id as Bpv7Id;
-use hardy_bpv7::editor::Editor;
+use hardy_bpv7::editor::{Chunk, Editor};
 use time::OffsetDateTime;
 use trace_err::*;
 use tracing::{debug, error};
@@ -227,7 +227,7 @@ impl Store {
         };
 
         // Now rebuild
-        let new_data = match editor.update_block(1) {
+        let chunks = match editor.update_block(1) {
             Err((_, e)) => {
                 debug!("Missing payload block?: {e}");
                 return None;
@@ -237,12 +237,19 @@ impl Store {
                     debug!("Failed to rebuild bundle: {e}");
                     return None;
                 }
-                Ok(new_data) => new_data,
+                Ok(chunks) => chunks,
             },
         };
 
         // Write the rewritten bundle now for safety
-        let new_data = Bytes::from(new_data);
+        let new_data = match old_data.try_into_mut() {
+            Ok(buf) => {
+                let mut vec = buf.into();
+                Chunk::flatten_inplace(chunks, &mut vec);
+                Bytes::from(vec)
+            }
+            Err(original) => Bytes::from(Chunk::flatten(chunks, &original)),
+        };
         let new_storage_name = self.save_data(new_data.clone()).await;
         Some((new_storage_name, new_data))
     }
@@ -422,6 +429,7 @@ mod tests {
             .with_data(std::borrow::Cow::Borrowed(&b"Hello"[..]))
             .rebuild()
             .rebuild()
+            .map(|c| Chunk::flatten(c, &complete_data))
             .unwrap();
 
         // Create fragment 1: offset=5, total=10, payload="World"
@@ -438,6 +446,7 @@ mod tests {
             .with_data(std::borrow::Cow::Borrowed(&b"World"[..]))
             .rebuild()
             .rebuild()
+            .map(|c| Chunk::flatten(c, &complete_data))
             .unwrap();
 
         // Parse fragments back to get Bundle structs with correct block ranges

--- a/bpa/src/storage/bundle_mem.rs
+++ b/bpa/src/storage/bundle_mem.rs
@@ -77,13 +77,21 @@ impl BundleStorage for BundleMemStorage {
         Ok(())
     }
 
+    // SAFETY: load() is always the final storage access before delete().
+    // Taking from the cache (rather than cloning) ensures the returned Bytes
+    // has a single refcount, enabling in-place mutation via try_into_mut()
+    // in the Editor's flatten_inplace() path.
+    // bundle_mem has no crash recovery, so there is no secondary load path
+    // that could observe the missing entry.
     async fn load(&self, storage_name: &str) -> Result<Option<Bytes>> {
-        Ok(self
-            .inner
-            .lock()
-            .cache
-            .peek(storage_name)
-            .map(|(_, b)| b.clone()))
+        let mut inner = self.inner.lock();
+        let Some((_, data)) = inner.cache.pop(storage_name) else {
+            return Ok(None);
+        };
+        inner.capacity = inner.capacity.saturating_sub(data.len());
+        metrics::gauge!("bpa.mem_store.bundles").set(inner.cache.len() as f64);
+        metrics::gauge!("bpa.mem_store.bytes").set(inner.capacity as f64);
+        Ok(Some(data))
     }
 
     async fn save(&self, data: Bytes) -> Result<Arc<str>> {
@@ -168,7 +176,7 @@ mod tests {
         }
     }
 
-    // When capacity is exceeded, the LRU (oldest-accessed) bundle is evicted.
+    // When capacity is exceeded, the oldest-inserted bundle is evicted.
     #[tokio::test]
     async fn test_eviction_policy_fifo() {
         // 100 bytes capacity, min 0 bundles (so eviction is purely capacity-driven)
@@ -181,17 +189,17 @@ mod tests {
         // At this point, capacity = 100, exactly at limit
         let name3 = storage.save(Bytes::from(vec![3u8; 50])).await.unwrap();
 
-        // name3 pushed capacity to 150 > 100, so LRU (name1) should be evicted
+        // name3 pushed capacity to 150 > 100, so oldest (name1) should be evicted
         assert!(
             storage.load(&name1).await.unwrap().is_none(),
             "Oldest bundle should be evicted"
         );
+        // load() takes — subsequent loads of name2/name3 confirm they survived eviction
         assert!(storage.load(&name2).await.unwrap().is_some());
         assert!(storage.load(&name3).await.unwrap().is_some());
     }
 
-    // BundleMemStorage uses insertion-order LRU. load() uses peek() so does NOT
-    // promote entries. Eviction is strictly FIFO by insertion order.
+    // Eviction is strictly FIFO by insertion order.
     #[tokio::test]
     async fn test_eviction_policy_priority() {
         let storage = BundleMemStorage::new(&small_config(100, 0));
@@ -228,6 +236,7 @@ mod tests {
 
         // Total capacity = 150 > 100, but we have exactly min_bundles (3) entries
         // So no eviction should occur despite exceeding byte capacity
+        // load() takes, so each call confirms the entry survived then removes it
         assert!(
             storage.load(&name1).await.unwrap().is_some(),
             "min_bundles should protect from eviction"

--- a/bpa/src/storage/cached.rs
+++ b/bpa/src/storage/cached.rs
@@ -49,23 +49,21 @@ impl BundleStorage for CachedBundleStorage {
         self.inner.recover(tx).await
     }
 
+    // SAFETY: load() is always the final storage access before delete().
+    // Taking from the cache (rather than cloning) ensures the returned Bytes
+    // has a single refcount, enabling in-place mutation via try_into_mut()
+    // in the Editor's flatten_inplace() path.
+    // On a cache miss, the inner backend (disk/sqlite) returns a fresh
+    // Bytes with refcount=1, so we do not re-populate the cache.
     async fn load(&self, storage_name: &str) -> Result<Option<Bytes>> {
-        if let Some(data) = self.lru.lock().get(storage_name) {
+        if let Some(data) = self.lru.lock().pop(storage_name) {
             metrics::counter!("bpa.store.cache.hits").increment(1);
-            return Ok(Some(data.clone()));
+            return Ok(Some(data));
         }
 
         metrics::counter!("bpa.store.cache.misses").increment(1);
 
-        let Some(data) = self.inner.load(storage_name).await? else {
-            return Ok(None);
-        };
-
-        if self.is_cacheable(&data) {
-            self.lru.lock().put(storage_name.into(), data.clone());
-        }
-
-        Ok(Some(data))
+        self.inner.load(storage_name).await
     }
 
     async fn save(&self, data: Bytes) -> Result<Arc<str>> {

--- a/bpa/tests/pipeline.rs
+++ b/bpa/tests/pipeline.rs
@@ -127,30 +127,23 @@ impl services::Service for EchoService {
     async fn on_unregister(&self) {}
 
     async fn on_receive(&self, data: Bytes, _expiry: time::OffsetDateTime) {
-        let Ok(parsed) = hardy_bpv7::bundle::ParsedBundle::parse(&data, hardy_bpv7::bpsec::no_keys)
-        else {
-            return;
-        };
-
-        // Swap source and destination via Editor
-        let Ok(editor) = hardy_bpv7::editor::Editor::new(&parsed.bundle, &data)
-            .with_source(parsed.bundle.destination.clone())
-            .map_err(|(_, e)| e)
-        else {
-            return;
-        };
-        let Ok(editor) = editor
-            .with_destination(parsed.bundle.id.source.clone())
-            .map_err(|(_, e)| e)
-        else {
-            return;
-        };
-        let Ok(reply_data) = editor.rebuild() else {
-            return;
-        };
-
-        if let Some(sink) = self.sink.get() {
-            let _ = sink.send(reply_data.into()).await;
+        if let Some(sink) = self.sink.get()
+            && let Ok(parsed) =
+                hardy_bpv7::bundle::ParsedBundle::parse(&data, hardy_bpv7::bpsec::no_keys)
+            && let Ok(editor) = hardy_bpv7::editor::Editor::new(&parsed.bundle, &data)
+                .with_source(parsed.bundle.destination.clone())
+            && let Ok(editor) = editor.with_destination(parsed.bundle.id.source.clone())
+            && let Ok(chunks) = editor.rebuild()
+        {
+            let reply = match data.try_into_mut() {
+                Ok(buf) => {
+                    let mut vec = buf.into();
+                    hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut vec);
+                    Bytes::from(vec)
+                }
+                Err(original) => Bytes::from(hardy_bpv7::editor::Chunk::flatten(chunks, &original)),
+            };
+            let _ = sink.send(reply).await;
         }
     }
 

--- a/bpv7/fuzz/src/bundle.rs
+++ b/bpv7/fuzz/src/bundle.rs
@@ -58,6 +58,7 @@ pub fn test_bundle(orig_data: &[u8]) {
     if let Ok(RewrittenBundle::Rewritten { new_data, .. }) =
         RewrittenBundle::parse_with_keys(orig_data, keys)
     {
+        let new_data = hardy_bpv7::editor::Chunk::flatten(new_data, orig_data);
         match RewrittenBundle::parse_with_keys(&new_data, keys) {
             Ok(RewrittenBundle::Valid { .. }) => {}
             Ok(RewrittenBundle::Rewritten { .. }) => {

--- a/bpv7/src/block.rs
+++ b/bpv7/src/block.rs
@@ -325,12 +325,6 @@ impl Block {
         )?));
         Ok(())
     }
-
-    /// Copies the entire block from a source byte array to a new CBOR array.
-    /// This is an internal function used when modifying a bundle.
-    pub(crate) fn copy_whole(&mut self, source_data: &[u8], array: &mut hardy_cbor::encode::Array) {
-        self.extent = array.emit(&hardy_cbor::encode::Raw(&source_data[self.extent.clone()]));
-    }
 }
 
 /// A helper struct used during bundle parsing to associate a block with its block number.

--- a/bpv7/src/bpsec/encryptor.rs
+++ b/bpv7/src/bpsec/encryptor.rs
@@ -180,11 +180,18 @@ impl<'a> Encryptor<'a> {
 
     /// Applies all queued encryption operations and rebuilds the bundle as raw bytes.
     pub fn rebuild(self) -> Result<Box<[u8]>, Error> {
+        self.rebuild_editor()?.rebuild().map_err(Into::into)
+    }
+
+    /// Applies all queued encryption operations and rebuilds the bundle,
+    /// returning both the updated `Bundle` and the serialized data.
+    pub fn rebuild_bundle(self) -> Result<(bundle::Bundle, Box<[u8]>), Error> {
+        self.rebuild_editor()?.rebuild_bundle().map_err(Into::into)
+    }
+
+    fn rebuild_editor(self) -> Result<editor::Editor<'a>, Error> {
         if self.templates.is_empty() {
-            // No signing to do
-            return editor::Editor::new(self.original, self.source_data)
-                .rebuild()
-                .map_err(Into::into);
+            return Ok(editor::Editor::new(self.original, self.source_data));
         }
 
         // Reorder and accumulate BCB operations if sharing is possible
@@ -251,7 +258,7 @@ impl<'a> Encryptor<'a> {
 
             // Reserve a block number for the BCB block
             let b = editor
-                .push_block(block::Type::BlockSecurity)
+                .alloc_block(block::Type::BlockSecurity)
                 .map_err(|(_, e)| e)?
                 .with_crc_type(crc::CrcType::None)
                 .with_flags(block::Flags {
@@ -287,6 +294,9 @@ impl<'a> Encryptor<'a> {
                 operations.insert(target, op);
             }
 
+            // Set BCB coverage on target blocks before operations is moved
+            let target_blocks: SmallVec<[u64; 4]> = operations.keys().copied().collect();
+
             // Rewrite the BCB with the real data
             editor = editor_bs
                 .editor
@@ -301,9 +311,13 @@ impl<'a> Encryptor<'a> {
                     .into(),
                 )
                 .rebuild();
+
+            for target in target_blocks {
+                editor.set_bcb_target(target, source);
+            }
         }
 
-        editor.rebuild().map_err(Into::into)
+        Ok(editor)
     }
 }
 

--- a/bpv7/src/bpsec/encryptor.rs
+++ b/bpv7/src/bpsec/encryptor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use editor::{Chunk, Editor};
 use smallvec::SmallVec;
 use thiserror::Error;
 
@@ -180,18 +181,26 @@ impl<'a> Encryptor<'a> {
 
     /// Applies all queued encryption operations and rebuilds the bundle as raw bytes.
     pub fn rebuild(self) -> Result<Box<[u8]>, Error> {
-        self.rebuild_editor()?.rebuild().map_err(Into::into)
+        let source_data = self.source_data;
+        self.rebuild_editor()?
+            .rebuild()
+            .map(|c| Chunk::flatten(c, source_data))
+            .map_err(Error::from)
     }
 
     /// Applies all queued encryption operations and rebuilds the bundle,
     /// returning both the updated `Bundle` and the serialized data.
     pub fn rebuild_bundle(self) -> Result<(bundle::Bundle, Box<[u8]>), Error> {
-        self.rebuild_editor()?.rebuild_bundle().map_err(Into::into)
+        let source_data = self.source_data;
+        self.rebuild_editor()?
+            .rebuild_bundle()
+            .map(|(b, c)| (b, Chunk::flatten(c, source_data)))
+            .map_err(Error::from)
     }
 
-    fn rebuild_editor(self) -> Result<editor::Editor<'a>, Error> {
+    fn rebuild_editor(self) -> Result<Editor<'a>, Error> {
         if self.templates.is_empty() {
-            return Ok(editor::Editor::new(self.original, self.source_data));
+            return Ok(Editor::new(self.original, self.source_data));
         }
 
         // Reorder and accumulate BCB operations if sharing is possible
@@ -232,7 +241,7 @@ impl<'a> Encryptor<'a> {
                 .map(|((bpsec_source, context), targets)| (bpsec_source, context, targets)),
         );
 
-        let mut editor = editor::Editor::new(self.original, self.source_data);
+        let mut editor = Editor::new(self.original, self.source_data);
 
         // Now build BCB blocks
         for (bpsec_source, context, targets) in bcbs {

--- a/bpv7/src/bpsec/rfc9173/test.rs
+++ b/bpv7/src/bpsec/rfc9173/test.rs
@@ -1,9 +1,11 @@
+#![cfg(test)]
+
 use super::*;
 use crate::bpsec::{encryptor, key, signer};
 use crate::builder::Builder;
 use crate::bundle;
 use crate::creation_timestamp::CreationTimestamp;
-use crate::editor::Editor;
+use crate::editor::{Chunk, Editor};
 
 // Helper function to count blocks of a specific type
 fn count_blocks_of_type(bundle: &bundle::Bundle, block_type: crate::block::Type) -> usize {
@@ -459,6 +461,7 @@ fn test_rfc9173_decrypt_payload_leaves_bib_encrypted() {
         .expect("Failed to remove BCB from payload");
     let decrypted_bytes = editor
         .rebuild()
+        .map(|c| Chunk::flatten(c, &encrypted_bytes))
         .expect("Failed to rebuild after removing payload BCB");
 
     let parsed_decrypted = bundle::ParsedBundle::parse_with_keys(&decrypted_bytes, &all_keys)
@@ -554,6 +557,7 @@ fn test_bib_removal_and_readd() {
         .expect("Failed to remove BIB");
     let unsigned_bytes = editor
         .rebuild()
+        .map(|c| Chunk::flatten(c, &signed_bytes))
         .expect("Failed to rebuild after BIB removal");
 
     let parsed_unsigned = bundle::ParsedBundle::parse_with_keys(&unsigned_bytes, &keys)
@@ -791,6 +795,7 @@ fn test_bcb_without_bib_removal() {
         .expect("Failed to remove BCB");
     let decrypted_bytes = editor
         .rebuild()
+        .map(|c| Chunk::flatten(c, &encrypted_bytes))
         .expect("Failed to rebuild after BCB removal");
 
     let parsed_decrypted = bundle::ParsedBundle::parse_with_keys(&decrypted_bytes, &keys)

--- a/bpv7/src/bpsec/signer.rs
+++ b/bpv7/src/bpsec/signer.rs
@@ -1,4 +1,5 @@
 use super::*;
+use editor::{Chunk, Editor};
 use smallvec::SmallVec;
 use thiserror::Error;
 
@@ -122,19 +123,27 @@ impl<'a> Signer<'a> {
 
     /// Applies all queued signing operations and rebuilds the bundle as raw bytes.
     pub fn rebuild(self) -> Result<Box<[u8]>, Error> {
-        self.rebuild_editor()?.rebuild().map_err(Into::into)
+        let source_data = self.source_data;
+        self.rebuild_editor()?
+            .rebuild()
+            .map(|c| Chunk::flatten(c, source_data))
+            .map_err(Error::from)
     }
 
     /// Applies all queued signing operations and rebuilds the bundle,
     /// returning both the updated `Bundle` and the serialized data.
     pub fn rebuild_bundle(self) -> Result<(bundle::Bundle, Box<[u8]>), Error> {
-        self.rebuild_editor()?.rebuild_bundle().map_err(Into::into)
+        let source_data = self.source_data;
+        self.rebuild_editor()?
+            .rebuild_bundle()
+            .map(|(b, c)| (b, Chunk::flatten(c, source_data)))
+            .map_err(Error::from)
     }
 
-    fn rebuild_editor(self) -> Result<editor::Editor<'a>, Error> {
+    fn rebuild_editor(self) -> Result<Editor<'a>, Error> {
         if self.templates.is_empty() {
             // No signing to do
-            return Ok(editor::Editor::new(self.original, self.source_data));
+            return Ok(Editor::new(self.original, self.source_data));
         }
 
         // Reorder and accumulate BIB operations
@@ -147,7 +156,7 @@ impl<'a> Signer<'a> {
                 .push((block_number, template.key));
         }
 
-        let mut editor = editor::Editor::new(self.original, self.source_data);
+        let mut editor = Editor::new(self.original, self.source_data);
 
         // Now build BIB blocks
         for ((bpsec_source, context), targets) in blocks {

--- a/bpv7/src/bpsec/signer.rs
+++ b/bpv7/src/bpsec/signer.rs
@@ -122,11 +122,19 @@ impl<'a> Signer<'a> {
 
     /// Applies all queued signing operations and rebuilds the bundle as raw bytes.
     pub fn rebuild(self) -> Result<Box<[u8]>, Error> {
+        self.rebuild_editor()?.rebuild().map_err(Into::into)
+    }
+
+    /// Applies all queued signing operations and rebuilds the bundle,
+    /// returning both the updated `Bundle` and the serialized data.
+    pub fn rebuild_bundle(self) -> Result<(bundle::Bundle, Box<[u8]>), Error> {
+        self.rebuild_editor()?.rebuild_bundle().map_err(Into::into)
+    }
+
+    fn rebuild_editor(self) -> Result<editor::Editor<'a>, Error> {
         if self.templates.is_empty() {
             // No signing to do
-            return editor::Editor::new(self.original, self.source_data)
-                .rebuild()
-                .map_err(Into::into);
+            return Ok(editor::Editor::new(self.original, self.source_data));
         }
 
         // Reorder and accumulate BIB operations
@@ -166,7 +174,7 @@ impl<'a> Signer<'a> {
 
             // Reserve a block number for the BIB block
             let b = editor
-                .push_block(block::Type::BlockIntegrity)
+                .alloc_block(block::Type::BlockIntegrity)
                 .map_err(|(_, e)| e)?
                 .with_crc_type(crc::CrcType::None);
 
@@ -203,9 +211,14 @@ impl<'a> Signer<'a> {
                 .map_err(|(_, e)| e)?
                 .with_data(hardy_cbor::encode::emit(&operation_set).0.into())
                 .rebuild();
+
+            // Set BIB coverage on target blocks
+            for target in operation_set.operations.keys() {
+                editor.set_bib_target(*target, source);
+            }
         }
 
-        editor.rebuild().map_err(Into::into)
+        Ok(editor)
     }
 }
 

--- a/bpv7/src/builder.rs
+++ b/bpv7/src/builder.rs
@@ -140,7 +140,12 @@ impl<'a> Builder<'a> {
 
         let data = hardy_cbor::encode::try_emit_array(None, |a| {
             // Emit primary block
-            bundle.emit_primary_block(a)?;
+            let primary_bytes = bundle::primary_block::PrimaryBlock::emit(&bundle)?;
+            let extent = a.emit(&hardy_cbor::encode::Raw(&primary_bytes));
+            bundle.blocks.insert(
+                0,
+                bundle::primary_block::PrimaryBlock::as_block(bundle.crc_type, extent),
+            );
 
             // Emit extension blocks
             for (block_number, block) in self.extensions.into_iter().enumerate() {
@@ -228,6 +233,33 @@ impl<'a> BlockTemplate<'a> {
             },
             data,
         }
+    }
+
+    /// Builds the [`block::Block`] to standalone bytes.
+    pub fn build_to_vec(mut self, block_number: u64) -> Result<(block::Block, Vec<u8>), Error> {
+        let data = self.data.take().ok_or(Error::NoBlockData)?;
+        let bytes = crc::append_crc_value(
+            self.block.crc_type,
+            hardy_cbor::encode::emit_array(
+                Some(if let crc::CrcType::None = self.block.crc_type {
+                    5
+                } else {
+                    6
+                }),
+                |a| {
+                    a.emit(&self.block.block_type);
+                    a.emit(&block_number);
+                    a.emit(&self.block.flags);
+                    a.emit(&self.block.crc_type);
+                    self.block.data = a.emit(&hardy_cbor::encode::Bytes(&data));
+                    if !matches!(self.block.crc_type, crc::CrcType::None) {
+                        a.skip_value();
+                    }
+                },
+            ),
+        )
+        .map_err(|e| Error::InternalError(e.into()))?;
+        Ok((self.block, bytes))
     }
 
     /// Builds the [`block::Block`] with the given block number and array.

--- a/bpv7/src/bundle/mod.rs
+++ b/bpv7/src/bundle/mod.rs
@@ -9,7 +9,7 @@ use super::*;
 use base64::prelude::*;
 
 mod parse;
-mod primary_block;
+pub(crate) mod primary_block;
 
 /// Holds fragmentation information for a bundle.
 ///
@@ -447,23 +447,6 @@ pub struct Bundle {
 }
 
 impl Bundle {
-    /// Emits the primary block into a CBOR array during bundle creation.
-    pub(crate) fn emit_primary_block(
-        &mut self,
-        array: &mut hardy_cbor::encode::Array,
-    ) -> Result<(), Error> {
-        let extent = array.emit(&hardy_cbor::encode::Raw(
-            &primary_block::PrimaryBlock::emit(self)?,
-        ));
-
-        // Replace existing block record
-        self.blocks.insert(
-            0,
-            primary_block::PrimaryBlock::as_block(self.crc_type, extent),
-        );
-        Ok(())
-    }
-
     /// Retrieves the payload of a specific block by its number.
     ///
     /// This method handles the complexity of block-level security. If the target
@@ -651,7 +634,7 @@ pub enum RewrittenBundle {
     /// is requested for an unsupported block and if the rewrite was due to non-canonical CBOR.
     Rewritten {
         bundle: Bundle,
-        new_data: Box<[u8]>,
+        new_data: Vec<editor::Chunk>,
         report_unsupported: bool,
         non_canonical: bool,
     },
@@ -691,5 +674,5 @@ pub struct CheckedBundle {
     /// The parsed bundle structure.
     pub bundle: Bundle,
     /// The rewritten bundle data if canonicalization was needed, `None` if already canonical.
-    pub new_data: Option<Box<[u8]>>,
+    pub new_data: Option<Vec<editor::Chunk>>,
 }

--- a/bpv7/src/bundle/parse.rs
+++ b/bpv7/src/bundle/parse.rs
@@ -6,6 +6,7 @@ canonicalization issues.
 */
 
 use super::*;
+use editor::{Chunk, Editor};
 use error::CaptureFieldErr;
 use smallvec::SmallVec;
 use thiserror::Error;
@@ -650,7 +651,7 @@ impl<'a> BlockParse<'a> {
     /// Rewrites the entire bundle if any blocks were non-canonical or removed.
     /// Returns `None` if no rewrite was necessary.
     #[allow(clippy::type_complexity)]
-    fn finish(mut self, bundle: &mut Bundle) -> Result<(Option<Box<[u8]>>, bool), Error> {
+    fn finish(mut self, bundle: &mut Bundle) -> Result<(Option<Vec<Chunk>>, bool), Error> {
         bundle.blocks = core::mem::take(&mut self.blocks);
 
         // Preserve mode: never rewrite
@@ -665,7 +666,7 @@ impl<'a> BlockParse<'a> {
         }
 
         // Construct Editor from the bundle and its source data
-        let mut editor = editor::Editor::new(bundle, self.source_data);
+        let mut editor = Editor::new(bundle, self.source_data);
 
         // Handle non-canonical primary block
         if let Some(Some(data)) = self.noncanonical_blocks.remove(&0) {
@@ -704,12 +705,12 @@ impl<'a> BlockParse<'a> {
         }
 
         // Rebuild and update the bundle
-        let (new_bundle, data) = editor
+        let (new_bundle, chunks) = editor
             .rebuild_bundle()
             .unwrap_or_else(|e| panic!("Editor rebuild failed on parsed bundle: {e}"));
         *bundle = new_bundle;
 
-        Ok((Some(data), non_canonical))
+        Ok((Some(chunks), non_canonical))
     }
 }
 
@@ -722,7 +723,7 @@ fn parse_blocks(
     source_data: &[u8],
     key_source: &dyn bpsec::key::KeySource,
     mode: ParseMode,
-) -> Result<(Option<Box<[u8]>>, bool, bool), Error> {
+) -> Result<(Option<Vec<Chunk>>, bool, bool), Error> {
     let mut parser = BlockParse::new(source_data, mode);
 
     // Steal the primary block, we put it back later
@@ -830,7 +831,7 @@ fn parse_bundle_with_provider<F>(
     canonical: bool,
     tags: &[u64],
     mode: ParseMode,
-) -> Result<(Bundle, Option<Box<[u8]>>, bool, bool), (Option<Bundle>, Error)>
+) -> Result<(Bundle, Option<Vec<Chunk>>, bool, bool), (Option<Bundle>, Error)>
 where
     F: FnOnce(&Bundle, &[u8]) -> Box<dyn bpsec::key::KeySource>,
 {
@@ -863,7 +864,7 @@ fn parse_bundle_with_keys(
     canonical: bool,
     tags: &[u64],
     mode: ParseMode,
-) -> Result<(Bundle, Option<Box<[u8]>>, bool, bool), (Option<Bundle>, Error)> {
+) -> Result<(Bundle, Option<Vec<Chunk>>, bool, bool), (Option<Bundle>, Error)> {
     let (mut bundle, canonical) = parse_primary_block(block_array, canonical, tags)?;
     match parse_blocks(&mut bundle, canonical, block_array, data, key_source, mode) {
         Ok((new_data, non_canonical, report_unsupported)) => {
@@ -1388,8 +1389,9 @@ mod test {
             } => {
                 assert!(non_canonical, "Should flag as non-canonical rewrite");
                 // Rewritten data should not have the tag
+                let flattened = editor::Chunk::flatten(new_data, &tagged);
                 assert_eq!(
-                    new_data[0], 0x9F,
+                    flattened[0], 0x9F,
                     "Rewritten bundle should start with indefinite array"
                 );
             }

--- a/bpv7/src/bundle/parse.rs
+++ b/bpv7/src/bundle/parse.rs
@@ -647,86 +647,69 @@ impl<'a> BlockParse<'a> {
         }
     }
 
-    /// Emits a single block into a CBOR array, handling canonical and non-canonical data.
-    fn emit_block(
-        &mut self,
-        block: &mut block::Block,
-        block_number: u64,
-        array: &mut hardy_cbor::encode::Array,
-    ) -> Result<(), Error> {
-        match self.noncanonical_blocks.remove(&block_number) {
-            Some(Some(payload)) => block.emit(block_number, &payload, array),
-            Some(None) => block.emit(
-                block_number,
-                &self.source_data[block.payload_range()],
-                array,
-            ),
-            None => {
-                block.copy_whole(self.source_data, array);
-                Ok(())
-            }
-        }
-    }
-
     /// Rewrites the entire bundle if any blocks were non-canonical or removed.
     /// Returns `None` if no rewrite was necessary.
     #[allow(clippy::type_complexity)]
     fn finish(mut self, bundle: &mut Bundle) -> Result<(Option<Box<[u8]>>, bool), Error> {
+        bundle.blocks = core::mem::take(&mut self.blocks);
+
         // Preserve mode: never rewrite
         if matches!(self.mode, ParseMode::Preserve) {
-            bundle.blocks = self.blocks;
             return Ok((None, !self.noncanonical_blocks.is_empty()));
         }
 
         // Canonicalize/Full: check if we need to rewrite
-        if self.noncanonical_blocks.is_empty() && self.blocks_to_remove.is_empty() {
-            bundle.blocks = self.blocks;
+        let non_canonical = !self.noncanonical_blocks.is_empty();
+        if !non_canonical && self.blocks_to_remove.is_empty() {
             return Ok((None, false));
         }
 
-        let non_canonical = !self.noncanonical_blocks.is_empty();
+        // Construct Editor from the bundle and its source data
+        let mut editor = editor::Editor::new(bundle, self.source_data);
 
-        // Drop any blocks marked for removal
-        self.blocks
-            .retain(|block_number, _| !self.blocks_to_remove.contains(block_number));
+        // Handle non-canonical primary block
+        if let Some(Some(data)) = self.noncanonical_blocks.remove(&0) {
+            editor.set_canonical_primary(data.into_vec().into());
+        }
 
-        // Write out the new bundle
-        Ok((
-            Some(
-                hardy_cbor::encode::try_emit_array(None, |block_array| {
-                    // Primary block first
-                    let mut primary_block = self.blocks.remove(&0).expect("Missing primary block!");
+        // Remove blocks marked for removal
+        for block_number in &self.blocks_to_remove {
+            editor = editor
+                .remove_block_inner(*block_number)
+                .unwrap_or_else(|(_, e)| {
+                    panic!("Editor remove_block failed on parsed bundle: {e}")
+                });
+        }
 
-                    primary_block.extent =
-                        if let Some(Some(payload)) = self.noncanonical_blocks.remove(&0) {
-                            block_array.emit(&hardy_cbor::encode::Raw(&payload))
-                        } else {
-                            block_array.emit(&hardy_cbor::encode::Raw(
-                                &self.source_data[primary_block.extent],
-                            ))
-                        };
-                    primary_block.data = primary_block.extent.clone();
-                    bundle.blocks.insert(0, primary_block);
+        // Apply non-canonical block rewrites
+        for (block_number, payload) in self.noncanonical_blocks {
+            // Skip blocks that were already removed
+            if self.blocks_to_remove.contains(&block_number) {
+                continue;
+            }
 
-                    // Stash payload block
-                    let mut payload_block = self.blocks.remove(&1).expect("Missing payload block!");
+            let mut bb = editor
+                .update_block_inner(block_number)
+                .unwrap_or_else(|(_, e)| {
+                    panic!("Editor update_block failed on parsed bundle: {e}")
+                });
 
-                    // Emit all blocks
-                    for (block_number, mut block) in core::mem::take(&mut self.blocks) {
-                        self.emit_block(&mut block, block_number, block_array)?;
-                        bundle.blocks.insert(block_number, block);
-                    }
+            // If there's replacement payload data, use it; otherwise
+            // update_block_inner already pre-populated the original payload
+            if let Some(data) = payload {
+                bb = bb.with_data(data.into_vec().into());
+            }
 
-                    // And final payload block
-                    self.emit_block(&mut payload_block, 1, block_array)?;
-                    bundle.blocks.insert(1, payload_block);
+            editor = bb.rebuild();
+        }
 
-                    Ok::<_, Error>(())
-                })?
-                .into(),
-            ),
-            non_canonical,
-        ))
+        // Rebuild and update the bundle
+        let (new_bundle, data) = editor
+            .rebuild_bundle()
+            .unwrap_or_else(|e| panic!("Editor rebuild failed on parsed bundle: {e}"));
+        *bundle = new_bundle;
+
+        Ok((Some(data), non_canonical))
     }
 }
 

--- a/bpv7/src/editor.rs
+++ b/bpv7/src/editor.rs
@@ -68,7 +68,9 @@ impl Chunk {
     /// Flatten chunks into a contiguous byte buffer, wrapping in a CBOR
     /// indefinite-length array (0x9F prefix, 0xFF suffix).
     pub fn flatten(chunks: Vec<Self>, source: &[u8]) -> Box<[u8]> {
-        let mut result = vec![0x9F];
+        let total_len = 2 + chunks.iter().map(|c| c.len()).sum::<usize>();
+        let mut result = Vec::with_capacity(total_len);
+        result.push(0x9F);
         for c in chunks {
             match c {
                 Chunk::Unchanged(extent) => {
@@ -81,6 +83,7 @@ impl Chunk {
             }
         }
         result.push(0xFF);
+        debug_assert_eq!(result.len(), total_len);
         result.into()
     }
 

--- a/bpv7/src/editor.rs
+++ b/bpv7/src/editor.rs
@@ -1,5 +1,6 @@
 use super::*;
 use alloc::borrow::Cow;
+use core::ops::Range;
 use smallvec::SmallVec;
 use thiserror::Error;
 
@@ -47,6 +48,207 @@ impl From<bpsec::Error> for Error {
 impl From<error::Error> for Error {
     fn from(e: error::Error) -> Self {
         Error::Builder(builder::Error::InternalError(e))
+    }
+}
+
+#[derive(Debug)]
+pub enum Chunk {
+    Unchanged(Range<usize>),
+    New(Box<[u8]>),
+}
+
+impl Chunk {
+    fn len(&self) -> usize {
+        match self {
+            Chunk::Unchanged(range) => range.len(),
+            Chunk::New(data) => data.len(),
+        }
+    }
+
+    /// Flatten chunks into a contiguous byte buffer, wrapping in a CBOR
+    /// indefinite-length array (0x9F prefix, 0xFF suffix).
+    pub fn flatten(chunks: Vec<Self>, source: &[u8]) -> Box<[u8]> {
+        let mut result = vec![0x9F];
+        for c in chunks {
+            match c {
+                Chunk::Unchanged(extent) => {
+                    result.extend_from_slice(&source[extent]);
+                }
+                Chunk::New(items) => {
+                    result.extend(items);
+                }
+            }
+        }
+        result.push(0xFF);
+        result.into()
+    }
+
+    /// Modify the source buffer in place to produce the rebuilt bundle.
+    ///
+    /// This avoids allocation when the assembled chunks fit within the
+    /// original buffer. Unchanged ranges that are already at the correct
+    /// position are left untouched; New chunks overwrite the gaps.
+    /// The buffer is resized (truncated or extended) if the total output
+    /// length differs from the source.
+    pub fn flatten_inplace(chunks: Vec<Self>, source: &mut Vec<u8>) {
+        // Single pass: compute total length and check if backward copy is needed
+        let mut content_len: usize = 0;
+        let mut write_pos: usize = 1; // after 0x9F
+        let mut needs_backward = false;
+        for chunk in &chunks {
+            let len = chunk.len();
+            if !needs_backward
+                && let Chunk::Unchanged(range) = chunk
+                && write_pos > range.start
+            {
+                needs_backward = true;
+            }
+            content_len += len;
+            write_pos += len;
+        }
+        let total_len = 1 + content_len + 1; // 0x9F prefix + content + 0xFF suffix
+
+        // Ensure buffer is large enough
+        if total_len > source.len() {
+            source.resize(total_len, 0);
+        }
+
+        source[0] = 0x9F;
+
+        if needs_backward {
+            // Backward pass: process chunks from back to front to avoid
+            // overwriting source data that hasn't been read yet
+            let mut write_end = 1 + content_len;
+            for chunk in chunks.iter().rev() {
+                match chunk {
+                    Chunk::Unchanged(range) => {
+                        write_end -= range.len();
+                        if range.start != write_end {
+                            source.copy_within(range.clone(), write_end);
+                        }
+                    }
+                    Chunk::New(data) => {
+                        write_end -= data.len();
+                        source[write_end..write_end + data.len()].copy_from_slice(data);
+                    }
+                }
+            }
+        } else {
+            // Forward pass: safe when write positions are at or before source positions
+            let mut write_pos: usize = 1;
+            for chunk in chunks {
+                match chunk {
+                    Chunk::Unchanged(range) => {
+                        let len = range.len();
+                        if range.start != write_pos {
+                            source.copy_within(range, write_pos);
+                        }
+                        write_pos += len;
+                    }
+                    Chunk::New(data) => {
+                        source[write_pos..write_pos + data.len()].copy_from_slice(&data);
+                        write_pos += data.len();
+                    }
+                }
+            }
+        }
+
+        // Write 0xFF suffix and truncate
+        source[total_len - 1] = 0xFF;
+        source.truncate(total_len);
+    }
+
+    /// Assemble chunks into optimal order for output:
+    /// - Primary first, payload last
+    /// - Unchanged extension blocks sorted by source position
+    /// - New extension blocks slotted into gaps of matching size where possible
+    /// - Adjacent Unchanged ranges merged
+    ///
+    /// If `bundle` is provided, block extents are updated to reflect positions
+    /// in the flattened output (offset 1 for the 0x9F array header).
+    fn assemble(
+        primary: (u64, Chunk),
+        extensions: Vec<(u64, Chunk)>,
+        payload: (u64, Chunk),
+        bundle: Option<&mut bundle::Bundle>,
+    ) -> Vec<Chunk> {
+        // Separate unchanged and new extension chunks
+        let mut unchanged: Vec<(u64, Range<usize>)> = Vec::new();
+        let mut new_chunks: Vec<(u64, Box<[u8]>)> = Vec::new();
+
+        for (block_number, chunk) in extensions {
+            match chunk {
+                Chunk::Unchanged(range) => unchanged.push((block_number, range)),
+                Chunk::New(data) => new_chunks.push((block_number, data)),
+            }
+        }
+
+        // Sort unchanged by source position
+        unchanged.sort_by_key(|(_, range)| range.start);
+
+        // Sort new chunks by size descending for best-fit gap filling
+        new_chunks.sort_by(|(_, a), (_, b)| b.len().cmp(&a.len()));
+
+        // Build ordered extension list: try to fill gaps with matching-size New chunks
+        let mut ordered: Vec<(u64, Chunk)> = Vec::with_capacity(unchanged.len() + new_chunks.len());
+        let mut prev_end: Option<usize> = None;
+
+        for (block_number, range) in unchanged {
+            // Check for gap before this unchanged block
+            if let Some(end) = prev_end {
+                let gap_size = range.start.saturating_sub(end);
+                if gap_size > 0 {
+                    // Try to find a New chunk that fits this gap exactly
+                    if let Some(idx) = new_chunks
+                        .iter()
+                        .position(|(_, data)| data.len() == gap_size)
+                    {
+                        let (new_bn, new_data) = new_chunks.swap_remove(idx);
+                        ordered.push((new_bn, Chunk::New(new_data)));
+                    }
+                }
+            }
+            prev_end = Some(range.end);
+            ordered.push((block_number, Chunk::Unchanged(range)));
+        }
+
+        // Append remaining New chunks that didn't fit in gaps
+        for (block_number, data) in new_chunks {
+            ordered.push((block_number, Chunk::New(data)));
+        }
+
+        // Assemble final list: primary + extensions + payload
+        let mut assembled: Vec<(u64, Chunk)> = Vec::with_capacity(1 + ordered.len() + 1);
+        assembled.push(primary);
+        assembled.extend(ordered);
+        assembled.push(payload);
+
+        // Update block extents if bundle provided
+        if let Some(bundle) = bundle {
+            let mut offset: usize = 1; // 0x9F prefix
+            for (block_number, chunk) in &assembled {
+                let len = chunk.len();
+                if let Some(block) = bundle.blocks.get_mut(block_number) {
+                    block.extent = offset..offset + len;
+                }
+                offset += len;
+            }
+        }
+
+        // Merge adjacent Unchanged ranges
+        let mut result: Vec<Chunk> = Vec::with_capacity(assembled.len());
+        for (_, chunk) in assembled {
+            match (&mut result.last_mut(), &chunk) {
+                (Some(Chunk::Unchanged(prev)), Chunk::Unchanged(next))
+                    if prev.end == next.start =>
+                {
+                    prev.end = next.end;
+                }
+                _ => result.push(chunk),
+            }
+        }
+
+        result
     }
 }
 
@@ -909,101 +1111,110 @@ impl<'a> Editor<'a> {
     /// - The public API prevents adding/updating security blocks
     /// - Cascade deletes preserve or remove security block references
     /// - Signer/Encryptor set bib/bcb overrides explicitly
-    pub fn rebuild_bundle(mut self) -> Result<(bundle::Bundle, Box<[u8]>), Error> {
+    pub fn rebuild_bundle(mut self) -> Result<(bundle::Bundle, Vec<Chunk>), Error> {
         let mut bundle_out = bundle::Bundle::default();
 
-        let data: Box<[u8]> = hardy_cbor::encode::try_emit_array(None, |a| {
-            let primary_block = self.blocks.remove(&0).expect("No primary block!");
+        let primary_block = self.blocks.remove(&0).expect("No primary block!");
 
-            if let Some(mut update) = self.bundle.take() {
-                // Primary block modified via with_* methods
-                update.bundle_flags.is_fragment = update.fragment_info.is_some();
+        // Build primary chunk
+        let primary_chunk = if let Some(mut update) = self.bundle.take() {
+            update.bundle_flags.is_fragment = update.fragment_info.is_some();
 
-                bundle_out.id.source = update.source;
-                bundle_out.id.timestamp = update.timestamp;
-                bundle_out.id.fragment_info = update.fragment_info;
-                bundle_out.flags = update.bundle_flags;
-                bundle_out.crc_type = update.crc_type;
-                bundle_out.destination = update.destination;
-                bundle_out.report_to = update.report_to;
-                bundle_out.lifetime = update.lifetime;
-                bundle_out.emit_primary_block(a)?;
+            bundle_out.id.source = update.source;
+            bundle_out.id.timestamp = update.timestamp;
+            bundle_out.id.fragment_info = update.fragment_info;
+            bundle_out.flags = update.bundle_flags;
+            bundle_out.crc_type = update.crc_type;
+            bundle_out.destination = update.destination;
+            bundle_out.report_to = update.report_to;
+            bundle_out.lifetime = update.lifetime;
+
+            let primary_bytes = bundle::primary_block::PrimaryBlock::emit(&bundle_out)?;
+            let len = primary_bytes.len();
+            bundle_out.blocks.insert(
+                0,
+                bundle::primary_block::PrimaryBlock::as_block(bundle_out.crc_type, 0..len),
+            );
+            (0u64, Chunk::New(primary_bytes.into()))
+        } else {
+            bundle_out.id = self.original.id.clone();
+            bundle_out.flags = self.original.flags.clone();
+            bundle_out.crc_type = self.original.crc_type;
+            bundle_out.destination = self.original.destination.clone();
+            bundle_out.report_to = self.original.report_to.clone();
+            bundle_out.lifetime = self.original.lifetime;
+
+            if let BlockTemplate::Update(template) = primary_block {
+                let primary_bytes = template
+                    .data
+                    .ok_or(Error::Builder(builder::Error::NoBlockData))?;
+                let len = primary_bytes.len();
+                bundle_out.blocks.insert(
+                    0,
+                    bundle::primary_block::PrimaryBlock::as_block(bundle_out.crc_type, 0..len),
+                );
+                (0u64, Chunk::New(primary_bytes.into_owned().into()))
             } else {
-                // Primary block fields unchanged from original
-                bundle_out.id = self.original.id.clone();
-                bundle_out.flags = self.original.flags.clone();
-                bundle_out.crc_type = self.original.crc_type;
-                bundle_out.destination = self.original.destination.clone();
-                bundle_out.report_to = self.original.report_to.clone();
-                bundle_out.lifetime = self.original.lifetime;
-
-                if let BlockTemplate::Update(template) = primary_block {
-                    // Pre-encoded canonical primary block (from parser)
-                    let data = template
-                        .data
-                        .as_ref()
-                        .ok_or(Error::Builder(builder::Error::NoBlockData))?;
-                    let mut block = template.block;
-                    block.extent = a.emit(&hardy_cbor::encode::Raw(data));
-                    block.data = block.extent.clone();
-                    bundle_out.blocks.insert(0, block);
-                } else {
-                    let block = self.build_block(0, primary_block, a)?;
-                    bundle_out.blocks.insert(0, block);
-                }
+                let block = self
+                    .original
+                    .blocks
+                    .get(&0)
+                    .ok_or(Error::from(error::Error::Altered))?;
+                bundle_out.blocks.insert(0, block.clone());
+                (0u64, Chunk::Unchanged(block.extent.clone()))
             }
+        };
 
-            let payload_block = self.blocks.remove(&1).expect("No payload block!");
+        let payload_block = self.blocks.remove(&1).expect("No payload block!");
 
-            for (block_number, block_template) in core::mem::take(&mut self.blocks) {
-                match &block_template {
-                    BlockTemplate::Keep(block::Type::PreviousNode) => {
-                        bundle_out.previous_node = self.original.previous_node.clone();
-                    }
-                    BlockTemplate::Keep(block::Type::BundleAge) => {
-                        bundle_out.age = self.original.age;
-                    }
-                    BlockTemplate::Keep(block::Type::HopCount) => {
-                        bundle_out.hop_count = self.original.hop_count.clone();
-                    }
-                    BlockTemplate::Update(template) | BlockTemplate::Insert(template) => {
-                        if let Some(ref payload) = template.data {
-                            match template.block.block_type {
-                                block::Type::PreviousNode => {
-                                    if let Ok(eid) = hardy_cbor::decode::parse::<eid::Eid>(payload)
-                                    {
-                                        bundle_out.previous_node = Some(eid);
-                                    }
+        // Build extension chunks
+        let mut ext_chunks = Vec::new();
+        for (block_number, block_template) in core::mem::take(&mut self.blocks) {
+            match &block_template {
+                BlockTemplate::Keep(block::Type::PreviousNode) => {
+                    bundle_out.previous_node = self.original.previous_node.clone();
+                }
+                BlockTemplate::Keep(block::Type::BundleAge) => {
+                    bundle_out.age = self.original.age;
+                }
+                BlockTemplate::Keep(block::Type::HopCount) => {
+                    bundle_out.hop_count = self.original.hop_count.clone();
+                }
+                BlockTemplate::Update(template) | BlockTemplate::Insert(template) => {
+                    if let Some(ref payload) = template.data {
+                        match template.block.block_type {
+                            block::Type::PreviousNode => {
+                                if let Ok(eid) = hardy_cbor::decode::parse::<eid::Eid>(payload) {
+                                    bundle_out.previous_node = Some(eid);
                                 }
-                                block::Type::BundleAge => {
-                                    if let Ok(millis) = hardy_cbor::decode::parse::<u64>(payload) {
-                                        bundle_out.age =
-                                            Some(core::time::Duration::from_millis(millis));
-                                    }
-                                }
-                                block::Type::HopCount => {
-                                    if let Ok(hop) =
-                                        hardy_cbor::decode::parse::<hop_info::HopInfo>(payload)
-                                    {
-                                        bundle_out.hop_count = Some(hop);
-                                    }
-                                }
-                                _ => {}
                             }
+                            block::Type::BundleAge => {
+                                if let Ok(millis) = hardy_cbor::decode::parse::<u64>(payload) {
+                                    bundle_out.age =
+                                        Some(core::time::Duration::from_millis(millis));
+                                }
+                            }
+                            block::Type::HopCount => {
+                                if let Ok(hop) =
+                                    hardy_cbor::decode::parse::<hop_info::HopInfo>(payload)
+                                {
+                                    bundle_out.hop_count = Some(hop);
+                                }
+                            }
+                            _ => {}
                         }
                     }
-                    _ => {}
                 }
-                let block = self.build_block(block_number, block_template, a)?;
-                bundle_out.blocks.insert(block_number, block);
+                _ => {}
             }
+            let (block, chunk) = self.build_chunk(block_number, block_template)?;
+            bundle_out.blocks.insert(block_number, block);
+            ext_chunks.push((block_number, chunk));
+        }
 
-            let block = self.build_block(1, payload_block, a)?;
-            bundle_out.blocks.insert(1, block);
-
-            Ok::<_, Error>(())
-        })?
-        .into();
+        // Build payload chunk
+        let (block, payload_chunk) = self.build_chunk(1, payload_block)?;
+        bundle_out.blocks.insert(1, block);
 
         // Apply security metadata overrides from Signer/Encryptor
         for (block_number, bib) in &self.bib_overrides {
@@ -1017,82 +1228,98 @@ impl<'a> Editor<'a> {
             }
         }
 
-        Ok((bundle_out, data))
+        // Assemble, order, set extents, and merge
+        let chunks = Chunk::assemble(
+            primary_chunk,
+            ext_chunks,
+            (1, payload_chunk),
+            Some(&mut bundle_out),
+        );
+
+        Ok((bundle_out, chunks))
     }
 
-    /// Rebuild the bundle, applying all of the modifications.
+    /// Rebuild the bundle as a list of chunks.
     ///
-    /// Returns only the serialized representation, discarding the updated
-    /// bundle metadata. Use [`rebuild_bundle`](Self::rebuild_bundle) if you
-    /// need the updated `Bundle` with correct block extents.
-    pub fn rebuild(mut self) -> Result<Box<[u8]>, Error> {
-        hardy_cbor::encode::try_emit_array(None, |a| {
-            // Emit primary block
-            let primary_block = self.blocks.remove(&0).expect("No primary block!");
+    /// `Chunk::Unchanged` references ranges in the original `source_data`,
+    /// `Chunk::New` contains freshly encoded bytes. Use `Chunk::flatten()`
+    /// to concatenate into contiguous bytes.
+    pub fn rebuild(mut self) -> Result<Vec<Chunk>, Error> {
+        let primary_block = self.blocks.remove(&0).expect("No primary block!");
 
-            if let Some(mut update) = self.bundle.take() {
-                // Sync the is_fragment flags to the presence of fragment info
-                update.bundle_flags.is_fragment = update.fragment_info.is_some();
+        // Build primary chunk
+        let primary_chunk = if let Some(mut update) = self.bundle.take() {
+            update.bundle_flags.is_fragment = update.fragment_info.is_some();
 
-                let mut bundle = bundle::Bundle {
-                    id: bundle::Id {
-                        source: update.source,
-                        timestamp: update.timestamp,
-                        fragment_info: update.fragment_info,
-                    },
-                    flags: update.bundle_flags,
-                    crc_type: update.crc_type,
-                    destination: update.destination,
-                    report_to: update.report_to,
-                    lifetime: update.lifetime,
-                    ..Default::default()
-                };
-                // Emit primary block
-                bundle.emit_primary_block(a)?;
-            } else if let BlockTemplate::Update(template) = primary_block {
-                // Pre-encoded canonical primary block (from parser)
-                let data = template
-                    .data
-                    .as_ref()
-                    .ok_or(Error::Builder(builder::Error::NoBlockData))?;
-                a.emit(&hardy_cbor::encode::Raw(data));
-            } else {
-                self.build_block(0, primary_block, a)?;
-            }
+            let bundle = bundle::Bundle {
+                id: bundle::Id {
+                    source: update.source,
+                    timestamp: update.timestamp,
+                    fragment_info: update.fragment_info,
+                },
+                flags: update.bundle_flags,
+                crc_type: update.crc_type,
+                destination: update.destination,
+                report_to: update.report_to,
+                lifetime: update.lifetime,
+                ..Default::default()
+            };
+            (
+                0u64,
+                Chunk::New(bundle::primary_block::PrimaryBlock::emit(&bundle)?.into()),
+            )
+        } else if let BlockTemplate::Update(template) = primary_block {
+            let data = template
+                .data
+                .ok_or(Error::Builder(builder::Error::NoBlockData))?;
+            (0u64, Chunk::New(data.into_owned().into()))
+        } else {
+            let block = self
+                .original
+                .blocks
+                .get(&0)
+                .ok_or(Error::from(error::Error::Altered))?;
+            (0u64, Chunk::Unchanged(block.extent.clone()))
+        };
 
-            // Stash payload block
-            let payload_block = self.blocks.remove(&1).expect("No payload block!");
+        let payload_block = self.blocks.remove(&1).expect("No payload block!");
 
-            // Emit extension blocks
-            for (block_number, block_template) in core::mem::take(&mut self.blocks) {
-                self.build_block(block_number, block_template, a)?;
-            }
+        // Build extension chunks
+        let mut ext_chunks = Vec::new();
+        for (block_number, block_template) in core::mem::take(&mut self.blocks) {
+            let (_, chunk) = self.build_chunk(block_number, block_template)?;
+            ext_chunks.push((block_number, chunk));
+        }
 
-            // Emit payload block
-            self.build_block(1, payload_block, a)?;
+        // Build payload chunk
+        let (_, payload_chunk) = self.build_chunk(1, payload_block)?;
 
-            Ok::<_, Error>(())
-        })
-        .map(Into::into)
+        // Assemble, order, and merge (no extent tracking)
+        Ok(Chunk::assemble(
+            primary_chunk,
+            ext_chunks,
+            (1, payload_chunk),
+            None,
+        ))
     }
 
-    fn build_block(
+    fn build_chunk(
         &self,
         block_number: u64,
         template: BlockTemplate,
-        array: &mut hardy_cbor::encode::Array,
-    ) -> Result<block::Block, Error> {
+    ) -> Result<(block::Block, Chunk), Error> {
         if let BlockTemplate::Update(template) | BlockTemplate::Insert(template) = template {
-            template.build(block_number, array).map_err(Into::into)
+            let (block, bytes) = template.build_to_vec(block_number).map_err(Error::from)?;
+            Ok((block, Chunk::New(bytes.into())))
         } else {
-            let mut block = self
+            let block = self
                 .original
                 .blocks
                 .get(&block_number)
                 .ok_or(Error::from(error::Error::Altered))?
                 .clone();
-            block.copy_whole(self.source_data, array);
-            Ok(block)
+            let extent = block.extent.clone();
+            Ok((block, Chunk::Unchanged(extent)))
         }
     }
 }
@@ -1224,7 +1451,10 @@ mod test {
     #[test]
     fn no_op_rebuild() {
         let (bundle, data) = make_bundle();
-        let new_data = Editor::new(&bundle, &data).rebuild().unwrap();
+        let new_data = Editor::new(&bundle, &data)
+            .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
+            .unwrap();
         let reparsed = reparse(&new_data);
         assert_eq!(reparsed.id.source, bundle.id.source);
         assert_eq!(reparsed.destination, bundle.destination);
@@ -1236,6 +1466,7 @@ mod test {
         let new_dest: eid::Eid = "ipn:99.0".parse().unwrap();
         let new_data = ok(Editor::new(&bundle, &data).with_destination(new_dest.clone()))
             .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
             .unwrap();
         let reparsed = reparse(&new_data);
         assert_eq!(reparsed.destination, new_dest);
@@ -1248,6 +1479,7 @@ mod test {
         let new_src: eid::Eid = "ipn:50.0".parse().unwrap();
         let new_data = ok(Editor::new(&bundle, &data).with_source(new_src.clone()))
             .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
             .unwrap();
         let reparsed = reparse(&new_data);
         assert_eq!(reparsed.id.source, new_src);
@@ -1259,6 +1491,7 @@ mod test {
         let new_rt: eid::Eid = "ipn:77.0".parse().unwrap();
         let new_data = ok(Editor::new(&bundle, &data).with_report_to(new_rt.clone()))
             .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
             .unwrap();
         let reparsed = reparse(&new_data);
         assert_eq!(reparsed.report_to, new_rt);
@@ -1270,6 +1503,7 @@ mod test {
         let new_lifetime = core::time::Duration::from_secs(7200);
         let new_data = ok(Editor::new(&bundle, &data).with_lifetime(new_lifetime))
             .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
             .unwrap();
         let reparsed = reparse(&new_data);
         assert_eq!(reparsed.lifetime, new_lifetime);
@@ -1281,6 +1515,7 @@ mod test {
         let new_data =
             ok(Editor::new(&bundle, &data).with_bundle_crc_type(crc::CrcType::CRC16_X25))
                 .rebuild()
+                .map(|c| Chunk::flatten(c, &data))
                 .unwrap();
         let reparsed = reparse(&new_data);
         assert!(matches!(reparsed.crc_type, crc::CrcType::CRC16_X25));
@@ -1293,6 +1528,7 @@ mod test {
             .with_data((&[0xCA, 0xFE][..]).into())
             .rebuild()
             .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
             .unwrap();
         let reparsed = reparse(&new_data);
         assert!(reparsed.blocks.contains_key(&2));
@@ -1310,6 +1546,7 @@ mod test {
 
         let new_data = ok(Editor::new(&bundle, &data).remove_block(hop_block))
             .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
             .unwrap();
         let reparsed = reparse(&new_data);
         assert!(reparsed.hop_count.is_none());
@@ -1342,7 +1579,10 @@ mod test {
         let new_dest: eid::Eid = "ipn:99.0".parse().unwrap();
         let new_lifetime = core::time::Duration::from_secs(600);
         let editor = ok(Editor::new(&bundle, &data).with_destination(new_dest.clone()));
-        let new_data = ok(editor.with_lifetime(new_lifetime)).rebuild().unwrap();
+        let new_data = ok(editor.with_lifetime(new_lifetime))
+            .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
+            .unwrap();
         let reparsed = reparse(&new_data);
         assert_eq!(reparsed.destination, new_dest);
         assert_eq!(reparsed.lifetime, new_lifetime);
@@ -1357,6 +1597,7 @@ mod test {
             .with_data((&[0x01, 0x02][..]).into())
             .rebuild()
             .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
             .unwrap();
         let reparsed = reparse(&new_data);
         assert!(reparsed.blocks.contains_key(&2));
@@ -1449,7 +1690,10 @@ mod test {
     #[test]
     fn rebuild_bundle_no_op() {
         let (bundle, data) = make_bundle();
-        let (new_bundle, new_data) = Editor::new(&bundle, &data).rebuild_bundle().unwrap();
+        let (new_bundle, new_data) = Editor::new(&bundle, &data)
+            .rebuild_bundle()
+            .map(|(b, c)| (b, Chunk::flatten(c, &data)))
+            .unwrap();
         assert_rebuild_matches_parse(&new_bundle, &new_data);
     }
 
@@ -1460,6 +1704,7 @@ mod test {
         let (new_bundle, new_data) =
             ok(Editor::new(&bundle, &data).with_destination(new_dest.clone()))
                 .rebuild_bundle()
+                .map(|(b, c)| (b, Chunk::flatten(c, &data)))
                 .unwrap();
         assert_eq!(new_bundle.destination, new_dest);
         assert_eq!(new_bundle.id.source, bundle.id.source);
@@ -1474,6 +1719,7 @@ mod test {
         let editor = ok(Editor::new(&bundle, &data).with_destination(new_dest.clone()));
         let (new_bundle, new_data) = ok(editor.with_lifetime(new_lifetime))
             .rebuild_bundle()
+            .map(|(b, c)| (b, Chunk::flatten(c, &data)))
             .unwrap();
         assert_eq!(new_bundle.destination, new_dest);
         assert_eq!(new_bundle.lifetime, new_lifetime);
@@ -1488,6 +1734,7 @@ mod test {
                 .with_data((&[0xCA, 0xFE][..]).into())
                 .rebuild()
                 .rebuild_bundle()
+                .map(|(b, c)| (b, Chunk::flatten(c, &data)))
                 .unwrap();
         assert!(new_bundle.blocks.contains_key(&2));
         assert_rebuild_matches_parse(&new_bundle, &new_data);
@@ -1505,8 +1752,84 @@ mod test {
 
         let (new_bundle, new_data) = ok(Editor::new(&bundle, &data).remove_block(hop_block))
             .rebuild_bundle()
+            .map(|(b, c)| (b, Chunk::flatten(c, &data)))
             .unwrap();
         assert!(!new_bundle.blocks.contains_key(&hop_block));
         assert_rebuild_matches_parse(&new_bundle, &new_data);
+    }
+
+    #[test]
+    fn flatten_inplace_no_op() {
+        let (bundle, data) = make_bundle();
+        let flattened = Editor::new(&bundle, &data)
+            .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
+            .unwrap();
+        let chunks = Editor::new(&bundle, &data).rebuild().unwrap();
+        let mut inplace = data.to_vec();
+        Chunk::flatten_inplace(chunks, &mut inplace);
+        assert_eq!(&*flattened, &*inplace);
+    }
+
+    #[test]
+    fn flatten_inplace_change_destination() {
+        let (bundle, data) = make_bundle();
+        let new_dest: eid::Eid = "ipn:99.0".parse().unwrap();
+
+        let flattened = ok(Editor::new(&bundle, &data).with_destination(new_dest.clone()))
+            .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
+            .unwrap();
+
+        let chunks = ok(Editor::new(&bundle, &data).with_destination(new_dest))
+            .rebuild()
+            .unwrap();
+        let mut inplace = data.to_vec();
+        Chunk::flatten_inplace(chunks, &mut inplace);
+        assert_eq!(&*flattened, &*inplace);
+    }
+
+    #[test]
+    fn flatten_inplace_add_block() {
+        let (bundle, data) = make_bundle();
+
+        let flattened = ok(Editor::new(&bundle, &data).push_block(block::Type::Unrecognised(200)))
+            .with_data((&[0xCA, 0xFE][..]).into())
+            .rebuild()
+            .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
+            .unwrap();
+
+        let chunks = ok(Editor::new(&bundle, &data).push_block(block::Type::Unrecognised(200)))
+            .with_data((&[0xCA, 0xFE][..]).into())
+            .rebuild()
+            .rebuild()
+            .unwrap();
+        let mut inplace = data.to_vec();
+        Chunk::flatten_inplace(chunks, &mut inplace);
+        assert_eq!(&*flattened, &*inplace);
+    }
+
+    #[test]
+    fn flatten_inplace_remove_block() {
+        let (bundle, data) = make_bundle_with_hop_count();
+        let hop_block = bundle
+            .blocks
+            .iter()
+            .find(|(_, b)| matches!(b.block_type, block::Type::HopCount))
+            .map(|(n, _)| *n)
+            .expect("Should have hop count block");
+
+        let flattened = ok(Editor::new(&bundle, &data).remove_block(hop_block))
+            .rebuild()
+            .map(|c| Chunk::flatten(c, &data))
+            .unwrap();
+
+        let chunks = ok(Editor::new(&bundle, &data).remove_block(hop_block))
+            .rebuild()
+            .unwrap();
+        let mut inplace = data.to_vec();
+        Chunk::flatten_inplace(chunks, &mut inplace);
+        assert_eq!(&*flattened, &*inplace);
     }
 }

--- a/bpv7/src/editor.rs
+++ b/bpv7/src/editor.rs
@@ -887,22 +887,13 @@ impl<'a> Editor<'a> {
     ///
     /// Returns the updated `Bundle` (with block extents and BPSec coverage
     /// pointing into the new data) and the serialized representation.
-    /// Falls back to a Preserve-mode parse if the security block references
-    /// have been invalidated by the modifications.
+    ///
+    /// BPSec coverage is correct by construction:
+    /// - The public API prevents adding/updating security blocks
+    /// - Cascade deletes preserve or remove security block references
+    /// - Signer/Encryptor set bib/bcb overrides explicitly
     pub fn rebuild_bundle(mut self) -> Result<(bundle::Bundle, Box<[u8]>), Error> {
         let mut bundle_out = self.original.clone();
-        let mut refs_valid = true;
-
-        let kept_security_blocks: HashSet<u64> = self
-            .blocks
-            .iter()
-            .filter_map(|(n, t)| match t {
-                BlockTemplate::Keep(block::Type::BlockIntegrity | block::Type::BlockSecurity) => {
-                    Some(*n)
-                }
-                _ => None,
-            })
-            .collect();
 
         let data: Box<[u8]> = hardy_cbor::encode::try_emit_array(None, |a| {
             let primary_block = self.blocks.remove(&0).expect("No primary block!");
@@ -921,7 +912,6 @@ impl<'a> Editor<'a> {
                 bundle_out.emit_primary_block(a)?;
             } else {
                 let block = self.build_block(0, primary_block, a)?;
-                Self::check_security_refs(&block, &kept_security_blocks, &mut refs_valid);
                 bundle_out.blocks.insert(0, block);
             }
 
@@ -931,12 +921,10 @@ impl<'a> Editor<'a> {
 
             for (block_number, block_template) in core::mem::take(&mut self.blocks) {
                 let block = self.build_block(block_number, block_template, a)?;
-                Self::check_security_refs(&block, &kept_security_blocks, &mut refs_valid);
                 bundle_out.blocks.insert(block_number, block);
             }
 
             let block = self.build_block(1, payload_block, a)?;
-            Self::check_security_refs(&block, &kept_security_blocks, &mut refs_valid);
             bundle_out.blocks.insert(1, block);
 
             Ok::<_, Error>(())
@@ -944,47 +932,18 @@ impl<'a> Editor<'a> {
         .into();
 
         // Apply security metadata overrides from Signer/Encryptor
-        if !self.bib_overrides.is_empty() || !self.bcb_overrides.is_empty() {
-            for (block_number, bib) in &self.bib_overrides {
-                if let Some(block) = bundle_out.blocks.get_mut(block_number) {
-                    block.bib = bib.clone();
-                }
+        for (block_number, bib) in &self.bib_overrides {
+            if let Some(block) = bundle_out.blocks.get_mut(block_number) {
+                block.bib = bib.clone();
             }
-            for (block_number, bcb) in &self.bcb_overrides {
-                if let Some(block) = bundle_out.blocks.get_mut(block_number) {
-                    block.bcb = *bcb;
-                }
+        }
+        for (block_number, bcb) in &self.bcb_overrides {
+            if let Some(block) = bundle_out.blocks.get_mut(block_number) {
+                block.bcb = *bcb;
             }
-            refs_valid = true;
         }
 
-        if refs_valid {
-            Ok((bundle_out, data))
-        } else {
-            let parsed = bundle::ParsedBundle::parse_with_keys(&data, &bpsec::key::KeySet::EMPTY)
-                .map_err(|e| Error::Builder(builder::Error::InternalError(e)))?;
-            Ok((parsed.bundle, data))
-        }
-    }
-
-    fn check_security_refs(
-        block: &block::Block,
-        kept_security_blocks: &HashSet<u64>,
-        refs_valid: &mut bool,
-    ) {
-        if !*refs_valid {
-            return;
-        }
-        if let block::BibCoverage::Some(bib) = block.bib {
-            if !kept_security_blocks.contains(&bib) {
-                *refs_valid = false;
-            }
-        }
-        if let Some(bcb) = block.bcb {
-            if !kept_security_blocks.contains(&bcb) {
-                *refs_valid = false;
-            }
-        }
+        Ok((bundle_out, data))
     }
 
     /// Rebuild the bundle, applying all of the modifications.

--- a/bpv7/src/editor.rs
+++ b/bpv7/src/editor.rs
@@ -435,6 +435,23 @@ impl<'a> Editor<'a> {
         self.bcb_overrides.insert(target_block, Some(bcb_block));
     }
 
+    /// Set a pre-encoded canonical primary block for re-emission.
+    ///
+    /// Used by the parser when the primary block needs re-encoding for
+    /// canonicalization. The data is the complete encoded primary block,
+    /// emitted as raw bytes during rebuild.
+    pub(crate) fn set_canonical_primary(&mut self, data: Cow<'a, [u8]>) {
+        self.blocks.insert(
+            0,
+            BlockTemplate::Update(builder::BlockTemplate::new(
+                block::Type::Primary,
+                block::Flags::default(),
+                crc::CrcType::None,
+                Some(data),
+            )),
+        );
+    }
+
     /// Update an existing block without automatic security target removal.
     ///
     /// This is for internal use by encryptor/signer which need to update blocks
@@ -520,7 +537,7 @@ impl<'a> Editor<'a> {
     }
 
     #[allow(clippy::result_large_err)]
-    fn remove_block_inner(mut self, block_number: u64) -> Result<Self, (Self, Error)> {
+    pub(crate) fn remove_block_inner(mut self, block_number: u64) -> Result<Self, (Self, Error)> {
         // Get the block's security references BEFORE removing it
         let (bib, bcb) = if let Some((block, _)) = self.block(block_number) {
             (block.bib.clone(), block.bcb)
@@ -893,12 +910,13 @@ impl<'a> Editor<'a> {
     /// - Cascade deletes preserve or remove security block references
     /// - Signer/Encryptor set bib/bcb overrides explicitly
     pub fn rebuild_bundle(mut self) -> Result<(bundle::Bundle, Box<[u8]>), Error> {
-        let mut bundle_out = self.original.clone();
+        let mut bundle_out = bundle::Bundle::default();
 
         let data: Box<[u8]> = hardy_cbor::encode::try_emit_array(None, |a| {
             let primary_block = self.blocks.remove(&0).expect("No primary block!");
 
             if let Some(mut update) = self.bundle.take() {
+                // Primary block modified via with_* methods
                 update.bundle_flags.is_fragment = update.fragment_info.is_some();
 
                 bundle_out.id.source = update.source;
@@ -911,15 +929,71 @@ impl<'a> Editor<'a> {
                 bundle_out.lifetime = update.lifetime;
                 bundle_out.emit_primary_block(a)?;
             } else {
-                let block = self.build_block(0, primary_block, a)?;
-                bundle_out.blocks.insert(0, block);
+                // Primary block fields unchanged from original
+                bundle_out.id = self.original.id.clone();
+                bundle_out.flags = self.original.flags.clone();
+                bundle_out.crc_type = self.original.crc_type;
+                bundle_out.destination = self.original.destination.clone();
+                bundle_out.report_to = self.original.report_to.clone();
+                bundle_out.lifetime = self.original.lifetime;
+
+                if let BlockTemplate::Update(template) = primary_block {
+                    // Pre-encoded canonical primary block (from parser)
+                    let data = template
+                        .data
+                        .as_ref()
+                        .ok_or(Error::Builder(builder::Error::NoBlockData))?;
+                    let mut block = template.block;
+                    block.extent = a.emit(&hardy_cbor::encode::Raw(data));
+                    block.data = block.extent.clone();
+                    bundle_out.blocks.insert(0, block);
+                } else {
+                    let block = self.build_block(0, primary_block, a)?;
+                    bundle_out.blocks.insert(0, block);
+                }
             }
 
             let payload_block = self.blocks.remove(&1).expect("No payload block!");
 
-            bundle_out.blocks.retain(|k, _| *k == 0);
-
             for (block_number, block_template) in core::mem::take(&mut self.blocks) {
+                match &block_template {
+                    BlockTemplate::Keep(block::Type::PreviousNode) => {
+                        bundle_out.previous_node = self.original.previous_node.clone();
+                    }
+                    BlockTemplate::Keep(block::Type::BundleAge) => {
+                        bundle_out.age = self.original.age;
+                    }
+                    BlockTemplate::Keep(block::Type::HopCount) => {
+                        bundle_out.hop_count = self.original.hop_count.clone();
+                    }
+                    BlockTemplate::Update(template) | BlockTemplate::Insert(template) => {
+                        if let Some(ref payload) = template.data {
+                            match template.block.block_type {
+                                block::Type::PreviousNode => {
+                                    if let Ok(eid) = hardy_cbor::decode::parse::<eid::Eid>(payload)
+                                    {
+                                        bundle_out.previous_node = Some(eid);
+                                    }
+                                }
+                                block::Type::BundleAge => {
+                                    if let Ok(millis) = hardy_cbor::decode::parse::<u64>(payload) {
+                                        bundle_out.age =
+                                            Some(core::time::Duration::from_millis(millis));
+                                    }
+                                }
+                                block::Type::HopCount => {
+                                    if let Ok(hop) =
+                                        hardy_cbor::decode::parse::<hop_info::HopInfo>(payload)
+                                    {
+                                        bundle_out.hop_count = Some(hop);
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    _ => {}
+                }
                 let block = self.build_block(block_number, block_template, a)?;
                 bundle_out.blocks.insert(block_number, block);
             }
@@ -975,6 +1049,13 @@ impl<'a> Editor<'a> {
                 };
                 // Emit primary block
                 bundle.emit_primary_block(a)?;
+            } else if let BlockTemplate::Update(template) = primary_block {
+                // Pre-encoded canonical primary block (from parser)
+                let data = template
+                    .data
+                    .as_ref()
+                    .ok_or(Error::Builder(builder::Error::NoBlockData))?;
+                a.emit(&hardy_cbor::encode::Raw(data));
             } else {
                 self.build_block(0, primary_block, a)?;
             }

--- a/bpv7/src/editor.rs
+++ b/bpv7/src/editor.rs
@@ -1,5 +1,6 @@
 use super::*;
 use alloc::borrow::Cow;
+use smallvec::SmallVec;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -30,6 +31,9 @@ pub enum Error {
     )]
     CannotDecryptRelatedBib(u64),
 
+    #[error("Security blocks (BIB/BCB) must be managed via Signer/Encryptor, not the Editor")]
+    SecurityBlock,
+
     #[error(transparent)]
     Builder(#[from] builder::Error),
 }
@@ -55,6 +59,8 @@ pub struct Editor<'a> {
     source_data: &'a [u8],
     bundle: Option<BundleUpdate>,
     blocks: HashMap<u64, BlockTemplate<'a>>,
+    bib_overrides: HashMap<u64, block::BibCoverage>,
+    bcb_overrides: HashMap<u64, Option<u64>>,
 }
 
 struct BundleUpdate {
@@ -97,6 +103,8 @@ impl<'a> Editor<'a> {
             source_data,
             original,
             bundle: None,
+            bib_overrides: HashMap::new(),
+            bcb_overrides: HashMap::new(),
         }
     }
 
@@ -257,33 +265,44 @@ impl<'a> Editor<'a> {
     /// On error, returns the editor along with the error so it can be reused for recovery.
     #[allow(clippy::result_large_err)]
     pub fn push_block(self, block_type: block::Type) -> Result<BlockBuilder<'a>, (Self, Error)> {
-        if let block::Type::Primary
-        | block::Type::Payload
-        | block::Type::BundleAge
-        | block::Type::HopCount
-        | block::Type::PreviousNode = block_type
-        {
-            for template in self.blocks.values() {
-                match template {
-                    BlockTemplate::Keep(t) if t == &block_type => {
-                        return Err((self, Error::IllegalDuplicate(block_type)));
+        match block_type {
+            block::Type::Primary => {
+                return Err((self, Error::PrimaryBlock));
+            }
+            block::Type::BlockIntegrity | block::Type::BlockSecurity => {
+                return Err((self, Error::SecurityBlock));
+            }
+            block::Type::Payload
+            | block::Type::BundleAge
+            | block::Type::HopCount
+            | block::Type::PreviousNode => {
+                for template in self.blocks.values() {
+                    match template {
+                        BlockTemplate::Keep(t) if t == &block_type => {
+                            return Err((self, Error::IllegalDuplicate(block_type)));
+                        }
+                        BlockTemplate::Insert(template) | BlockTemplate::Update(template)
+                            if template.block.block_type == block_type =>
+                        {
+                            return Err((self, Error::IllegalDuplicate(block_type)));
+                        }
+                        _ => {}
                     }
-                    BlockTemplate::Insert(template) | BlockTemplate::Update(template)
-                        if template.block.block_type == block_type =>
-                    {
-                        return Err((self, Error::IllegalDuplicate(block_type)));
-                    }
-                    _ => {}
                 }
             }
+            _ => {}
         }
 
-        self.add_block(block_type)
+        self.alloc_block(block_type)
     }
 
+    /// Allocate the next available block number and return a builder.
+    /// No policy checks — used internally and by Signer/Encryptor.
     #[allow(clippy::result_large_err)]
-    fn add_block(self, block_type: block::Type) -> Result<BlockBuilder<'a>, (Self, Error)> {
-        // Find the lowest unused block_number
+    pub(crate) fn alloc_block(
+        self,
+        block_type: block::Type,
+    ) -> Result<BlockBuilder<'a>, (Self, Error)> {
         let mut block_number = 2u64;
         while self.blocks.contains_key(&block_number) {
             block_number = match block_number.checked_add(1) {
@@ -303,8 +322,12 @@ impl<'a> Editor<'a> {
     /// On error, returns the editor along with the error so it can be reused for recovery.
     #[allow(clippy::result_large_err)]
     pub fn insert_block(self, block_type: block::Type) -> Result<BlockBuilder<'a>, (Self, Error)> {
-        if let block::Type::Primary = block_type {
-            return Err((self, Error::PrimaryBlock));
+        match block_type {
+            block::Type::Primary => return Err((self, Error::PrimaryBlock)),
+            block::Type::BlockIntegrity | block::Type::BlockSecurity => {
+                return Err((self, Error::SecurityBlock));
+            }
+            _ => {}
         }
 
         if let Some((block_number, is_new, template)) =
@@ -341,7 +364,7 @@ impl<'a> Editor<'a> {
             ));
         }
 
-        self.add_block(block_type)
+        self.alloc_block(block_type)
     }
 
     /// Update an existing block in the bundle.
@@ -354,36 +377,62 @@ impl<'a> Editor<'a> {
     /// On error, returns the editor along with the error so it can be reused for recovery.
     #[allow(clippy::result_large_err)]
     pub fn update_block(mut self, block_number: u64) -> Result<BlockBuilder<'a>, (Self, Error)> {
-        // Get security references before any modifications
-        let (bib, bcb) = match self.original.blocks.get(&block_number) {
-            Some(block) => (block.bib.clone(), block.bcb),
-            None => (block::BibCoverage::None, None),
+        // Check block type and get security references in one lookup
+        let (bib, bcb) = match self.block(block_number) {
+            Some((block, _)) => {
+                match block.block_type {
+                    block::Type::Primary => {
+                        return Err((self, Error::PrimaryBlock));
+                    }
+                    block::Type::BlockIntegrity | block::Type::BlockSecurity => {
+                        return Err((self, Error::SecurityBlock));
+                    }
+                    _ => {}
+                }
+                (block.bib.clone(), block.bcb)
+            }
+            None => return Err((self, Error::NoSuchBlock(block_number))),
         };
 
-        // Handle BIB coverage - must remove from target list if present
-        match &bib {
+        // Handle BIB coverage — must remove from target list if present
+        match bib {
             block::BibCoverage::Maybe => {
                 return Err((self, bpsec::Error::MaybeHasBib(block_number).into()));
             }
             block::BibCoverage::Some(bib_num) => {
-                // Check if the BIB is encrypted
-                if let Some(bib_block) = self.original.blocks.get(bib_num)
+                if let Some((bib_block, _)) = self.block(bib_num)
                     && bib_block.bcb.is_some()
                 {
                     return Err((self, Error::BibIsEncrypted(block_number)));
                 }
-                // Remove from BIB target list (signature will be invalid after update)
-                self = self.remove_from_bib_targets(block_number, *bib_num)?;
+                self = self.remove_from_bib_targets(block_number, bib_num)?;
             }
             block::BibCoverage::None => {}
         }
 
-        // Remove from BCB target list if present (encryption will be invalid after update)
+        // Remove from BCB target list if present
         if let Some(bcb_num) = bcb {
             self = self.remove_from_bcb_targets(block_number, bcb_num)?;
         }
 
         self.update_block_inner(block_number)
+    }
+
+    /// Record that a BIB covers the given target block.
+    ///
+    /// Used by `Signer` to set `bib` metadata on target blocks so that
+    /// `rebuild_bundle()` returns a correct `Bundle` without reparsing.
+    pub(crate) fn set_bib_target(&mut self, target_block: u64, bib_block: u64) {
+        self.bib_overrides
+            .insert(target_block, block::BibCoverage::Some(bib_block));
+    }
+
+    /// Record that a BCB covers the given target block.
+    ///
+    /// Used by `Encryptor` to set `bcb` metadata on target blocks so that
+    /// `rebuild_bundle()` returns a correct `Bundle` without reparsing.
+    pub(crate) fn set_bcb_target(&mut self, target_block: u64, bcb_block: u64) {
+        self.bcb_overrides.insert(target_block, Some(bcb_block));
     }
 
     /// Update an existing block without automatic security target removal.
@@ -741,7 +790,7 @@ impl<'a> Editor<'a> {
                 // uniqueness requirements, so this code path is for future security
                 // contexts (e.g., COSE-based) that may support multi-target BCBs.
                 if opset.can_share() {
-                    let bib_targets: Vec<u64> = opset
+                    let bib_targets: SmallVec<[u64; 4]> = opset
                         .operations
                         .keys()
                         .filter(|&&target| {
@@ -836,7 +885,113 @@ impl<'a> Editor<'a> {
 
     /// Rebuild the bundle, applying all of the modifications.
     ///
-    /// This will return the new `Bundle` and its serialized representation.
+    /// Returns the updated `Bundle` (with block extents and BPSec coverage
+    /// pointing into the new data) and the serialized representation.
+    /// Falls back to a Preserve-mode parse if the security block references
+    /// have been invalidated by the modifications.
+    pub fn rebuild_bundle(mut self) -> Result<(bundle::Bundle, Box<[u8]>), Error> {
+        let mut bundle_out = self.original.clone();
+        let mut refs_valid = true;
+
+        let kept_security_blocks: HashSet<u64> = self
+            .blocks
+            .iter()
+            .filter_map(|(n, t)| match t {
+                BlockTemplate::Keep(block::Type::BlockIntegrity | block::Type::BlockSecurity) => {
+                    Some(*n)
+                }
+                _ => None,
+            })
+            .collect();
+
+        let data: Box<[u8]> = hardy_cbor::encode::try_emit_array(None, |a| {
+            let primary_block = self.blocks.remove(&0).expect("No primary block!");
+
+            if let Some(mut update) = self.bundle.take() {
+                update.bundle_flags.is_fragment = update.fragment_info.is_some();
+
+                bundle_out.id.source = update.source;
+                bundle_out.id.timestamp = update.timestamp;
+                bundle_out.id.fragment_info = update.fragment_info;
+                bundle_out.flags = update.bundle_flags;
+                bundle_out.crc_type = update.crc_type;
+                bundle_out.destination = update.destination;
+                bundle_out.report_to = update.report_to;
+                bundle_out.lifetime = update.lifetime;
+                bundle_out.emit_primary_block(a)?;
+            } else {
+                let block = self.build_block(0, primary_block, a)?;
+                Self::check_security_refs(&block, &kept_security_blocks, &mut refs_valid);
+                bundle_out.blocks.insert(0, block);
+            }
+
+            let payload_block = self.blocks.remove(&1).expect("No payload block!");
+
+            bundle_out.blocks.retain(|k, _| *k == 0);
+
+            for (block_number, block_template) in core::mem::take(&mut self.blocks) {
+                let block = self.build_block(block_number, block_template, a)?;
+                Self::check_security_refs(&block, &kept_security_blocks, &mut refs_valid);
+                bundle_out.blocks.insert(block_number, block);
+            }
+
+            let block = self.build_block(1, payload_block, a)?;
+            Self::check_security_refs(&block, &kept_security_blocks, &mut refs_valid);
+            bundle_out.blocks.insert(1, block);
+
+            Ok::<_, Error>(())
+        })?
+        .into();
+
+        // Apply security metadata overrides from Signer/Encryptor
+        if !self.bib_overrides.is_empty() || !self.bcb_overrides.is_empty() {
+            for (block_number, bib) in &self.bib_overrides {
+                if let Some(block) = bundle_out.blocks.get_mut(block_number) {
+                    block.bib = bib.clone();
+                }
+            }
+            for (block_number, bcb) in &self.bcb_overrides {
+                if let Some(block) = bundle_out.blocks.get_mut(block_number) {
+                    block.bcb = *bcb;
+                }
+            }
+            refs_valid = true;
+        }
+
+        if refs_valid {
+            Ok((bundle_out, data))
+        } else {
+            let parsed = bundle::ParsedBundle::parse_with_keys(&data, &bpsec::key::KeySet::EMPTY)
+                .map_err(|e| Error::Builder(builder::Error::InternalError(e)))?;
+            Ok((parsed.bundle, data))
+        }
+    }
+
+    fn check_security_refs(
+        block: &block::Block,
+        kept_security_blocks: &HashSet<u64>,
+        refs_valid: &mut bool,
+    ) {
+        if !*refs_valid {
+            return;
+        }
+        if let block::BibCoverage::Some(bib) = block.bib {
+            if !kept_security_blocks.contains(&bib) {
+                *refs_valid = false;
+            }
+        }
+        if let Some(bcb) = block.bcb {
+            if !kept_security_blocks.contains(&bcb) {
+                *refs_valid = false;
+            }
+        }
+    }
+
+    /// Rebuild the bundle, applying all of the modifications.
+    ///
+    /// Returns only the serialized representation, discarding the updated
+    /// bundle metadata. Use [`rebuild_bundle`](Self::rebuild_bundle) if you
+    /// need the updated `Bundle` with correct block extents.
     pub fn rebuild(mut self) -> Result<Box<[u8]>, Error> {
         hardy_cbor::encode::try_emit_array(None, |a| {
             // Emit primary block
@@ -1165,5 +1320,153 @@ mod test {
             .unwrap();
         let reparsed = reparse(&new_data);
         assert!(reparsed.blocks.contains_key(&2));
+    }
+
+    /// Asserts that the Bundle returned by `rebuild_bundle()` matches a fresh
+    /// parse of the same data — same block set, same extents, same primary
+    /// block fields.
+    fn assert_rebuild_matches_parse(bundle: &bundle::Bundle, data: &[u8]) {
+        let reparsed = reparse(data);
+
+        // Primary block fields
+        assert_eq!(bundle.id.source, reparsed.id.source);
+        assert_eq!(bundle.id.timestamp, reparsed.id.timestamp);
+        assert_eq!(bundle.id.fragment_info, reparsed.id.fragment_info);
+        assert_eq!(bundle.destination, reparsed.destination);
+        assert_eq!(bundle.report_to, reparsed.report_to);
+        assert_eq!(bundle.lifetime, reparsed.lifetime);
+        assert!(
+            matches!(
+                (&bundle.crc_type, &reparsed.crc_type),
+                (crc::CrcType::None, crc::CrcType::None)
+                    | (crc::CrcType::CRC16_X25, crc::CrcType::CRC16_X25)
+                    | (
+                        crc::CrcType::CRC32_CASTAGNOLI,
+                        crc::CrcType::CRC32_CASTAGNOLI
+                    )
+            ),
+            "CRC type mismatch"
+        );
+        assert_eq!(bundle.flags, reparsed.flags);
+
+        // Same set of block numbers
+        assert_eq!(
+            bundle.blocks.keys().collect::<HashSet<_>>(),
+            reparsed.blocks.keys().collect::<HashSet<_>>(),
+            "Block sets differ"
+        );
+
+        // Block fields match and ranges index validly into the data
+        for (block_number, block) in &bundle.blocks {
+            let reparsed_block = reparsed.blocks.get(block_number).unwrap();
+            assert_eq!(
+                block.block_type, reparsed_block.block_type,
+                "Block {block_number} type mismatch"
+            );
+            assert_eq!(
+                block.flags, reparsed_block.flags,
+                "Block {block_number} flags mismatch"
+            );
+            assert!(
+                matches!(
+                    (&block.crc_type, &reparsed_block.crc_type),
+                    (crc::CrcType::None, crc::CrcType::None)
+                        | (crc::CrcType::CRC16_X25, crc::CrcType::CRC16_X25)
+                        | (
+                            crc::CrcType::CRC32_CASTAGNOLI,
+                            crc::CrcType::CRC32_CASTAGNOLI
+                        )
+                ),
+                "Block {block_number} CRC type mismatch"
+            );
+            assert_eq!(
+                block.bib, reparsed_block.bib,
+                "Block {block_number} BIB coverage mismatch"
+            );
+            assert_eq!(
+                block.bcb, reparsed_block.bcb,
+                "Block {block_number} BCB mismatch"
+            );
+            assert_eq!(
+                block.extent, reparsed_block.extent,
+                "Block {block_number} extent mismatch"
+            );
+            assert_eq!(
+                block.data, reparsed_block.data,
+                "Block {block_number} data range mismatch"
+            );
+            assert!(
+                block.extent.end <= data.len(),
+                "Block {block_number} extent exceeds data length"
+            );
+            assert!(
+                block.data.end <= data.len(),
+                "Block {block_number} data range exceeds data length"
+            );
+        }
+    }
+
+    #[test]
+    fn rebuild_bundle_no_op() {
+        let (bundle, data) = make_bundle();
+        let (new_bundle, new_data) = Editor::new(&bundle, &data).rebuild_bundle().unwrap();
+        assert_rebuild_matches_parse(&new_bundle, &new_data);
+    }
+
+    #[test]
+    fn rebuild_bundle_change_destination() {
+        let (bundle, data) = make_bundle();
+        let new_dest: eid::Eid = "ipn:99.0".parse().unwrap();
+        let (new_bundle, new_data) =
+            ok(Editor::new(&bundle, &data).with_destination(new_dest.clone()))
+                .rebuild_bundle()
+                .unwrap();
+        assert_eq!(new_bundle.destination, new_dest);
+        assert_eq!(new_bundle.id.source, bundle.id.source);
+        assert_rebuild_matches_parse(&new_bundle, &new_data);
+    }
+
+    #[test]
+    fn rebuild_bundle_multiple_primary_changes() {
+        let (bundle, data) = make_bundle();
+        let new_dest: eid::Eid = "ipn:99.0".parse().unwrap();
+        let new_lifetime = core::time::Duration::from_secs(600);
+        let editor = ok(Editor::new(&bundle, &data).with_destination(new_dest.clone()));
+        let (new_bundle, new_data) = ok(editor.with_lifetime(new_lifetime))
+            .rebuild_bundle()
+            .unwrap();
+        assert_eq!(new_bundle.destination, new_dest);
+        assert_eq!(new_bundle.lifetime, new_lifetime);
+        assert_rebuild_matches_parse(&new_bundle, &new_data);
+    }
+
+    #[test]
+    fn rebuild_bundle_add_block() {
+        let (bundle, data) = make_bundle();
+        let (new_bundle, new_data) =
+            ok(Editor::new(&bundle, &data).push_block(block::Type::Unrecognised(200)))
+                .with_data((&[0xCA, 0xFE][..]).into())
+                .rebuild()
+                .rebuild_bundle()
+                .unwrap();
+        assert!(new_bundle.blocks.contains_key(&2));
+        assert_rebuild_matches_parse(&new_bundle, &new_data);
+    }
+
+    #[test]
+    fn rebuild_bundle_remove_block() {
+        let (bundle, data) = make_bundle_with_hop_count();
+        let hop_block = bundle
+            .blocks
+            .iter()
+            .find(|(_, b)| matches!(b.block_type, block::Type::HopCount))
+            .map(|(n, _)| *n)
+            .expect("Should have hop count block");
+
+        let (new_bundle, new_data) = ok(Editor::new(&bundle, &data).remove_block(hop_block))
+            .rebuild_bundle()
+            .unwrap();
+        assert!(!new_bundle.blocks.contains_key(&hop_block));
+        assert_rebuild_matches_parse(&new_bundle, &new_data);
     }
 }

--- a/bpv7/src/editor.rs
+++ b/bpv7/src/editor.rs
@@ -72,6 +72,7 @@ impl Chunk {
         for c in chunks {
             match c {
                 Chunk::Unchanged(extent) => {
+                    debug_assert!(extent.end <= source.len());
                     result.extend_from_slice(&source[extent]);
                 }
                 Chunk::New(items) => {
@@ -97,11 +98,11 @@ impl Chunk {
         let mut needs_backward = false;
         for chunk in &chunks {
             let len = chunk.len();
-            if !needs_backward
-                && let Chunk::Unchanged(range) = chunk
-                && write_pos > range.start
-            {
-                needs_backward = true;
+            if let Chunk::Unchanged(range) = chunk {
+                debug_assert!(range.end <= source.len());
+                if !needs_backward && write_pos > range.start {
+                    needs_backward = true;
+                }
             }
             content_len += len;
             write_pos += len;
@@ -133,6 +134,7 @@ impl Chunk {
                     }
                 }
             }
+            debug_assert_eq!(write_end, 1);
         } else {
             // Forward pass: safe when write positions are at or before source positions
             let mut write_pos: usize = 1;
@@ -151,6 +153,7 @@ impl Chunk {
                     }
                 }
             }
+            debug_assert_eq!(write_pos, 1 + content_len);
         }
 
         // Write 0xFF suffix and truncate

--- a/bpv7/tools/add_block.rs
+++ b/bpv7/tools/add_block.rs
@@ -92,7 +92,7 @@ pub struct Command {
 impl Command {
     pub fn exec(self) -> anyhow::Result<()> {
         let key_store: hardy_bpv7::bpsec::key::KeySet = self.key_args.try_into()?;
-        let data = self.input.read_all()?;
+        let mut data = self.input.read_all()?;
 
         let bundle = hardy_bpv7::bundle::ParsedBundle::parse_with_keys(&data, &key_store)
             .map_err(|e| anyhow::anyhow!("Failed to parse bundle: {e}"))?
@@ -143,9 +143,11 @@ impl Command {
         // Set block data and rebuild
         let editor = block_builder.with_data(block_data.into()).rebuild();
 
-        let data = editor
+        let chunks = editor
             .rebuild()
             .map_err(|e| anyhow::anyhow!("Failed to rebuild bundle: {e}"))?;
+
+        hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut data);
 
         self.output.write_all(&data)
     }

--- a/bpv7/tools/remove_block.rs
+++ b/bpv7/tools/remove_block.rs
@@ -29,7 +29,7 @@ pub struct Command {
 impl Command {
     pub fn exec(self) -> anyhow::Result<()> {
         let key_store: hardy_bpv7::bpsec::key::KeySet = self.key_args.try_into()?;
-        let data = self.input.read_all()?;
+        let mut data = self.input.read_all()?;
 
         let bundle = hardy_bpv7::bundle::ParsedBundle::parse_with_keys(&data, &key_store)
             .map_err(|e| anyhow::anyhow!("Failed to parse bundle: {e}"))?
@@ -41,9 +41,11 @@ impl Command {
                 anyhow::anyhow!("Failed to remove block {}: {e}", self.block_number)
             })?;
 
-        let data = editor
+        let chunks = editor
             .rebuild()
             .map_err(|e| anyhow::anyhow!("Failed to rebuild bundle: {e}"))?;
+
+        hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut data);
 
         self.output.write_all(&data)
     }

--- a/bpv7/tools/remove_encryption.rs
+++ b/bpv7/tools/remove_encryption.rs
@@ -29,7 +29,7 @@ impl Command {
     pub fn exec(self) -> anyhow::Result<()> {
         let key_store: hardy_bpv7::bpsec::key::KeySet = self.key_args.try_into()?;
 
-        let data = self.input.read_all()?;
+        let mut data = self.input.read_all()?;
 
         let bundle = hardy_bpv7::bundle::ParsedBundle::parse_with_keys(&data, &key_store)
             .map_err(|e| anyhow::anyhow!("Failed to parse bundle: {e}"))?
@@ -39,9 +39,11 @@ impl Command {
             .remove_encryption(self.block, &key_store)
             .map_err(|(_, e)| anyhow::anyhow!("Failed to remove encryption: {e}"))?;
 
-        let data = editor
+        let chunks = editor
             .rebuild()
             .map_err(|e| anyhow::anyhow!("Failed to rebuild bundle: {e}"))?;
+
+        hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut data);
 
         self.output.write_all(&data)
     }

--- a/bpv7/tools/remove_integrity.rs
+++ b/bpv7/tools/remove_integrity.rs
@@ -29,7 +29,7 @@ impl Command {
     pub fn exec(self) -> anyhow::Result<()> {
         let key_store: hardy_bpv7::bpsec::key::KeySet = self.key_args.try_into()?;
 
-        let data = self.input.read_all()?;
+        let mut data = self.input.read_all()?;
 
         let bundle = hardy_bpv7::bundle::ParsedBundle::parse_with_keys(&data, &key_store)
             .map_err(|e| anyhow::anyhow!("Failed to parse bundle: {e}"))?
@@ -39,9 +39,11 @@ impl Command {
             .remove_integrity(self.block)
             .map_err(|(_, e)| anyhow::anyhow!("Failed to remove integrity check: {e}"))?;
 
-        let data = editor
+        let chunks = editor
             .rebuild()
             .map_err(|e| anyhow::anyhow!("Failed to rebuild bundle: {e}"))?;
+
+        hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut data);
 
         self.output.write_all(&data)
     }

--- a/bpv7/tools/rewrite.rs
+++ b/bpv7/tools/rewrite.rs
@@ -30,7 +30,9 @@ impl Command {
             .map_err(|e| anyhow::anyhow!("Failed to parse bundle: {e}"))?
         {
             hardy_bpv7::bundle::RewrittenBundle::Valid { .. } => data,
-            hardy_bpv7::bundle::RewrittenBundle::Rewritten { new_data, .. } => new_data.into(),
+            hardy_bpv7::bundle::RewrittenBundle::Rewritten { new_data, .. } => {
+                hardy_bpv7::editor::Chunk::flatten(new_data, &data).into()
+            }
             hardy_bpv7::bundle::RewrittenBundle::Invalid { error, .. } => {
                 return Err(anyhow::anyhow!("Failed to parse bundle: {error}"));
             }

--- a/bpv7/tools/update_block.rs
+++ b/bpv7/tools/update_block.rs
@@ -46,7 +46,7 @@ pub struct Command {
 impl Command {
     pub fn exec(self) -> anyhow::Result<()> {
         let key_store: hardy_bpv7::bpsec::key::KeySet = self.key_args.try_into()?;
-        let data = self.input.read_all()?;
+        let mut data = self.input.read_all()?;
 
         let bundle = hardy_bpv7::bundle::ParsedBundle::parse_with_keys(&data, &key_store)
             .map_err(|e| anyhow::anyhow!("Failed to parse bundle: {e}"))?
@@ -78,9 +78,11 @@ impl Command {
 
         let editor = block_builder.rebuild();
 
-        let data = editor
+        let chunks = editor
             .rebuild()
             .map_err(|e| anyhow::anyhow!("Failed to rebuild bundle: {e}"))?;
+
+        hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut data);
 
         self.output.write_all(&data)
     }

--- a/bpv7/tools/update_primary.rs
+++ b/bpv7/tools/update_primary.rs
@@ -67,7 +67,7 @@ impl Command {
         }
 
         let key_store: hardy_bpv7::bpsec::key::KeySet = self.key_args.try_into()?;
-        let data = self.input.read_all()?;
+        let mut data = self.input.read_all()?;
 
         let bundle = hardy_bpv7::bundle::ParsedBundle::parse_with_keys(&data, &key_store)
             .map_err(|e| anyhow::anyhow!("Failed to parse bundle: {e}"))?
@@ -124,9 +124,11 @@ impl Command {
                 .map_err(|(_, e)| anyhow::anyhow!("Failed to update CRC type: {e}"))?;
         }
 
-        let data = editor
+        let chunks = editor
             .rebuild()
             .map_err(|e| anyhow::anyhow!("Failed to rebuild bundle: {e}"))?;
+
+        hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut data);
 
         self.output.write_all(&data)
     }

--- a/echo-service/src/lib.rs
+++ b/echo-service/src/lib.rs
@@ -57,7 +57,7 @@ impl EchoService {
             );
 
             // Swap source and destination
-            let data = hardy_bpv7::editor::Editor::new(&bundle, &data)
+            let chunks = hardy_bpv7::editor::Editor::new(&bundle, &data)
                 .with_source(bundle.destination.clone())
                 .map_err(|(_, e)| {
                     debug!("Failed to set source Eid: {e:?}");
@@ -77,7 +77,18 @@ impl EchoService {
                 "Sending echo reply"
             );
 
-            sink.send(data.into()).await.inspect_err(|e| {
+            let reply = match data.try_into_mut() {
+                Ok(buf) => {
+                    let mut vec = buf.into();
+                    hardy_bpv7::editor::Chunk::flatten_inplace(chunks, &mut vec);
+                    hardy_bpa::Bytes::from(vec)
+                }
+                Err(original) => {
+                    hardy_bpa::Bytes::from(hardy_bpv7::editor::Chunk::flatten(chunks, &original))
+                }
+            };
+
+            sink.send(reply).await.inspect_err(|e| {
                 warn!("Failed to send reply: {e:?}");
             })?;
         }

--- a/ipn-legacy-filter/src/lib.rs
+++ b/ipn-legacy-filter/src/lib.rs
@@ -8,7 +8,7 @@ for peers that require the older encoding.
 use hardy_bpa::async_trait;
 use hardy_bpa::bundle::Bundle;
 use hardy_bpa::filter::{WriteFilter, WriteResult};
-use hardy_bpv7::editor::Editor;
+use hardy_bpv7::editor::{Chunk, Editor};
 use hardy_bpv7::eid::Eid;
 
 /// Configuration for IPN 2-element legacy encoding filter
@@ -94,9 +94,9 @@ impl WriteFilter for IpnLegacyFilter {
                 .map_err(|(_, e)| e)?;
         }
 
-        let new_data = editor.rebuild()?;
+        let data = editor.rebuild().map(|c| Chunk::flatten(c, data))?;
 
-        Ok(WriteResult::Continue(None, Some(new_data.into())))
+        Ok(WriteResult::Continue(None, Some(data.into())))
     }
 }
 


### PR DESCRIPTION
Closes: #147 
Closes: #526 

# Editor: rebuild_bundle() returns (Bundle, Vec<Chunk>)

- rebuild_bundle(): Returns updated Bundle with correct block extents and BPSec coverage, plus Vec<Chunk> for zero-copy output
- No clone: Bundle constructed field-by-field during emission — convenience fields (previous_node, age, hop_count) parsed inline from block payloads. Keep blocks copy from original, Update blocks re-parse, deleted blocks stay None
- BPSec correctness by construction: Public API guards reject BIB/BCB on push_block/insert_block/update_block (Error::SecurityBlock); alloc_block/update_block_inner/remove_block_inner are pub(crate) for Signer/Encryptor
- Security metadata overrides: set_bib_target()/set_bcb_target() let Signer/Encryptor set coverage explicitly — no reparse fallback needed

# Chunk-based rebuild (zero-copy)

- Chunk type: Unchanged(Range<usize>) references original source data, New(Box<[u8]>) holds freshly encoded bytes
- rebuild(): Returns Vec<Chunk>; callers flatten explicitly
- Chunk::flatten(): Concatenates chunks with 0x9F/0xFF CBOR array wrapper
- Chunk::flatten_inplace(): Modifies source buffer in place — forward or backward pass depending on whether output grows; single scan pass + single write pass
- Chunk::assemble(): Orders chunks optimally — primary first, payload last, Unchanged extensions sorted by source position, New chunks slotted into gaps of matching size, adjacent Unchanged ranges merged
- Block extent tracking: assemble() sets block extents relative to flattened output (offset 1 for 0x9F)

# Primary block handling

- set_canonical_primary(): pub(crate) method for parser to provide pre-encoded canonical primary block bytes
- PrimaryBlock::emit() called directly instead of Bundle::emit_primary_block() — the latter removed
- build_to_vec() on builder::BlockTemplate — encodes extension blocks to standalone bytes without needing a CBOR Array encoder
- Block::copy_whole() and old array-based build_block() removed — build_chunk() is the sole path

# Signer/Encryptor

- rebuild_editor() extracted as shared internal method
- Both expose rebuild() (returns Vec<Chunk>) and rebuild_bundle() (returns (Bundle, Box<[u8]>))
- Set bib/bcb overrides explicitly during signing/encryption

# parse.rs finish() migration

- Rewritten to use Editor instead of manual CBOR emission — emit_block() removed
- Primary block: set_canonical_primary() with pre-emitted bytes
- Block removals: remove_block_inner() with panic on failure
- Non-canonical blocks: update_block_inner().with_data().rebuild()
- Returns Vec<Chunk> propagated through RewrittenBundle::Rewritten and CheckedBundle

# BPA: Zero-copy bundle rewriting at call sites

- dispatch.rs, restart.rs, local.rs: Bytes::try_into_mut() + flatten_inplace() when buffer exclusively owned; fallback to flatten() when shared
- forward.rs: rebuild() + try_into_mut / flatten_inplace for extension block updates
- adu_reassembly.rs: Same pattern for fragment reassembly
- echo-service, pipeline.rs: Same pattern for source/destination swap
- filter/chain.rs: flatten_inplace on filter-provided Vec<u8> for canonicalization

# Tests

- rebuild_bundle() roundtrip tests verify Bundle matches fresh parse (extents, block fields, BPSec coverage)
- flatten_inplace tests verify byte-identical output to flatten across no-op, destination change, block add, block remove
- All 7-implementation interop tests passing
- Significant performance improvement observed
