### PR TITLE
feat(docker-compose): use public hardy-bpa-server image url

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -51,7 +51,7 @@ services:
       dockerfile: ./bpa-server/Dockerfile
       args:
         CARGO_ARGS: "--features hardy-bpa-server/sqlite-storage,hardy-bpa-server/postgres-storage,hardy-bpa-server/s3-storage"
-    image: hardy-bpa-server:latest
+    image: ghcr.io/ricktaylor/hardy/hardy-bpa-server:latest
     restart: unless-stopped
     command: ["-u"]
     environment:
@@ -80,7 +80,7 @@ services:
     build:
       context: .
       dockerfile: ./bpa-server/Dockerfile
-    image: hardy-bpa-server:latest
+    image: ghcr.io/ricktaylor/hardy/hardy-bpa-server:latest
     restart: unless-stopped
     environment:
       HARDY_BPA_SERVER_CONFIG_FILE: /etc/hardy/config.yaml


### PR DESCRIPTION
#523

Use the ghcr's bpa-server image into the docker compose. `build` and `image` can live together in a **compose service**, and so, running the compose command (`docker compose up`) wil pull the bpa-server image from ghcr, otherwise you can use `—build` option for building an image from local project.