### PR TITLE
fix(tcpclv4): bound try_send retries so a flapping peer can't wedge a forward

### DIFF
--- a/tcpclv4/src/connection.rs
+++ b/tcpclv4/src/connection.rs
@@ -123,7 +123,12 @@ impl ConnectionPool {
         &self,
         bundle: hardy_bpa::Bytes,
     ) -> Result<hardy_bpa::cla::ForwardBundleResult, hardy_bpa::Bytes> {
-        // We repeatedly search as this function is async, so changes can happen while running
+        // We repeatedly search as this function is async, so changes can happen
+        // while running. Cap the retries so a peer whose sessions repeatedly
+        // accept-then-fail (while the pool stays above max_idle) can't wedge the
+        // forward indefinitely.
+        const MAX_RETRIES: usize = 3;
+        let mut retries = 0;
         loop {
             // Try to use an idle session
             while let Some(conn) = {
@@ -192,6 +197,14 @@ impl ConnectionPool {
                 // We can support more active connections
                 return Err(bundle);
             }
+
+            // Pool is above max_idle but nothing could send. Retry — bounded, and
+            // yielding so the tasks that manage the pool get a chance to run.
+            retries += 1;
+            if retries >= MAX_RETRIES {
+                return Err(bundle);
+            }
+            tokio::task::yield_now().await;
         }
     }
 }


### PR DESCRIPTION
## Summary

ConnectionPool::try_send can retry indefinitely under a specific connection-failure pattern, leaving a forward permanently stuck. This caps the retry loop and yields between passes, so the bundle is reported un-sendable (letting the caller apply its policy) instead
of the task wedging.

## The problem

try_send is async and the pool can change across its .await points, so it's a loop that re-drains the idle and active session sets each pass. It only re-loops when max_idle != 0 && (active + idle) > max_idle — i.e. when sessions were added concurrently.

In the normal case it returns after one pass. But if a peer's sessions repeatedly accept a send then fail the response (conn_tx.send().await.is_ok() but rx.await errors) while the pool stays above max_idle, the loop never terminates:

- it never returns Err(bundle), so the caller's failure handling (requeue / open a fresh connection / drop) never runs — the forward is wedged;
- there's no yield_now() between passes, so it doesn't hand the executor a clean point for the tasks that manage the pool to make progress.

## The fix

Cap the retries (MAX_RETRIES = 3) and yield_now() between passes, on the re-loop path:

// Pool is above max_idle but nothing could send. Retry — bounded, and
// yielding so the tasks that manage the pool get a chance to run.
retries += 1;
if retries >= MAX_RETRIES {
    return Err(bundle);
}
tokio::task::yield_now().await;

max_idle == 0 still returns Err immediately, so non-pooled sends are unaffected.

## Scope

Narrow trigger — a flapping/half-broken peer with connection pooling enabled — so this is defensive hardening against a livelock under adverse network conditions, not a bug seen in normal traffic. ~14 lines, self-contained, no dependency on any in-flight refactor.

## Testing

cargo fmt, cargo clippy --all-targets, and cargo test -p hardy-tcpclv4 all clean (24 tests pass).

## Provenance

Independently re-derived from the try_send fix in 442e5b0d on refactor/cla (a Sylvain experiment otherwise superseded on main) — the one substantive fix from that branch not already on main.