### PR TITLE
refactor(bpa): use SmallRng instead of ThreadRng for non-crypto RNG

### DIFF
--- a/bpa/Cargo.toml
+++ b/bpa/Cargo.toml
@@ -25,7 +25,6 @@ std = [
     "hardy-eid-patterns/std",
     "tracing/std",
     "rand/std",
-    "rand/thread_rng",
     "thiserror/std",
     "futures/std",
     "serde?/std",
@@ -48,7 +47,7 @@ bytes = "1"
 tracing = { version = "0.1", default-features = false }
 metrics = "0.24"
 trace-err = "1"
-rand = { version = "0.10", default-features = false, features = ["alloc", "sys_rng", "thread_rng"] }
+rand = { version = "0.10", default-features = false, features = ["alloc", "sys_rng"] }
 hashbrown = "0.17"
 foldhash = { version = "0.2", default-features = false }
 lru = { version = "0.18", default-features = false }

--- a/bpa/src/node_ids.rs
+++ b/bpa/src/node_ids.rs
@@ -91,7 +91,8 @@ impl NodeIds {
 impl Default for NodeIds {
     fn default() -> Self {
         // Node IDs are public identifiers, so a non-cryptographic PRNG suffices.
-        let mut rng = SmallRng::try_from_rng(&mut SysRng).expect("OS RNG unavailable");
+        let mut rng = SmallRng::try_from_rng(&mut SysRng)
+            .expect("OS RNG must be available to seed the node-id PRNG");
         Self {
             ipn: Some(IpnNodeId {
                 allocator_id: rng.random_range(0x40000000..0x80000000),

--- a/bpa/src/node_ids.rs
+++ b/bpa/src/node_ids.rs
@@ -1,5 +1,8 @@
 use hardy_bpv7::eid::{DtnNodeId, Eid, IpnNodeId, NodeId};
-use rand::RngExt;
+use rand::{
+    RngExt, SeedableRng,
+    rngs::{SmallRng, SysRng},
+};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -87,7 +90,8 @@ impl NodeIds {
 
 impl Default for NodeIds {
     fn default() -> Self {
-        let mut rng = rand::rng();
+        // Node IDs are public identifiers, so a non-cryptographic PRNG suffices.
+        let mut rng = SmallRng::try_from_rng(&mut SysRng).expect("OS RNG unavailable");
         Self {
             ipn: Some(IpnNodeId {
                 allocator_id: rng.random_range(0x40000000..0x80000000),

--- a/bpa/src/storage/bundle_mem.rs
+++ b/bpa/src/storage/bundle_mem.rs
@@ -1,16 +1,17 @@
-use super::{BundleStorage, RecoveryResponse, Result};
-use crate::{Arc, Bytes, stream::Sender};
 use core::num::{NonZero, NonZeroUsize};
+
 use hardy_async::{async_trait, sync::Mutex};
 use rand::{
     SeedableRng,
     distr::{Alphanumeric, SampleString},
     rngs::{SmallRng, SysRng},
 };
-use tracing::info;
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use super::{BundleStorage, RecoveryResponse, Result};
+use crate::{Arc, Bytes, stream::Sender};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -51,7 +52,8 @@ impl BundleMemStorage {
         let inner = Mutex::new(Inner {
             cache: lru::LruCache::unbounded(),
             capacity: 0,
-            rng: SmallRng::try_from_rng(&mut SysRng).expect("OS RNG unavailable"),
+            rng: SmallRng::try_from_rng(&mut SysRng)
+                .expect("OS RNG must be available to seed the storage-name PRNG"),
         });
         let max_capacity = config.capacity;
         let min_bundles = config.min_bundles;

--- a/bpa/src/storage/bundle_mem.rs
+++ b/bpa/src/storage/bundle_mem.rs
@@ -1,13 +1,16 @@
-use core::num::{NonZero, NonZeroUsize};
-
-use hardy_async::{async_trait, sync::Mutex};
-use rand::distr::{Alphanumeric, SampleString};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use tracing::info;
-
 use super::{BundleStorage, RecoveryResponse, Result};
 use crate::{Arc, Bytes, stream::Sender};
+use core::num::{NonZero, NonZeroUsize};
+use hardy_async::{async_trait, sync::Mutex};
+use rand::{
+    SeedableRng,
+    distr::{Alphanumeric, SampleString},
+    rngs::{SmallRng, SysRng},
+};
+use tracing::info;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -29,6 +32,7 @@ impl Default for Config {
 struct Inner {
     cache: lru::LruCache<String, (time::OffsetDateTime, Bytes)>,
     capacity: usize,
+    rng: SmallRng,
 }
 
 pub struct BundleMemStorage {
@@ -47,6 +51,7 @@ impl BundleMemStorage {
         let inner = Mutex::new(Inner {
             cache: lru::LruCache::unbounded(),
             capacity: 0,
+            rng: SmallRng::try_from_rng(&mut SysRng).expect("OS RNG unavailable"),
         });
         let max_capacity = config.capacity;
         let min_bundles = config.min_bundles;
@@ -96,13 +101,12 @@ impl BundleStorage for BundleMemStorage {
     }
 
     async fn save(&self, data: Bytes) -> Result<Arc<str>> {
-        let mut rng = rand::rng();
         let new_len = data.len();
 
         loop {
-            let storage_name = Alphanumeric.sample_string(&mut rng, 64);
-
             let mut inner = self.inner.lock();
+            // Storage names only need to be unique, not unpredictable.
+            let storage_name = Alphanumeric.sample_string(&mut inner.rng, 64);
             if inner.cache.contains(&storage_name) {
                 continue;
             }


### PR DESCRIPTION
### Summary
`bpa` has two RNG sites, neither of which needs cryptographic randomness:

- `NodeIds::default()` — invents a fallback IPN node ID. Node IDs are **public identifiers** (they're advertised), so they need to
avoid collisions, not be unpredictable.
- `BundleMemStorage::save()` — mints in-memory storage keys. These are **internal handles** that need to be unique, not
unguessable.

Both used `rand::rng()` (`ThreadRng`). This PR switches them to `SmallRng`, seeded once from the OS (`SysRng`), and drops `bpa`'s
now-unused `rand/thread_rng` feature.

### Why
- **Right tool for the job:** `SmallRng` (xoshiro) is a fast, non-cryptographic PRNG — appropriate for
uniqueness/collision-avoidance. Cryptographic randomness in Hardy lives in `bpv7` BPSec, which already uses `SysRng` and is
untouched here.
- **Smaller surface:** removes the reseeding `ThreadRng` machinery — and the `chacha20` backend — from `bpa`, sidestepping the `rand` `ThreadRng` soundness advisory class entirely.

### Changes
- `bpa/src/node_ids.rs` — seed a `SmallRng` from `SysRng` for the fallback node ID.
- `bpa/src/storage/bundle_mem.rs` — hold a `SmallRng` in `Inner`, seeded once at construction; draw storage keys from it under the existing lock.
- `bpa/Cargo.toml` — drop `rand/thread_rng` (keep `sys_rng` for seeding).
