### PR TITLE
docs: add AGENTS.md/CLAUDE.md and consolidate style guides under docs/style_guides/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Full reference: [`docs/style_guides/code_style_guide.md`](./docs/style_guides/co
 
 - **Write idiomatic Rust.** Default to community-standard idioms (the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) and [Rust Style Guide](https://doc.rust-lang.org/style-guide/)); the guide only records project-specific conventions, and Clippy enforces most of the rest.
 - **Formatting is `rustfmt`-decided.** Run `cargo fmt`; never hand-format to deviate from it.
-- **`use` statements form up to four blank-line-separated blocks**, in order: `super::`, then `std`/`core`/`alloc`, then `crate::`, then external crates. Merge imports from one path with `{}` rather than repeating the prefix.
+- **`use` statements form up to three blank-line-separated blocks**, in order: `std`/`core`/`alloc`, then third-party crates, then local (`crate::`/`super::`/`self::`) — the rustfmt `group_imports = "StdExternalCrate"` order. Collapse same-crate imports into one nested `use` (`imports_granularity = "Crate"`, e.g. `use crate::{bundle::Bundle, eid::Eid};`); avoid glob imports (`use foo::*;`) except `super::*` in leaf/test modules.
 - **Set visibility at the definition.** Use `pub`/`pub(crate)` on the item itself; do not widen or narrow it via re-exports elsewhere. Inside a private or `pub(crate)` module, write plain `pub`, not redundant `pub(crate)`.
 - **32-bit safe.** Hardy targets 32-bit. Never `as usize` a wire-derived `u64` length — compare in `u64` first, then `try_from`.
 - **Errors are `thiserror` enums** with a `#[error("…")]` per variant; modules expose `pub type Result<T> = core::result::Result<T, Error>`. Give sub-parsers focused leaf error types rather than reusing a crate-root `Error`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# Hardy — agent guide
+
+Hardy is a performant, RFC 9171-compliant, extensible BPv7 Delay-Tolerant Networking (DTN) implementation, written in async Rust. It is a Cargo workspace on the **stable** toolchain; the edition and MSRV are defined in the workspace [`Cargo.toml`](./Cargo.toml) (`[workspace.package]`). See [`README.md`](./README.md) for the full feature list and the complete crate inventory.
+
+## Workspace layout
+
+The workspace is split into many small crates. The ones you will touch most often:
+
+- `cbor/` — RFC 8949 canonical CBOR codec (`no_std`).
+- `bpv7/` — RFC 9171 bundle format: parsing, building, editing, BPSec (`no_std`).
+- `bpa/` — the Bundle Processing Agent library: routing, dispatch, filter pipeline, RIB, storage/CLA/service registries.
+- `bpa-server/` — the binary that wires the BPA together; closed-source extensions register against the **unmodified** `bpa` crate via public traits.
+- `eid-patterns/`, `async/`, `proto/`, `otel/` — supporting libraries.
+- `*-storage/` — pluggable storage backends (localdisk, sqlite, postgres, s3).
+- `tcpclv4/`, `file-cla/`, `bibe/` — convergence layers; `tvr/` — Time-Variant Routing agent.
+- `tools/`, `bpv7/tools/`, `cbor/tools/` — CLI tools (`bp`, `bundle`, `cbor`).
+
+`tests/interop/mtcp` is excluded from the workspace and built separately.
+
+## Build, test, lint
+
+Proto-dependent crates require `protoc` (CI installs `protobuf-compiler`). Common commands:
+
+```bash
+cargo build --release                          # build everything
+cargo test --workspace --all-features          # run the test suite
+cargo fmt                                       # format
+cargo clippy --all-targets --all-features      # lint
+```
+
+**A change is not done until these CI gates pass** — run them before handing work back:
+
+```bash
+cargo fmt --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --all-features --workspace
+```
+
+Clippy is enforced with `-D warnings`: no warnings are allowed to land.
+
+## Code style — the essentials
+
+Full reference: [`docs/style_guides/code_style_guide.md`](./docs/style_guides/code_style_guide.md). Existing code does not all comply — apply these only to files you are already changing for another reason, never as a standalone reformatting sweep. The rules most easily missed:
+
+- **Write idiomatic Rust.** Default to community-standard idioms (the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) and [Rust Style Guide](https://doc.rust-lang.org/style-guide/)); the guide only records project-specific conventions, and Clippy enforces most of the rest.
+- **Formatting is `rustfmt`-decided.** Run `cargo fmt`; never hand-format to deviate from it.
+- **`use` statements form up to four blank-line-separated blocks**, in order: `super::`, then `std`/`core`/`alloc`, then `crate::`, then external crates. Merge imports from one path with `{}` rather than repeating the prefix.
+- **Set visibility at the definition.** Use `pub`/`pub(crate)` on the item itself; do not widen or narrow it via re-exports elsewhere. Inside a private or `pub(crate)` module, write plain `pub`, not redundant `pub(crate)`.
+- **32-bit safe.** Hardy targets 32-bit. Never `as usize` a wire-derived `u64` length — compare in `u64` first, then `try_from`.
+- **Errors are `thiserror` enums** with a `#[error("…")]` per variant; modules expose `pub type Result<T> = core::result::Result<T, Error>`. Give sub-parsers focused leaf error types rather than reusing a crate-root `Error`.
+- **`no_std` core.** `cbor`, `bpv7`, and `bpa` are `no_std` + `alloc`; gate `std` behind a feature, don't assume it.
+- **Comments describe the present.** No "moved from / replaces the old X / now takes Y" porting narration — git holds that history.
+
+## Documentation & prose
+
+- Rustdoc on public items follows [`docs/style_guides/rustdoc_style_guide.md`](./docs/style_guides/rustdoc_style_guide.md).
+- **Markdown: one line per paragraph — do not hard-wrap at 80 columns.**
+
+## Style guides
+
+All in [`docs/style_guides/`](./docs/style_guides/):
+
+| Topic | Guide |
+|-------|-------|
+| Rust code conventions | [code_style_guide.md](./docs/style_guides/code_style_guide.md) |
+| Rustdoc comments | [rustdoc_style_guide.md](./docs/style_guides/rustdoc_style_guide.md) |
+| Per-crate design docs | [design_doc_style_guide.md](./docs/style_guides/design_doc_style_guide.md) |
+| Per-crate READMEs | [readme_style_guide.md](./docs/style_guides/readme_style_guide.md) |
+| Test coverage reports | [coverage_report_style_guide.md](./docs/style_guides/coverage_report_style_guide.md) |
+
+For the overall testing approach, see [`docs/test_strategy.md`](./docs/test_strategy.md) — a deliverable document, not a style guide.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -224,11 +224,11 @@ See [tests/interop/README.md](./tests/interop/README.md) for details.
 We welcome contributions to the Hardy project! If you would like to contribute, please follow these guidelines:
 
 1. Fork the repository and create a new branch for your contribution.
-2. Make your changes and ensure that the code follows the project's coding style and conventions.
+2. Make your changes and ensure the code follows the [coding style guide](./docs/style_guides/code_style_guide.md) and passes the CI checks (`cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings`).
 3. Write tests to cover your changes and ensure that all existing tests pass.
 4. Submit a pull request with a clear description of your changes and the problem they solve.
 
-Before contributing, please familiarize yourself with the project's [Test Strategy](./docs/test_strategy.md) to understand our approach to quality and verification.
+Before contributing, please familiarize yourself with the [coding style guide](./docs/style_guides/code_style_guide.md) and the project's [Test Strategy](./docs/test_strategy.md) to understand our conventions and approach to quality. [`AGENTS.md`](./AGENTS.md) summarises the build, test, and style essentials in one place — it is also the file that AI coding assistants load.
 
 By contributing to Hardy, you agree to license your contributions under the project's license.
 

--- a/docs/style_guides/code_style_guide.md
+++ b/docs/style_guides/code_style_guide.md
@@ -60,28 +60,52 @@ Follow standard Rust naming (Clippy enforces most of it):
 
 ## Imports and `use` Blocks
 
-Organise `use` statements into up to four blocks, each separated by a single blank line, in this order:
+Organise `use` statements into up to three blocks, each separated by a single blank line, in this order:
 
-1. `super::` (and `self::`) imports — e.g. `use super::*;`
-2. The standard library — `std::…`, `core::…`, and `alloc::…` all share this one block (`no_std` crates use `core`/`alloc` in place of `std`)
-3. Crate-internal — `crate::…`
-4. External crates — `<external_crate>::…`
+1. The standard library — `std::…`, `core::…`, and `alloc::…` all share this one block (`no_std` crates use `core`/`alloc` in place of `std`).
+2. Third-party crates — `<external_crate>::…`.
+3. Local imports — `crate::…`, `super::…`, and `self::…` share this one block.
 
-Omit any block that has no imports (hence "up to four") — never leave an empty block. `rustfmt` sorts within each block and preserves the blank-line separation, but it does not reorder or merge the blocks themselves, so the order above is a manual discipline.
-
-Group several imports from the same path with brace syntax rather than repeating the prefix (`use crate::foo::{Bar, Baz}`, not two `use crate::foo::…` lines):
+This is the order of the (currently unstable) rustfmt option `group_imports = "StdExternalCrate"`: writing it by hand now means that if the option stabilises and we enable it, `cargo fmt` reproduces the layout with no churn. Omit any block that has no imports (hence "up to three") — never leave an empty block. `rustfmt` sorts within each block and preserves the blank-line separation, but under its default settings it does not reorder or merge the blocks themselves, so the order above is a manual discipline.
 
 ```rust
-use super::*;
-
 use core::num::NonZeroUsize;
 
-use crate::{bundle::Bundle, eid::Eid};
-
 use thiserror::Error;
+
+use crate::{bundle::Bundle, eid::Eid};
 ```
 
-`use super::*;` is the exception, not the default. Reach for it only in a **leaf module** — where one logical module has been split across several deeply-interrelated files that legitimately share the parent's imports — to avoid re-listing those shared dependencies in every file. In ordinary submodules, list imports explicitly rather than glob-importing the parent.
+**Collapse imports that share a leading path** into a single nested statement rather than repeating that prefix across lines: factor out the shared part and group the divergent tails in braces.
+
+```rust
+// preferred
+use crate::{bundle::Bundle, eid::Eid};
+
+// avoid — repeats the `crate` prefix
+use crate::bundle::Bundle;
+use crate::eid::Eid;
+```
+
+This is the rustfmt `imports_granularity = "Crate"` layout; like the block order above, writing it by hand keeps `cargo fmt` a no-op if the option is ever enabled (it defaults to `Preserve`, so the merging is manual for now). Avoid the opposite, Java-style extreme of giving every item its own fully-qualified line.
+
+**Avoid glob imports** (`use some_crate::*;`). Pulling every item from a crate into scope hides where each name comes from: when a dependency is later updated and removes or renames an item, the compiler reports an undefined symbol with no hint which glob it came from, and a newly-added upstream item can silently clash with a name from another glob. Explicit imports keep that traceable for the next maintainer.
+
+`use super::*;` is the one sanctioned glob, and even then it is the exception, not the default. Reach for it only in a **leaf module** — where one logical module has been split across several deeply-interrelated files that legitimately share the parent's imports — or in a **unit-test module**, where `#[cfg(test)] mod tests { use super::*; … }` is the well-defined idiom (see [Tests](#tests)). In ordinary submodules, list imports explicitly rather than glob-importing the parent.
+
+**Don't glob enum variants into scope** (`use SomeEnum::*;`) — it hides the variants' type and can obscure that an enum is being handled at all. Spell out `SomeEnum::Variant` in full, including in `match` arms. The visible type is the point, not noise; no local rename is worth losing it.
+
+**Keep `use` at module scope.** Imports belong at the top of the file (or `mod` block), never inside a function body. A reader should find every path a function depends on in one place, and a function-local `use` — an alias especially — hides where a name really comes from.
+
+**Name child modules through `self::`** when importing or re-exporting from them (`use self::foo::Foo;`, `pub use self::foo::Foo;`). The explicit `self::` distinguishes the child module from a same-named dependency, so introducing a crate called `foo` later cannot silently change what the path resolves to.
+
+```rust
+mod config;
+mod error;
+
+pub use self::config::Config;
+pub use self::error::Error;
+```
 
 ## Visibility
 

--- a/docs/style_guides/code_style_guide.md
+++ b/docs/style_guides/code_style_guide.md
@@ -1,0 +1,185 @@
+# Rust Code Style Guide
+
+This guide defines the general Rust coding conventions used across Hardy crates. It complements the more specialised guides — [rustdoc](rustdoc_style_guide.md) for doc comments, [design docs](design_doc_style_guide.md), [READMEs](readme_style_guide.md), and [coverage reports](coverage_report_style_guide.md) — and is based on the patterns already established in `hardy-cbor`, `hardy-bpv7`, `hardy-bpa`, and `hardy-async`.
+
+The conventions here are what reviewers expect and what keeps a change reading like the code around it. When in doubt, match the surrounding module and write idiomatic Rust.
+
+## Applying These Conventions
+
+These conventions have converged over time, so not all existing code complies with every rule here. That is expected. **Do not make style-only sweeps across untouched files** — they create large, hard-to-review diffs and churn history for no functional gain.
+
+Bring a file into line with this guide only when you are already modifying it for another reason, and keep the tidy-ups proportionate to the change so the substantive diff stays easy to review.
+
+## Idiomatic Rust First
+
+Default to idiomatic, community-standard Rust. This guide records Hardy's *project-specific* conventions and the few places we deviate from the norm — it is not a complete style manual. For everything it does not cover, follow the canonical references:
+
+- [The Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) — the checklist for predictable, idiomatic public APIs (naming, trait implementations, interoperability).
+- [The Rust Style Guide](https://doc.rust-lang.org/style-guide/) — the formatting and layout conventions that `rustfmt` implements.
+- [The Rust Book](https://doc.rust-lang.org/book/) and [Rust by Example](https://doc.rust-lang.org/rust-by-example/) — idioms and patterns.
+
+Clippy is the practical enforcer of most of these idioms; under `-D warnings` (see [Linting](#linting)) its suggestions are not optional. Prefer the idioms the compiler and Clippy steer you toward:
+
+- Express flow with iterators and `Option`/`Result` combinators (`map`, `and_then`, `ok_or`, `?`) rather than manual index loops or nested matches, where it reads more clearly.
+- Implement the standard conversion and formatting traits — `From` / `TryFrom`, `Display`, `FromStr`, `Default`, `Iterator` — instead of bespoke `to_x` / `from_x` methods, so types compose with the ecosystem. (EIDs parse via `FromStr`; bundles are constructed with a builder; dropping a `Sink` unregisters via `Drop` — RAII.)
+- Accept borrowed types in function signatures (`&str`, `&[T]`, `impl AsRef<…>`) and return owned values; do not take `String` / `Vec<T>` by value just to read from it.
+- Use the newtype pattern to give wire and domain values distinct types rather than threading raw integers around.
+- Avoid needless `clone()` and intermediate allocations on hot paths — borrow, or move, instead.
+
+## Toolchain and Edition
+
+- The workspace targets the **stable** toolchain (`rust-toolchain.toml` pins `channel = "stable"` with `rustfmt` and `clippy`).
+- The edition and MSRV are defined once in the workspace [`Cargo.toml`](../Cargo.toml) (`[workspace.package]` `edition` and `rust-version`) and inherited per crate via `edition.workspace = true` / `rust-version.workspace = true` — never hard-code them in a crate's `Cargo.toml`. Check that file for the current values.
+- Do not use nightly-only features. If a feature is not available on the stable toolchain at the workspace MSRV, it is not available here.
+
+## Formatting
+
+Formatting is decided by `rustfmt` with default settings — there is no `rustfmt.toml`. Run `cargo fmt` (editors in the repo format on save). Do not hand-format code to deviate from what `rustfmt` produces; CI runs `cargo fmt --check` and a mismatch fails the build.
+
+## Linting
+
+Clippy is a hard gate. CI runs:
+
+```bash
+cargo clippy --locked --all-targets --all-features -- -D warnings
+```
+
+Every warning is an error, across all targets and all features. Fix the lint rather than suppressing it. If a lint genuinely does not apply, use a narrowly-scoped `#[allow(...)]` on the specific item (not a crate-wide allow) with a `//` comment explaining why.
+
+There is no `[workspace.lints]` table; lint levels come from clippy's defaults under `-D warnings`. Do not add per-crate lint configuration without discussing it first.
+
+## Naming
+
+Follow standard Rust naming (Clippy enforces most of it):
+
+- `snake_case` for functions, methods, variables, modules, and crate features.
+- `UpperCamelCase` for types, traits, and enum variants.
+- `SCREAMING_SNAKE_CASE` for constants and statics.
+- Crate names are `hardy-<name>` (hyphenated) on disk and `hardy_<name>` when imported.
+- Prefer descriptive names over abbreviations, but keep domain terms from the RFCs intact (`eid`, `cla`, `bpsec`, `bib`, `bcb`) — they are the vocabulary of the codebase.
+
+## Imports and `use` Blocks
+
+Organise `use` statements into up to four blocks, each separated by a single blank line, in this order:
+
+1. `super::` (and `self::`) imports — e.g. `use super::*;`
+2. The standard library — `std::…`, `core::…`, and `alloc::…` all share this one block (`no_std` crates use `core`/`alloc` in place of `std`)
+3. Crate-internal — `crate::…`
+4. External crates — `<external_crate>::…`
+
+Omit any block that has no imports (hence "up to four") — never leave an empty block. `rustfmt` sorts within each block and preserves the blank-line separation, but it does not reorder or merge the blocks themselves, so the order above is a manual discipline.
+
+Group several imports from the same path with brace syntax rather than repeating the prefix (`use crate::foo::{Bar, Baz}`, not two `use crate::foo::…` lines):
+
+```rust
+use super::*;
+
+use core::num::NonZeroUsize;
+
+use crate::{bundle::Bundle, eid::Eid};
+
+use thiserror::Error;
+```
+
+`use super::*;` is the exception, not the default. Reach for it only in a **leaf module** — where one logical module has been split across several deeply-interrelated files that legitimately share the parent's imports — to avoid re-listing those shared dependencies in every file. In ordinary submodules, list imports explicitly rather than glob-importing the parent.
+
+## Visibility
+
+Control an item's visibility **at its own definition**, using `pub` or `pub(crate)` on the item. Do not widen or restrict visibility indirectly through re-exports or wrapper modules elsewhere — the `pub` keyword on the declaration is the single source of truth for how visible something is.
+
+Inside a module that is itself private or `pub(crate)`, write plain `pub`, not `pub(crate)`. The enclosing module already caps visibility, so `pub(crate)` is redundant noise (the codebase does not rely on `unreachable_pub`).
+
+Re-export public API at the crate root where it aids discoverability, but document each item at its definition, not at the re-export.
+
+## Error Handling
+
+Crates and subsystems define their own error enums with [`thiserror`](https://docs.rs/thiserror):
+
+```rust
+#[derive(Error, Debug)]
+pub enum Error {
+    /// Indicates that the bundle protocol version is unsupported.
+    #[error("Unsupported bundle protocol version {0}")]
+    InvalidVersion(u64),
+}
+```
+
+- Give every variant a `#[error("…")]` message and a `///` doc line.
+- Modules expose a local result alias: `pub type Result<T> = core::result::Result<T, Error>;`.
+- Prefer **focused, leaf error types** for self-contained sub-parsers over reusing a crate-root `Error`. A small parser returning the whole crate's error enum leaks unrelated variants into its signature.
+- Use `?` for propagation. Convert between error types with `#[from]` or explicit `map_err`, not by stringifying.
+- Avoid `.unwrap()` / `.expect()` on fallible paths in library code. They are acceptable only where an invariant guarantees success — in which case use `.expect("reason the invariant holds")` so the message documents the invariant. Tests may unwrap freely.
+- Never `panic!` in response to malformed wire input — parsers return errors. This is a security property, verified by fuzzing.
+
+## 32-bit Safety
+
+Hardy targets 32-bit platforms, so `usize` may be 32 bits wide. Wire formats carry 64-bit lengths and offsets.
+
+**Never cast a wire-derived `u64` to `usize` with `as`.** Compare and validate in `u64` first, then convert with `try_from` and handle the error:
+
+```rust
+if len > MAX_LEN as u64 {
+    return Err(Error::TooLong(len));
+}
+let len = usize::try_from(len).map_err(|_| Error::TooLong(len))?;
+```
+
+A silent `as usize` truncation on a 32-bit target is a parsing bug and a potential vulnerability.
+
+## `no_std` and Feature Flags
+
+The core libraries (`hardy-cbor`, `hardy-bpv7`, `hardy-bpa`) are `no_std`-compatible with an allocator. Keep them that way:
+
+```rust
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+```
+
+- Import from `core` and `alloc`, not `std`, in `no_std` crates (`core::result::Result`, `alloc::vec::Vec`, etc.).
+- Gate anything requiring the standard library behind a `std` feature, and propagate it to dependencies.
+- Features should be additive — enabling one must not break another. Code must compile with `--all-features` (CI builds this way) and with default features.
+- Document every feature flag in the crate-level doc comment (see the [rustdoc guide](rustdoc_style_guide.md)).
+
+## Comments
+
+- Doc comments (`///`, `/*! */`) document the public API — see the [rustdoc guide](rustdoc_style_guide.md). Public items require them; private and `pub(crate)` items do not.
+- Use `//` line comments for non-obvious private logic and for surprising trait-impl behaviour.
+- **Comments describe the present state of the code, not its history.** No "moved from X", "replaces the old Y", "now takes Z" porting narration — git holds that history, and stale migration notes mislead.
+- Explain *why*, not *what*, when the *what* is already clear from the code.
+
+## Async and Concurrency
+
+- Use the runtime-agnostic primitives in `hardy-async` rather than reaching for `tokio` directly: `TaskPool` / `BoundedTaskPool` for spawning, the `spawn!` macro for tracing-instrumented tasks, cancellation tokens for shutdown.
+- `hardy_async::sync::spin::{Mutex, RwLock, Once}` are for **O(1) critical sections only** — never hold a spin lock across an `.await`. For anything that awaits or does real work, use an async-aware lock.
+- Subsystems (CLAs, services, routing agents) follow the **Trait + Sink** pattern: a trait with `on_register(sink, …)` / `on_unregister()`, a `Sink` back-channel, and dropping the `Sink` triggers automatic unregistration. New pluggable components should match this shape.
+
+## Logging and Observability
+
+- Use the `tracing` macros (`tracing::debug!`, `error!`, `instrument`) for logging and spans — not `println!` / `eprintln!` in library or server code.
+- Keep log levels meaningful: `error!` for faults needing attention, `debug!`/`trace!` for diagnostics. Don't log per-bundle at `info!` on hot paths.
+
+## Cargo and Dependencies
+
+- Inherit shared package metadata from the workspace (`edition`, `rust-version`, `license`, `repository`) with `.workspace = true`.
+- There is no `[workspace.dependencies]` table — dependencies are declared per crate. Keep versions consistent with what the rest of the workspace already uses (check the lockfile / a sibling crate before bumping).
+- Keep dependencies minimal and justified; new third-party crates pass through `cargo deny` / the security-audit CI workflow.
+
+## Tests
+
+Where a test lives depends on what it needs to reach:
+
+- **Integration tests — the default.** If a test exercises a crate's public API, put it in the crate's `tests/` directory (a sibling of `src/`). These compile as separate crates and can only see the public surface, which keeps them honest about what the crate actually exposes.
+- **In-file unit tests — only for private access.** Add a `#[cfg(test)] mod tests { use super::*; … }` block at the bottom of a source file *only* when the test needs access to private module or file internals that are not (and should not be) public. This is the one place `use super::*;` is expected — the test module deliberately pulls in its parent's private items. When such a test module grows large relative to the source it covers, move it into a dedicated `tests.rs` file in the module (declared with `#[cfg(test)] mod tests;`) rather than letting it dominate the source file; as a child module it retains the same private access.
+
+Conventions for both:
+
+- Test functions are `snake_case` and name the scenario under test.
+- Do not add rustdoc to test functions or test helpers.
+- Parsers and protocol stream handlers also have fuzz targets under the crate's `fuzz/` directory; new wire-facing parsing code should come with one.
+
+See the [test strategy](../test_strategy.md) for the overall testing approach across unit, integration, fuzz, and interop levels.
+
+## Markdown and Prose (for docs you write)
+
+- **One line per paragraph — do not hard-wrap at 80 columns.** Let the renderer wrap.
+- Follow the relevant guide for the document type: [design docs](design_doc_style_guide.md), [READMEs](readme_style_guide.md), [coverage reports](coverage_report_style_guide.md).

--- a/docs/style_guides/coverage_report_style_guide.md
+++ b/docs/style_guides/coverage_report_style_guide.md
@@ -1,0 +1,221 @@
+# Test Coverage Report Style Guide
+
+This guide defines the style and content expectations for per-crate `test_coverage_report.md` documents in Hardy.
+
+## Purpose
+
+Coverage reports capture the **current state of test verification** against requirements. They answer: "what is tested, how, and what remains?" They are for reviewers assessing compliance and engineers planning test work.
+
+Coverage reports are **living documents** — updated when tests are added, not snapshots frozen in time. The date in the header reflects the last update.
+
+## What Belongs in Coverage Reports
+
+- **LLR verification status** — which requirements are verified and by which tests
+- **Test inventory** — what tests exist, where they are, what they cover
+- **Coverage metrics** — line coverage from `cargo llvm-cov` / `lcov`
+- **Gap analysis** — what is not yet tested and why
+- **Cross-references** — tests in other crates that verify requirements assigned to this crate
+
+## What Does NOT Belong in Coverage Reports
+
+- **Test plan content** — don't duplicate test descriptions from the test plans; link to them
+- **Bug reports or change history** — coverage reports track current state, not how we got here
+- **Implementation details** — don't explain how the code works; the design doc does that
+- **Aspirational targets** — report what IS covered, not what coverage SHOULD be
+
+## Document Structure
+
+Every coverage report should follow this structure. Sections may be omitted if genuinely not applicable (e.g., no fuzz targets), but the ordering should be preserved.
+
+```markdown
+# <Crate Name> Test Coverage Report
+
+| Document Info | Details |
+| :--- | :--- |
+| **Module** | `<crate-name>` |
+| **Standard** | <RFC or spec reference, if applicable> |
+| **Test Plans** | [links to unit, component, fuzz test plans] |
+| **Date** | <YYYY-MM-DD of last update> |
+```
+
+### Section 1: LLR Coverage Summary (Requirements Verification Matrix)
+
+This section serves as the **test verification report** referenced by the [Part 4 Requirements Verification Matrix](../requirements.md#part-4-requirements-verification-matrix). It provides end-to-end traceability from top-level requirements through LLRs to individual test results.
+
+A table mapping every LLR assigned to this crate to its verification status and result.
+
+```markdown
+| LLR | Feature | Result | Test | Part 4 Ref |
+| :--- | :--- | :--- | :--- | :--- |
+| **1.1.25** | Valid canonical bundle generation | Pass | `builder.rs::test_builder` + CLI CREATE-01..03 | 1.2 |
+| **1.1.33** | Bundle Age for expiry | N/A | Enforced by BPA, not parser | 1.2 |
+```
+
+- **Lead with a one-line summary**: "All LLRs verified (N pass, M N/A)" or "N of M LLRs pass"
+- **Every assigned LLR must appear** — even if N/A or not tested
+- **Result values**: `Pass` (test exists and passes), `Fail` (test exists and fails), `N/A` (not applicable to this crate), `Not tested` (no test exists)
+- **Test column**: cite specific test function names, not just file paths
+- **Part 4 Ref column**: the mid-level requirement ID from the [Part 4 matrix](../requirements.md#part-4-requirements-verification-matrix) that this LLR traces to (e.g., `1.2` for "demonstrate support via a test verification report of 1.1")
+- **Cross-crate coverage**: when an LLR is verified by another crate's tests, say `Pass (bpv7)` and cite the specific test. The Part 4 Ref still traces to the top-level requirement
+
+The Part 4 matrix defines two types of mid-level requirement:
+- **Compliance matrix** (e.g., 1.1, 3.1): "deliver a compliance verification matrix" — satisfied by the PICS proforma or RFC compliance matrix documents
+- **Test verification** (e.g., 1.2, 3.2): "demonstrate support via a test verification report" — satisfied by this LLR table, where every row with `Result = Pass` is evidence of verification
+
+### Section 2: Test Inventory
+
+List all tests, grouped by type:
+
+- **Unit tests**: table with columns `Test Function | File | Plan Section | Scope`
+- **Component/integration tests**: separate subsection with test script path and suite breakdown
+- **Fuzz tests**: table with `Target | File | Status`
+
+Include a total count for each group.
+
+When a crate has no unit tests, state "No unit tests are implemented" and reference the test plan for rationale (e.g., "see `PLAN-FOO-01` §4 for rationale"). The test plan should explain *why* — thin wrapper, logic verified end-to-end, or backend-specific scenarios would test third-party library semantics. Don't duplicate the rationale in both documents.
+
+### Section 3: Coverage vs Plan
+
+A table cross-referencing test plan sections against implementation status:
+
+```markdown
+| Section | Scenario | Planned | Implemented | Status |
+```
+
+- **Planned**: number of scenarios in the test plan
+- **Implemented**: number with passing tests
+- **Status**: `Complete`, `N/M remaining`, or `Delegated to <crate>`
+- **Delegated tests**: when a plan section is covered by another crate, use `—` for Planned/Implemented counts and explain in Status. Adjust totals accordingly
+- **Include a total row** with percentage
+
+### Section 4: Line Coverage
+
+Output from `cargo llvm-cov` / `lcov --summary`:
+
+```markdown
+cargo llvm-cov test --package <name> --lcov --output-path lcov.info
+lcov --summary lcov.info
+```
+
+- **Quote the summary output** in a code block
+- **Provide per-file breakdown** as a table: `File | Covered | Total | Coverage | Notes`
+- **Sort by coverage descending** — readers see strengths first, gaps last
+- **Note what the numbers exclude**: "unit tests only" or "includes integration tests"
+- **Explain anomalies**: generic monomorphisation inflating function counts, Display impls at 0%, etc.
+
+If line coverage has not yet been measured, include the command block so the reader can run it:
+
+```markdown
+```
+cargo llvm-cov test --package <name> --lcov --output-path lcov.info --html
+lcov --summary lcov.info
+```
+```
+
+Don't say "has not been run" — provide the command and leave space for results to be added. If line coverage is genuinely not applicable (e.g., thin wrapper with no unit tests and all verification via external harness), state why and omit the section.
+
+**Fuzz coverage**: For crates with fuzz targets, include a separate subsection showing how to generate fuzz coverage from the corpus. This measures which code paths the fuzzer has discovered, complementing the unit test coverage:
+
+```markdown
+### Fuzz Coverage
+
+```
+cargo +nightly fuzz coverage <target>
+cargo +nightly cov -- export --format=lcov ...
+lcov --summary ./fuzz/coverage/<target>/lcov.info
+```
+```
+
+Fuzz coverage is complementary to unit test coverage: unit tests verify correctness against known inputs, fuzz verifies robustness against adversarial input. When both are available, note this and explain what each layer contributes.
+
+### Section 5: Test Infrastructure
+
+Brief description of how tests are structured:
+
+- What test helpers/fixtures exist (e.g., `make_store()`, `Bpa::builder()`)
+- What mock types are used and where they live
+- Runtime requirements (e.g., `multi_thread` for concurrent tests)
+- Patterns that future test authors should follow
+
+This section is optional for simple crates with straightforward tests.
+
+### Section 6: Key Gaps
+
+A table of remaining coverage gaps:
+
+```markdown
+| Area | Gap | Severity | Notes |
+```
+
+- **Only list genuine gaps** — not items covered by other crates
+- **Severity**: High (LLR unverified), Medium (significant code path untested), Low (edge case or defence-in-depth)
+- **If no gaps remain**, state that explicitly: "All LLRs verified. No significant gaps remain."
+
+### Section 7: Conclusion
+
+A single paragraph summarising:
+
+- Total test count and plan coverage percentage
+- Line coverage percentage
+- How many LLRs are verified (the headline metric)
+- Key strengths (what's well-tested)
+- Primary remaining gaps (if any)
+- Other test layers that contribute (fuzz, interop, CLI)
+
+## Cross-Crate References
+
+When a crate delegates verification to another crate:
+
+- **In the LLR table**: use `Verified (other-crate)` status and cite the specific test
+- **In Coverage vs Plan**: use `Delegated to <crate>` and adjust totals to show "in-scope" vs "total"
+- **Don't double-count**: if a test in crate A verifies an LLR assigned to crate B, only crate B's report should count it as verified. Crate A's report should note it as "Verified (crate B)" without inflating its own counts
+
+## Consistency Rules
+
+- **Header table**: always use `| :--- | :--- |` alignment
+- **Date format**: `YYYY-MM-DD`
+- **Test function names**: use `file::function_name` format (e.g., `parse.rs::ccsds_compliance`)
+- **LLR references**: bold the ID (e.g., `**1.1.30**`)
+- **Percentages**: one decimal place for line coverage (e.g., 78.2%), zero for plan coverage (e.g., 92%)
+- **File paths**: relative to crate `src/` for source, relative to crate root for test scripts
+- **Plan references**: link to the plan file, use the plan's Test Suite ID in brackets (e.g., `[UTP-BPV7-01]`)
+
+## Root-Level Coverage Report
+
+The project-level report at `docs/test_coverage_report.md` summarises all crates. It should:
+
+- List all test plans with their crate and status
+- Aggregate test counts (unit, fuzz, component, interop)
+- Summarise PICS compliance
+- Identify cross-cutting gaps
+- Link to per-crate reports rather than duplicating their content
+
+## Requirements Traceability
+
+The coverage reports form part of the deliverable verification chain defined in [requirements.md](../requirements.md):
+
+```
+Part 2: Top-level Requirements (REQ-1, REQ-2, ...)
+    │
+Part 4: Verification Matrix (mid-level: 1.1, 1.2, 3.1, 3.2, ...)
+    │
+    ├── "compliance verification matrix" (1.1, 3.1, ...) → PICS Proforma / RFC compliance docs
+    │
+    └── "test verification report" (1.2, 3.2, ...) → Coverage Report §1 LLR table
+            │
+Part 3: Low-Level Requirements (LLR 1.1.1, 1.1.2, ...)
+            │
+            └── Individual test functions → Pass/Fail
+```
+
+Each coverage report's LLR table closes the loop from Part 4 "test verification report" requirements to individual test results. The `Part 4 Ref` column makes this traceability explicit.
+
+For the root-level coverage report (`docs/test_coverage_report.md`), include a summary mapping Part 4 mid-level requirements to the crate-level reports that satisfy them.
+
+## Questions to Ask When Writing
+
+1. Is every assigned LLR accounted for in the table?
+2. Does the test inventory match what `cargo test` actually runs?
+3. Are cross-crate references accurate and up to date?
+4. Would a reviewer know exactly what is and isn't verified?
+5. Are the line coverage numbers current?

--- a/docs/style_guides/design_doc_style_guide.md
+++ b/docs/style_guides/design_doc_style_guide.md
@@ -1,0 +1,106 @@
+# Design Document Style Guide
+
+This guide defines the style and content expectations for per-package design documents in Hardy.
+
+## Purpose
+
+Design documents capture **architectural decisions and rationale** - the "why" behind the code. They are for engineers who need to understand the system conceptually before diving into implementation details.
+
+## What Belongs in Design Docs
+
+- **Design goals and constraints** that shaped the implementation
+- **Key architectural decisions** and the alternatives considered
+- **Conceptual models** - how components interact, data flows, trust boundaries
+- **Trade-offs** - what was sacrificed for what benefit
+- **Integration points** - how this package relates to others in the system
+- **RFC/specification interpretation** - how standards requirements influenced design
+
+## What Does NOT Belong in Design Docs
+
+- **API reference material** - struct fields, enum variants, method signatures (these belong in rustdoc)
+- **Usage examples** - code snippets showing how to call APIs (rustdoc)
+- **Exhaustive lists** - every error type, every flag bit, every field (rustdoc)
+- **Implementation details** that don't reflect architectural choices
+
+## Document Structure
+
+```markdown
+# <package-name> Design
+
+<One-line description of purpose>
+
+## Design Goals
+
+What properties/qualities was this package designed to achieve?
+Why does this package exist rather than using an off-the-shelf solution?
+
+## Architecture Overview
+
+High-level conceptual model. How do the pieces fit together?
+Diagrams welcome if they clarify relationships.
+
+## Key Design Decisions
+
+### <Decision 1 Title>
+
+What was decided, why, and what alternatives were rejected.
+
+### <Decision 2 Title>
+
+...
+
+## Integration
+
+How does this package interact with other Hardy components?
+What are the contracts/interfaces?
+
+## Standards Compliance
+
+Which RFCs/specifications does this implement?
+Any notable interpretation decisions?
+
+## Testing
+
+Link to test plans (don't duplicate their content).
+```
+
+## Research and Verification
+
+When writing or updating design documents:
+
+- **Consult the RFC references** in `/workspace/references/` to ensure accurate terminology and correct descriptions of standards compliance. Use the precise language from specifications when describing protocol behaviour, message formats, or compliance requirements.
+- **Ask clarifying questions** if the design intent is unclear from examining the code. It is better to ask the maintainer for clarification than to guess or document assumptions that may be incorrect.
+
+## Writing Style
+
+- **Be concise but not terse** - brevity is good, but not at the expense of readability. Write in complete sentences with natural flow.
+- **Explain the "why"** - decisions without rationale are not useful
+- **Use concrete examples** when they clarify a concept, but not as API documentation
+- **Link to RFCs** with section numbers for traceability
+- **Bullets are fine when appropriate** - use bullets for lists of items, options, or requirements. But each bullet should be a complete thought, not a terse fragment. Design rationale and explanations typically read better as paragraphs.
+
+## Assumed Reader Background
+
+- **Familiar with DTN/BPv7 concepts** - bundle protocol, EIDs, CLAs, BPSec, etc.
+- **May have limited Rust experience** - explain Rust-specific idioms (traits, lifetimes, closures) when they're central to a design decision
+- **Likely background in C, C++, or Java** - comparisons to patterns in those languages can help clarify
+
+When Rust concepts are integral to the design (e.g., "we use closures for structural integrity"), briefly explain what the concept achieves rather than assuming the reader understands Rust idioms.
+
+## Questions to Ask When Writing
+
+1. If I deleted this paragraph, would someone misunderstand the design?
+2. Is this explaining a decision, or just describing what the code does?
+3. Could this information be found by reading the rustdoc or source?
+4. Would a new team member understand *why* things are this way?
+
+## Test Plan References
+
+Each design doc should link to relevant test plans but not duplicate their content:
+
+```markdown
+## Testing
+
+- [Unit Test Plan](unit_test_plan.md) - brief description of scope
+- [Fuzz Test Plan](fuzz_test_plan.md) - brief description of scope
+```

--- a/docs/style_guides/readme_style_guide.md
+++ b/docs/style_guides/readme_style_guide.md
@@ -1,0 +1,144 @@
+# Crate README Style Guide
+
+This guide defines the style and content expectations for per-crate `README.md` files in Hardy.
+
+## Purpose
+
+Each crate README is the **entry point for someone encountering the crate for the first time**. It answers: "what is this, why does it exist, and how do I use it?" READMEs serve two audiences:
+
+- **crates.io / docs.rs readers** — evaluating whether to use the crate
+- **Internal developers** — understanding a crate's role in the Hardy workspace
+
+## What Belongs in READMEs
+
+- **One-line description** — what the crate does
+- **Role in Hardy** — how it fits into the larger system
+- **Key features / capabilities**
+- **Quick start / usage example** (for binaries and public API crates)
+- **Configuration reference** (for server binaries)
+- **Links** to design docs, test coverage reports, API documentation, and the relevant section of the [user documentation](https://ricktaylor.github.io/hardy/). Test plans are referenced from the coverage report — do not link them separately from the README
+
+## What Does NOT Belong in READMEs
+
+- **Exhaustive API reference** — that belongs in rustdoc
+- **Design rationale** — that belongs in the design doc
+- **Test coverage details** — that belongs in the coverage report
+- **TODO lists or known issues** — those belong in docs/TODO.md
+
+## Document Structure
+
+### Library Crates
+
+```markdown
+# <crate-name>
+
+<One-line description of what this crate does.>
+
+Part of the [Hardy](https://github.com/ricktaylor/hardy) DTN Bundle Protocol implementation.
+
+## Overview
+
+<2-3 sentences explaining the crate's role in the system, what standard(s)
+it implements, and its relationship to other Hardy crates.>
+
+## Features
+
+- Feature 1
+- Feature 2
+- Feature flag: `feature-name` — what it enables
+
+## Usage
+
+```rust
+// Minimal example showing the primary API
+```
+
+## Documentation
+
+- [Design](docs/design.md)
+- [Test Coverage](docs/test_coverage_report.md)
+- [API Documentation](https://docs.rs/<crate-name>)
+- [User Documentation](https://ricktaylor.github.io/hardy/<relevant-section>/)
+
+## Licence
+
+Apache 2.0 — see [LICENCE](../LICENCE)
+```
+
+### Server / Binary Crates
+
+```markdown
+# <binary-name>
+
+<One-line description of what this binary does.>
+
+Part of the [Hardy](https://github.com/ricktaylor/hardy) DTN Bundle Protocol implementation.
+
+## Quick Start
+
+<3-5 steps to get running, including minimal config and run command.>
+
+## Configuration
+
+<Table of configuration options with defaults and descriptions.>
+
+Configuration is read from TOML files and environment variables
+(`<PREFIX>_` prefix).
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| ... | ... | ... |
+
+## Container Image
+
+```bash
+docker pull ghcr.io/ricktaylor/hardy/<image-name>:latest
+```
+
+## Documentation
+
+- [Design](docs/design.md)
+- [Test Coverage](docs/test_coverage_report.md)
+- [User Documentation](https://ricktaylor.github.io/hardy/<relevant-section>/)
+
+## Licence
+
+Apache 2.0 — see [LICENCE](../LICENCE)
+```
+
+### Small / Internal Library Crates
+
+For crates under ~200 lines with a single responsibility:
+
+```markdown
+# <crate-name>
+
+<One-line description.>
+
+Part of the [Hardy](https://github.com/ricktaylor/hardy) DTN Bundle Protocol implementation.
+<1-2 sentences on what it does and which crate(s) use it.>
+
+## Licence
+
+Apache 2.0 — see [LICENCE](../LICENCE)
+```
+
+## Writing Style
+
+- **Be concise** — READMEs should be scannable. If a section exceeds a screenful, it probably belongs in a separate doc
+- **Lead with the most useful information** — what it does, not how it's built
+- **Use concrete examples** — a 5-line code snippet is worth a paragraph of description
+- **Link, don't duplicate** — point to docs.rs for API details, design docs for rationale, user docs for operations
+
+## Naming Conventions
+
+- **Title**: use the crate name as-is (e.g., `# hardy-bpv7`, not `# BPv7 Library`)
+- **Links**: use relative paths within the repo (e.g., `docs/design.md`, not absolute URLs)
+- **Images**: avoid unless they add significant clarity; prefer text descriptions
+
+## Questions to Ask When Writing
+
+1. Could someone understand what this crate does from the first two sentences?
+2. Is there enough information to start using it without reading the source?
+3. Am I duplicating content that lives in another document?
+4. Would this be useful on crates.io / docs.rs?

--- a/docs/style_guides/rustdoc_style_guide.md
+++ b/docs/style_guides/rustdoc_style_guide.md
@@ -1,0 +1,217 @@
+# Rustdoc Style Guide
+
+This guide defines conventions for rustdoc comments across Hardy crates. It is based on patterns already established in `hardy-cbor`, `hardy-bpv7`, `hardy-bpa`, and `hardy-async`.
+
+## Crate-Level Documentation
+
+Every library crate must have a crate-level doc comment at the top of `lib.rs`. Binary crates (`main.rs`) do not need one.
+
+Use `/*! ... */` block comment style (not `//!` line comments) for readability.
+
+**Caution:** `/* */` blocks cannot contain `*/` sequences — even inside backticks. If the comment text includes glob patterns like `*/S` or `dtn://**`, use `//` line comments instead.
+
+The crate-level doc should include:
+
+1. **One-line summary** — what the crate does
+2. **Overview paragraph** — context, relationship to other crates, relevant standards
+3. **Key modules or types** — brief list linking to the main entry points
+4. **Feature flags** — if any, with descriptions
+
+```rust
+/*!
+RFC 8949 compliant CBOR encoder/decoder for the Hardy DTN Router.
+
+This crate provides low-level CBOR primitives used by [`hardy-bpv7`] for
+bundle parsing and generation. It is `no_std` compatible with an allocator.
+
+# Key Types
+
+- [`decode`] — streaming CBOR decoder with byte-range tracking
+- [`encode`] — canonical CBOR encoder
+
+# Feature Flags
+
+- `std` — enables `std::io` integration (default)
+*/
+```
+
+## Public Item Documentation
+
+Every public item (`pub fn`, `pub struct`, `pub enum`, `pub trait`, `pub type`) must have a doc comment. Items that are not part of the published API do not need rustdoc:
+
+- Private items (`fn`, `struct`, etc. without `pub`)
+- `pub(crate)` items — visible within the crate but not to consumers
+- `pub` items inside private modules (`mod foo`, not `pub mod foo`)
+
+Use `//` comments on these if the logic needs explaining. Confirm that public types are actually exposed via a public module path before adding rustdoc.
+
+### One-Liner Items
+
+Simple items use a single `///` line:
+
+```rust
+/// The bundle's creation timestamp.
+pub timestamp: CreationTimestamp,
+```
+
+### Functions and Methods
+
+Document what the function does, not how. Include parameters only when their purpose is not obvious from name and type.
+
+```rust
+/// Registers a CLA with the BPA under the given name.
+///
+/// Returns an error if a CLA with the same name is already registered.
+pub async fn register_cla(&self, name: String, ...) -> Result<()> {
+```
+
+### Complex Items
+
+For types or functions with non-trivial behaviour, use structured sections:
+
+```rust
+/// A cancellable pool of async tasks with panic propagation.
+///
+/// Tasks spawned on the pool are cancelled when the pool is dropped.
+/// If any task panics, the panic is propagated to the next `join()` call.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// let pool = TaskPool::new();
+/// pool.spawn(async { /* ... */ });
+/// pool.join().await;
+/// ```
+///
+/// # Panics
+///
+/// `join()` panics if any spawned task panicked.
+```
+
+## Sections
+
+Use only these standard sections, in this order:
+
+| Section | When to use |
+|---------|-------------|
+| `# Examples` | Complex APIs where usage is not obvious |
+| `# Panics` | When the function can panic in normal use |
+| `# Errors` | When returning `Result` — describe error conditions |
+| `# Safety` | `unsafe` functions only |
+
+Do not add sections that repeat the summary. If a function's error conditions are obvious from the `Result` type, omit `# Errors`.
+
+## Examples
+
+- Use `rust,no_run` for examples that need a runtime or network
+- Use `rust,ignore` only for incomplete snippets
+- Keep examples minimal — show the API call, not the setup
+- Examples must compile (CI will check this)
+
+## RFC and Standard References
+
+When a type or function implements a specific RFC section, reference it:
+
+```rust
+/// Parses the primary block fields defined in [RFC 9171 Section 4.3.1].
+///
+/// [RFC 9171 Section 4.3.1]: https://datatracker.ietf.org/doc/html/rfc9171#section-4.3.1
+```
+
+Use reference-style links at the bottom of the doc comment. Do not inline URLs.
+
+## Cross-References
+
+Link to other types and modules using rustdoc syntax:
+
+```rust
+/// Returns the [`Bundle`] parsed from the given bytes.
+///
+/// See [`BundleBuilder`] for constructing bundles programmatically.
+```
+
+Use full paths when referencing items in other crates:
+
+```rust
+/// Uses [`hardy_cbor::decode`] for CBOR parsing.
+```
+
+## Configuration Structs
+
+All `Config` structs with `serde` derive must document every field:
+
+```rust
+/// BPA server configuration.
+pub struct Config {
+    /// gRPC listen address. Default: `[::]:50051`.
+    pub address: String,
+
+    /// Maximum bundle size eligible for LRU caching, in bytes.
+    pub max_cached_bundle_size: NonZeroUsize,
+}
+```
+
+Include the default value in the doc comment when there is one.
+
+## Traits
+
+Trait documentation should describe the contract, not the implementation. Include:
+
+1. What implementors must provide
+2. What callers can expect
+3. Lifecycle (if registration/unregistration is involved)
+
+```rust
+/// A convergence layer adapter that can send and receive bundles.
+///
+/// Implementors register with a [`Bpa`] via [`Bpa::register_cla`] and
+/// receive a [`ClaSink`] for forwarding received bundles. Dropping the
+/// sink unregisters the CLA.
+pub trait Cla: Send + Sync + 'static {
+```
+
+## Trait Implementations
+
+Trait impl methods do not need `///` doc comments unless the implementation behaviour is surprising or deviates from the trait documentation. A normal `//` comment explaining the approach is useful:
+
+```rust
+impl BundleStorage for Storage {
+    // Atomic write: temp file + rename + dir fsync
+    async fn store(&self, id: &str, data: Bytes) -> Result<()> {
+```
+
+## What Not To Document
+
+- Re-exports (document at the source)
+- `impl` blocks for derived traits (`Debug`, `Clone`, etc.)
+- Trait impl methods (unless behaviour is surprising — use `//` comments instead)
+- Test modules and test helper functions
+- Items behind `#[doc(hidden)]`
+
+## Checking Documentation
+
+```bash
+# Check for missing docs on public items
+cargo doc --no-deps --package <crate> 2>&1 | grep "warning"
+
+# Build docs for the whole workspace
+cargo doc --no-deps --workspace
+
+# Verify examples compile
+cargo test --doc --package <crate>
+```
+
+## Correctness Pass
+
+After adding or updating doc comments, always perform a correctness pass against the actual code. Documentation that describes wrong behaviour is worse than no documentation.
+
+Check for:
+
+1. **Signature mismatches** — do parameter types and return types in docs match the code?
+2. **Stale defaults** — do documented default values match the `Default` impl?
+3. **Renamed or removed items** — do cross-references point to types/methods that still exist?
+4. **Example code** — would the examples compile against the current API?
+5. **Feature flag references** — are conditional compilation features still valid?
+6. **Behavioural claims** — does the code actually do what the doc says it does?
+
+This pass should be performed whenever docs are written or code is refactored.


### PR DESCRIPTION
- Add AGENTS.md (build/test/lint essentials, code-style highlights) with a CLAUDE.md symlink so Claude Code loads it from a single source of truth.
- Add docs/style_guides/code_style_guide.md covering general Rust conventions (idiomatic-Rust baseline, use-block ordering, visibility, error handling, 32-bit safety, no_std, tests).
- Move the existing rustdoc/design-doc/readme/coverage-report guides into docs/style_guides/ and fix all cross-references.
- Link the coding style guide from the README Contributing section