### PR TITLE
Bump MSRV to 1.95 and enforce it in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -139,3 +139,28 @@ jobs:
         run: |
           ./target/debug/hardy-bpa-server &
           bash ./tests/interop/hardy/run_hardy_ping_test.sh --peer 127.0.0.1:4556 --count 5
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        run: echo "version=$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Rust toolchain (MSRV ${{ steps.msrv.outputs.version }})
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      - name: Use cached dependencies and artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: msrv
+
+      - name: Install Protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Check on MSRV
+        run: cargo check --locked --all-features --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,6 @@ name = "hardy-bpa-fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
- "cfg-if",
  "flume",
  "hardy-async",
  "hardy-bpa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,6 @@ sqlx-sqlite = { path = "patches/sqlx-sqlite" }
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.94"
 license = "Apache-2.0"
 repository = "https://github.com/ricktaylor/hardy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,6 @@ sqlx-sqlite = { path = "patches/sqlx-sqlite" }
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 license = "Apache-2.0"
 repository = "https://github.com/ricktaylor/hardy"

--- a/async/src/signal.rs
+++ b/async/src/signal.rs
@@ -41,29 +41,29 @@ pub fn listen_for_cancel(tasks: &TaskPool) {
 }
 
 async fn wait_for_signal(cancel_token: &crate::CancellationToken) {
-    #[cfg(unix)]
-    {
-        let mut term_handler =
-            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                .expect("Failed to register signal handlers");
-        tokio::select! {
-            _ = term_handler.recv() => {
-                info!("Received terminate signal, stopping...");
+    cfg_select! {
+        unix => {
+            let mut term_handler =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                    .expect("Failed to register signal handlers");
+            tokio::select! {
+                _ = term_handler.recv() => {
+                    info!("Received terminate signal, stopping...");
+                }
+                _ = tokio::signal::ctrl_c() => {
+                    info!("Received CTRL+C, stopping...");
+                }
+                _ = cancel_token.cancelled() => {}
             }
-            _ = tokio::signal::ctrl_c() => {
-                info!("Received CTRL+C, stopping...");
-            }
-            _ = cancel_token.cancelled() => {}
         }
-    }
-    #[cfg(not(unix))]
-    {
-        tokio::select! {
-            result = tokio::signal::ctrl_c() => {
-                result.expect("Failed to listen for CTRL+C");
-                info!("Received CTRL+C, stopping...");
+        _ => {
+            tokio::select! {
+                result = tokio::signal::ctrl_c() => {
+                    result.expect("Failed to listen for CTRL+C");
+                    info!("Received CTRL+C, stopping...");
+                }
+                _ = cancel_token.cancelled() => {}
             }
-            _ = cancel_token.cancelled() => {}
         }
     }
 }

--- a/bpa-server/src/main.rs
+++ b/bpa-server/src/main.rs
@@ -149,21 +149,24 @@ async fn build(
         builder = builder.routing_agent(sr_config.protocol_id, agent);
     }
 
-    #[cfg(feature = "echo")]
-    if let Some(services) = config.built_in_services.echo {
-        if services.is_empty() {
-            warn!("built-in-services.echo: no endpoints configured, skipping");
-        } else {
-            for service_id in services {
-                builder =
-                    builder.service(Arc::new(hardy_echo_service::EchoService::new()), service_id);
+    cfg_select! {
+        feature = "echo" => {
+            if let Some(services) = config.built_in_services.echo {
+                if services.is_empty() {
+                    warn!("built-in-services.echo: no endpoints configured, skipping");
+                } else {
+                    for service_id in services {
+                        builder = builder
+                            .service(Arc::new(hardy_echo_service::EchoService::new()), service_id);
+                    }
+                }
             }
         }
-    }
-
-    #[cfg(not(feature = "echo"))]
-    if config.built_in_services.echo.is_some() {
-        warn!("Ignoring built-in-services.echo: echo feature is disabled at compile time");
+        _ => {
+            if config.built_in_services.echo.is_some() {
+                warn!("Ignoring built-in-services.echo: echo feature is disabled at compile time");
+            }
+        }
     }
 
     let mut policies = HashMap::new();

--- a/bpa/benches/bundle_bench.rs
+++ b/bpa/benches/bundle_bench.rs
@@ -111,21 +111,20 @@ fn get_state() -> &'static BenchState {
 
 fn print_system_info() {
     use std::fs;
-    if let Ok(cpuinfo) = fs::read_to_string("/proc/cpuinfo") {
-        if let Some(model) = cpuinfo
+    if let Ok(cpuinfo) = fs::read_to_string("/proc/cpuinfo")
+        && let Some(model) = cpuinfo
             .lines()
             .find(|l| l.starts_with("model name"))
             .and_then(|l| l.split(':').nth(1))
         {
             eprintln!("CPU: {}", model.trim());
         }
-    }
     let cores = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(0);
     eprintln!("Cores: {cores}");
-    if let Ok(meminfo) = fs::read_to_string("/proc/meminfo") {
-        if let Some(total) = meminfo
+    if let Ok(meminfo) = fs::read_to_string("/proc/meminfo")
+        && let Some(total) = meminfo
             .lines()
             .find(|l| l.starts_with("MemTotal"))
             .and_then(|l| l.split_whitespace().nth(1))
@@ -133,7 +132,6 @@ fn print_system_info() {
         {
             eprintln!("RAM: {} GB", total / 1_048_576);
         }
-    }
     eprintln!("Arch: {}", std::env::consts::ARCH);
     eprintln!(
         "Profile: {}",

--- a/bpa/benches/bundle_bench.rs
+++ b/bpa/benches/bundle_bench.rs
@@ -116,9 +116,9 @@ fn print_system_info() {
             .lines()
             .find(|l| l.starts_with("model name"))
             .and_then(|l| l.split(':').nth(1))
-        {
-            eprintln!("CPU: {}", model.trim());
-        }
+    {
+        eprintln!("CPU: {}", model.trim());
+    }
     let cores = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(0);
@@ -129,9 +129,9 @@ fn print_system_info() {
             .find(|l| l.starts_with("MemTotal"))
             .and_then(|l| l.split_whitespace().nth(1))
             .and_then(|v| v.parse::<u64>().ok())
-        {
-            eprintln!("RAM: {} GB", total / 1_048_576);
-        }
+    {
+        eprintln!("RAM: {} GB", total / 1_048_576);
+    }
     eprintln!("Arch: {}", std::env::consts::ARCH);
     eprintln!(
         "Profile: {}",

--- a/bpa/fuzz/Cargo.toml
+++ b/bpa/fuzz/Cargo.toml
@@ -30,7 +30,6 @@ tokio = { version = "1", features = ["rt-multi-thread", "time"] }
 time = { version = "0.3", features = ["parsing"] }
 tracing = { version = "0.1", default-features = false }
 arbitrary = { version = "1", features = ["derive"] }
-cfg-if = "1"
 flume = "0.12"
 percent-encoding = { version = "2", default-features = false, features = ["alloc"] }
 

--- a/bpa/fuzz/src/lib.rs
+++ b/bpa/fuzz/src/lib.rs
@@ -57,8 +57,8 @@ async fn new_bpa(testname: &str) -> hardy_bpa::bpa::Bpa {
         );
 
     // Bundle storage
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "localdisk-storage")] {
+    cfg_select! {
+        feature = "localdisk-storage" => {
             builder = builder.bundle_storage(hardy_localdisk_storage::new(
                 &hardy_localdisk_storage::Config {
                     store_dir: path.join("localdisk"),
@@ -66,7 +66,8 @@ async fn new_bpa(testname: &str) -> hardy_bpa::bpa::Bpa {
                 },
                 true,
             ));
-        } else {
+        }
+        _ => {
             builder = builder.bundle_storage(std::sync::Arc::new(
                 hardy_bpa::storage::BundleMemStorage::new(
                     &hardy_bpa::storage::BundleMemStorageConfig {
@@ -79,8 +80,8 @@ async fn new_bpa(testname: &str) -> hardy_bpa::bpa::Bpa {
     }
 
     // Metadata storage
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "sqlite-storage")] {
+    cfg_select! {
+        feature = "sqlite-storage" => {
             builder = builder.metadata_storage(hardy_sqlite_storage::new(
                 &hardy_sqlite_storage::Config {
                     db_dir: path.clone(),
@@ -88,7 +89,8 @@ async fn new_bpa(testname: &str) -> hardy_bpa::bpa::Bpa {
                 },
                 true,
             ));
-        } else if #[cfg(feature = "postgres-storage")] {
+        }
+        feature = "postgres-storage" => {
             builder = builder.metadata_storage(
                 hardy_postgres_storage::new(
                     &hardy_postgres_storage::Config {
@@ -100,7 +102,8 @@ async fn new_bpa(testname: &str) -> hardy_bpa::bpa::Bpa {
                 .await
                 .expect("Failed to create postgres metadata storage"),
             );
-        } else {
+        }
+        _ => {
             builder = builder.metadata_storage(std::sync::Arc::new(
                 hardy_bpa::storage::MetadataMemStorage::new(
                     &hardy_bpa::storage::MetadataMemStorageConfig {

--- a/bpa/fuzz/src/lib.rs
+++ b/bpa/fuzz/src/lib.rs
@@ -117,12 +117,10 @@ async fn new_bpa(testname: &str) -> hardy_bpa::bpa::Bpa {
 
     let bpa = builder.build().await.expect("Failed to build BPA");
 
-    bpa.start(
-        #[cfg(all(feature = "localdisk-storage", feature = "sqlite-storage"))]
-        true,
-        #[cfg(not(all(feature = "localdisk-storage", feature = "sqlite-storage")))]
-        false,
-    );
+    bpa.start(cfg_select! {
+        all(feature = "localdisk-storage", feature = "sqlite-storage") => true,
+        _ => false,
+    });
 
     #[cfg(feature = "file-cla")]
     {

--- a/bpa/src/filter/rfc9171.rs
+++ b/bpa/src/filter/rfc9171.rs
@@ -109,18 +109,19 @@ impl ReadFilter for Rfc9171ValidityFilter {
     async fn filter(&self, bundle: &Bundle, _data: &[u8]) -> Result<ReadResult, crate::Error> {
         // RFC9171 §4.3.1: Primary block integrity check
         if self.config.primary_block_integrity
-            && let Some(primary_block) = bundle.bundle.blocks.get(&0) {
-                let has_crc = !matches!(bundle.bundle.crc_type, CrcType::None);
-                let has_bib = !matches!(primary_block.bib, BibCoverage::None);
+            && let Some(primary_block) = bundle.bundle.blocks.get(&0)
+        {
+            let has_crc = !matches!(bundle.bundle.crc_type, CrcType::None);
+            let has_bib = !matches!(primary_block.bib, BibCoverage::None);
 
-                if !has_crc && !has_bib {
-                    debug!(
-                        bundle_id = %bundle.bundle.id,
-                        "Rejecting bundle: primary block has no integrity protection (no CRC, no BIB)"
-                    );
-                    return Ok(ReadResult::Drop(Some(ReasonCode::BlockUnintelligible)));
-                }
+            if !has_crc && !has_bib {
+                debug!(
+                    bundle_id = %bundle.bundle.id,
+                    "Rejecting bundle: primary block has no integrity protection (no CRC, no BIB)"
+                );
+                return Ok(ReadResult::Drop(Some(ReasonCode::BlockUnintelligible)));
             }
+        }
 
         // RFC9171 §4.4.2: Bundle Age required when no clock
         if self.config.bundle_age_required

--- a/bpa/src/filter/rfc9171.rs
+++ b/bpa/src/filter/rfc9171.rs
@@ -108,8 +108,8 @@ impl Rfc9171ValidityFilter {
 impl ReadFilter for Rfc9171ValidityFilter {
     async fn filter(&self, bundle: &Bundle, _data: &[u8]) -> Result<ReadResult, crate::Error> {
         // RFC9171 §4.3.1: Primary block integrity check
-        if self.config.primary_block_integrity {
-            if let Some(primary_block) = bundle.bundle.blocks.get(&0) {
+        if self.config.primary_block_integrity
+            && let Some(primary_block) = bundle.bundle.blocks.get(&0) {
                 let has_crc = !matches!(bundle.bundle.crc_type, CrcType::None);
                 let has_bib = !matches!(primary_block.bib, BibCoverage::None);
 
@@ -121,7 +121,6 @@ impl ReadFilter for Rfc9171ValidityFilter {
                     return Ok(ReadResult::Drop(Some(ReasonCode::BlockUnintelligible)));
                 }
             }
-        }
 
         // RFC9171 §4.4.2: Bundle Age required when no clock
         if self.config.bundle_age_required

--- a/bpa/src/filter/validity.rs
+++ b/bpa/src/filter/validity.rs
@@ -37,15 +37,16 @@ impl ReadFilter for BundleValidityFilter {
         }
 
         if let Some(hop_info) = bundle.bundle.hop_count.as_ref()
-            && hop_info.count > hop_info.limit {
-                debug!(
-                    bundle_id = %bundle.bundle.id,
-                    limit = hop_info.limit,
-                    count = hop_info.count,
-                    "Rejecting bundle: hop limit exceeded"
-                );
-                return Ok(ReadResult::Drop(Some(ReasonCode::HopLimitExceeded)));
-            }
+            && hop_info.count > hop_info.limit
+        {
+            debug!(
+                bundle_id = %bundle.bundle.id,
+                limit = hop_info.limit,
+                count = hop_info.count,
+                "Rejecting bundle: hop limit exceeded"
+            );
+            return Ok(ReadResult::Drop(Some(ReasonCode::HopLimitExceeded)));
+        }
 
         Ok(ReadResult::Continue)
     }

--- a/bpa/src/filter/validity.rs
+++ b/bpa/src/filter/validity.rs
@@ -36,8 +36,8 @@ impl ReadFilter for BundleValidityFilter {
             return Ok(ReadResult::Drop(Some(ReasonCode::LifetimeExpired)));
         }
 
-        if let Some(hop_info) = bundle.bundle.hop_count.as_ref() {
-            if hop_info.count > hop_info.limit {
+        if let Some(hop_info) = bundle.bundle.hop_count.as_ref()
+            && hop_info.count > hop_info.limit {
                 debug!(
                     bundle_id = %bundle.bundle.id,
                     limit = hop_info.limit,
@@ -46,7 +46,6 @@ impl ReadFilter for BundleValidityFilter {
                 );
                 return Ok(ReadResult::Drop(Some(ReasonCode::HopLimitExceeded)));
             }
-        }
 
         Ok(ReadResult::Continue)
     }

--- a/bpa/src/services/registry.rs
+++ b/bpa/src/services/registry.rs
@@ -94,9 +94,9 @@ impl Sink {
                 .registry
                 .unregister(service, &self.node_ids, &self.rib)
                 .await
-            {
-                error!("Failed to unregister service: {e}");
-            }
+        {
+            error!("Failed to unregister service: {e}");
+        }
     }
 
     async fn cancel_inner(&self, bundle_id: &hardy_bpv7::bundle::Id) -> services::Result<bool> {

--- a/bpa/src/services/registry.rs
+++ b/bpa/src/services/registry.rs
@@ -89,15 +89,14 @@ struct Sink {
 
 impl Sink {
     async fn unregister_inner(&self) {
-        if let Some(service) = self.service.upgrade() {
-            if let Err(e) = self
+        if let Some(service) = self.service.upgrade()
+            && let Err(e) = self
                 .registry
                 .unregister(service, &self.node_ids, &self.rib)
                 .await
             {
                 error!("Failed to unregister service: {e}");
             }
-        }
     }
 
     async fn cancel_inner(&self, bundle_id: &hardy_bpv7::bundle::Id) -> services::Result<bool> {

--- a/bpa/tests/pipeline.rs
+++ b/bpa/tests/pipeline.rs
@@ -207,15 +207,14 @@ fn print_system_info() {
     use std::fs;
 
     // CPU model
-    if let Ok(cpuinfo) = fs::read_to_string("/proc/cpuinfo") {
-        if let Some(model) = cpuinfo
+    if let Ok(cpuinfo) = fs::read_to_string("/proc/cpuinfo")
+        && let Some(model) = cpuinfo
             .lines()
             .find(|l| l.starts_with("model name"))
             .and_then(|l| l.split(':').nth(1))
         {
             eprintln!("CPU: {}", model.trim());
         }
-    }
 
     // Logical cores
     let cores = std::thread::available_parallelism()
@@ -224,8 +223,8 @@ fn print_system_info() {
     eprintln!("Cores: {cores}");
 
     // Total RAM
-    if let Ok(meminfo) = fs::read_to_string("/proc/meminfo") {
-        if let Some(total) = meminfo
+    if let Ok(meminfo) = fs::read_to_string("/proc/meminfo")
+        && let Some(total) = meminfo
             .lines()
             .find(|l| l.starts_with("MemTotal"))
             .and_then(|l| l.split_whitespace().nth(1))
@@ -233,18 +232,16 @@ fn print_system_info() {
         {
             eprintln!("RAM: {} GB", total / 1_048_576);
         }
-    }
 
     // OS
-    if let Ok(release) = fs::read_to_string("/etc/os-release") {
-        if let Some(pretty) = release
+    if let Ok(release) = fs::read_to_string("/etc/os-release")
+        && let Some(pretty) = release
             .lines()
             .find(|l| l.starts_with("PRETTY_NAME"))
             .and_then(|l| l.split('=').nth(1))
         {
             eprintln!("OS: {}", pretty.trim_matches('"'));
         }
-    }
 
     eprintln!("Arch: {}", std::env::consts::ARCH);
 

--- a/bpa/tests/pipeline.rs
+++ b/bpa/tests/pipeline.rs
@@ -212,9 +212,9 @@ fn print_system_info() {
             .lines()
             .find(|l| l.starts_with("model name"))
             .and_then(|l| l.split(':').nth(1))
-        {
-            eprintln!("CPU: {}", model.trim());
-        }
+    {
+        eprintln!("CPU: {}", model.trim());
+    }
 
     // Logical cores
     let cores = std::thread::available_parallelism()
@@ -229,9 +229,9 @@ fn print_system_info() {
             .find(|l| l.starts_with("MemTotal"))
             .and_then(|l| l.split_whitespace().nth(1))
             .and_then(|v| v.parse::<u64>().ok())
-        {
-            eprintln!("RAM: {} GB", total / 1_048_576);
-        }
+    {
+        eprintln!("RAM: {} GB", total / 1_048_576);
+    }
 
     // OS
     if let Ok(release) = fs::read_to_string("/etc/os-release")
@@ -239,9 +239,9 @@ fn print_system_info() {
             .lines()
             .find(|l| l.starts_with("PRETTY_NAME"))
             .and_then(|l| l.split('=').nth(1))
-        {
-            eprintln!("OS: {}", pretty.trim_matches('"'));
-        }
+    {
+        eprintln!("OS: {}", pretty.trim_matches('"'));
+    }
 
     eprintln!("Arch: {}", std::env::consts::ARCH);
 

--- a/localdisk-storage/src/config.rs
+++ b/localdisk-storage/src/config.rs
@@ -25,15 +25,10 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             store_dir: directories::ProjectDirs::from("dtn", "Hardy", env!("CARGO_PKG_NAME")).map_or_else(
-                || {
-                    #[cfg(unix)]
-                    return std::path::Path::new("/var/spool").join(env!("CARGO_PKG_NAME"));
-
-                    #[cfg(windows)]
-                    return std::env::current_exe().expect("Failed to get current exe").join(env!("CARGO_PKG_NAME"));
-
-                    #[cfg(not(any(unix,windows)))]
-                    compile_error!("No idea how to determine default localdisk bundle store directory for target platform");
+                || cfg_select! {
+                    unix => std::path::Path::new("/var/spool").join(env!("CARGO_PKG_NAME")),
+                    windows => std::env::current_exe().expect("Failed to get current exe").join(env!("CARGO_PKG_NAME")),
+                    _ => compile_error!("No idea how to determine default localdisk bundle store directory for target platform"),
                 },
                 |project_dirs| {
                     project_dirs.cache_dir().into()

--- a/localdisk-storage/src/storage.rs
+++ b/localdisk-storage/src/storage.rs
@@ -239,29 +239,30 @@ impl BundleStorage for Storage {
     async fn load(&self, storage_name: &str) -> storage::Result<Option<Bytes>> {
         let storage_name = self.store_root.join(PathBuf::from_str(storage_name)?);
 
-        #[cfg(feature = "mmap")]
-        {
-            let file = match tokio::fs::File::open(storage_name).await {
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    return Ok(None);
-                }
-                Err(e) => {
-                    return Err(e.into());
-                }
-                Ok(file) => file,
-            };
-            let data = unsafe { memmap2::Mmap::map(&file) };
-            Ok(Some(Bytes::from_owner(data?)))
+        cfg_select! {
+            feature = "mmap" => {
+                let file = match tokio::fs::File::open(storage_name).await {
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        return Ok(None);
+                    }
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                    Ok(file) => file,
+                };
+                let data = unsafe { memmap2::Mmap::map(&file) };
+                Ok(Some(Bytes::from_owner(data?)))
+            }
+            _ => {
+                tokio::fs::read(storage_name)
+                    .await
+                    .map(|data| Some(Bytes::from_owner(data)))
+                    .or_else(|e| match e.kind() {
+                        std::io::ErrorKind::NotFound => Ok(None),
+                        _ => Err(e.into()),
+                    })
+            }
         }
-
-        #[cfg(not(feature = "mmap"))]
-        tokio::fs::read(storage_name)
-            .await
-            .map(|data| Some(Bytes::from_owner(data)))
-            .or_else(|e| match e.kind() {
-                std::io::ErrorKind::NotFound => Ok(None),
-                _ => Err(e.into()),
-            })
     }
 
     #[cfg_attr(feature = "instrument", instrument(skip_all))]
@@ -595,15 +596,15 @@ mod tests {
         assert!(result.is_err(), "save to read-only dir should return Err");
 
         // Restore permissions so tempdir cleanup succeeds
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
-        }
-        #[cfg(not(unix))]
-        {
-            perms.set_readonly(false);
-            std::fs::set_permissions(dir.path(), perms).unwrap();
+        cfg_select! {
+            unix => {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+            }
+            _ => {
+                perms.set_readonly(false);
+                std::fs::set_permissions(dir.path(), perms).unwrap();
+            }
         }
     }
 

--- a/localdisk-storage/src/storage.rs
+++ b/localdisk-storage/src/storage.rs
@@ -317,9 +317,10 @@ impl BundleStorage for Storage {
 
                 // And now sync the parent directory, i.e. metadata
                 if let Some(parent_dir) = storage_name.parent()
-                    && let Err(e) = std::fs::File::open(parent_dir).and_then(|f| f.sync_all()) {
-                        warn!("Failed to sync parent directory: {e}");
-                    }
+                    && let Err(e) = std::fs::File::open(parent_dir).and_then(|f| f.sync_all())
+                {
+                    warn!("Failed to sync parent directory: {e}");
+                }
 
                 storage::Result::Ok(storage_name)
             })
@@ -377,9 +378,10 @@ impl BundleStorage for Storage {
                     _ = std::fs::remove_file(&tmp_path);
                 })?;
                 if let Some(parent_dir) = final_path.parent()
-                    && let Err(e) = std::fs::File::open(parent_dir).and_then(|f| f.sync_all()) {
-                        warn!("Failed to sync parent directory: {e}");
-                    }
+                    && let Err(e) = std::fs::File::open(parent_dir).and_then(|f| f.sync_all())
+                {
+                    warn!("Failed to sync parent directory: {e}");
+                }
                 storage::Result::Ok(())
             })
             .await

--- a/localdisk-storage/src/storage.rs
+++ b/localdisk-storage/src/storage.rs
@@ -316,11 +316,10 @@ impl BundleStorage for Storage {
                 })?;
 
                 // And now sync the parent directory, i.e. metadata
-                if let Some(parent_dir) = storage_name.parent() {
-                    if let Err(e) = std::fs::File::open(parent_dir).and_then(|f| f.sync_all()) {
+                if let Some(parent_dir) = storage_name.parent()
+                    && let Err(e) = std::fs::File::open(parent_dir).and_then(|f| f.sync_all()) {
                         warn!("Failed to sync parent directory: {e}");
                     }
-                }
 
                 storage::Result::Ok(storage_name)
             })
@@ -377,11 +376,10 @@ impl BundleStorage for Storage {
                     error!("Failed to rename temporary bundle data file: {e}");
                     _ = std::fs::remove_file(&tmp_path);
                 })?;
-                if let Some(parent_dir) = final_path.parent() {
-                    if let Err(e) = std::fs::File::open(parent_dir).and_then(|f| f.sync_all()) {
+                if let Some(parent_dir) = final_path.parent()
+                    && let Err(e) = std::fs::File::open(parent_dir).and_then(|f| f.sync_all()) {
                         warn!("Failed to sync parent directory: {e}");
                     }
-                }
                 storage::Result::Ok(())
             })
             .await

--- a/s3-storage/src/storage.rs
+++ b/s3-storage/src/storage.rs
@@ -212,11 +212,10 @@ impl storage::BundleStorage for Storage {
         {
             Ok(resp) => Ok(Some(resp.body.collect().await?.into_bytes())),
             Err(e) => {
-                if let aws_sdk_s3::error::SdkError::ServiceError(ref se) = e {
-                    if se.err().is_no_such_key() {
+                if let aws_sdk_s3::error::SdkError::ServiceError(ref se) = e
+                    && se.err().is_no_such_key() {
                         return Ok(None);
                     }
-                }
                 Err(Box::new(e))
             }
         }

--- a/s3-storage/src/storage.rs
+++ b/s3-storage/src/storage.rs
@@ -213,9 +213,10 @@ impl storage::BundleStorage for Storage {
             Ok(resp) => Ok(Some(resp.body.collect().await?.into_bytes())),
             Err(e) => {
                 if let aws_sdk_s3::error::SdkError::ServiceError(ref se) = e
-                    && se.err().is_no_such_key() {
-                        return Ok(None);
-                    }
+                    && se.err().is_no_such_key()
+                {
+                    return Ok(None);
+                }
                 Err(Box::new(e))
             }
         }

--- a/sqlite-storage/src/config.rs
+++ b/sqlite-storage/src/config.rs
@@ -20,15 +20,10 @@ impl Default for Config {
         Self {
             db_dir:  directories::ProjectDirs::from("dtn", "Hardy", env!("CARGO_PKG_NAME"))
             .map_or_else(
-                || {
-                    #[cfg(unix)]
-                    return std::path::Path::new("/var/spool").join(env!("CARGO_PKG_NAME"));
-
-                    #[cfg(windows)]
-                    return std::env::current_exe().expect("Failed to get current executable path").join(env!("CARGO_PKG_NAME"));
-
-                    #[cfg(not(any(unix,windows)))]
-                    compile_error!("No idea how to determine default sqlite metadata store directory for target platform");
+                || cfg_select! {
+                    unix => std::path::Path::new("/var/spool").join(env!("CARGO_PKG_NAME")),
+                    windows => std::env::current_exe().expect("Failed to get current executable path").join(env!("CARGO_PKG_NAME")),
+                    _ => compile_error!("No idea how to determine default sqlite metadata store directory for target platform"),
                 },
                 |project_dirs| {
                     project_dirs.cache_dir().into()

--- a/tcpclv4/src/connection.rs
+++ b/tcpclv4/src/connection.rs
@@ -284,9 +284,10 @@ impl ConnectionRegistry {
         {
             let mut pools = self.pools.lock().trace_expect("Failed to lock mutex");
             if let Some(current) = pools.get(remote_addr)
-                && Arc::ptr_eq(current, &pool) {
-                    pools.remove(remote_addr);
-                }
+                && Arc::ptr_eq(current, &pool)
+            {
+                pools.remove(remote_addr);
+            }
         }
     }
 

--- a/tcpclv4/src/connection.rs
+++ b/tcpclv4/src/connection.rs
@@ -283,11 +283,10 @@ impl ConnectionRegistry {
             && pool.remove(local_addr).await
         {
             let mut pools = self.pools.lock().trace_expect("Failed to lock mutex");
-            if let Some(current) = pools.get(remote_addr) {
-                if Arc::ptr_eq(current, &pool) {
+            if let Some(current) = pools.get(remote_addr)
+                && Arc::ptr_eq(current, &pool) {
                     pools.remove(remote_addr);
                 }
-            }
         }
     }
 

--- a/tools/lib/privilege.rs
+++ b/tools/lib/privilege.rs
@@ -53,16 +53,13 @@ fn test() -> anyhow::Result<()> {
         eprintln!("\nError: This application requires elevated privileges to run.");
 
         // Provide platform-specific instructions for the user.
-        #[cfg(target_os = "windows")]
-        eprintln!("Please right-click the executable and select 'Run as Administrator'.");
-
-        #[cfg(target_os = "linux")]
-        eprintln!(
-            "Please re-run as root or grant the application the 'CAP_NET_ADMIN' capability using 'setcap'."
-        );
-
-        #[cfg(not(any(target_os = "windows", target_os = "linux")))]
-        eprintln!("Please re-run as root.");
+        cfg_select! {
+            target_os = "windows" => eprintln!("Please right-click the executable and select 'Run as Administrator'."),
+            target_os = "linux" => eprintln!(
+                "Please re-run as root or grant the application the 'CAP_NET_ADMIN' capability using 'setcap'."
+            ),
+            _ => eprintln!("Please re-run as root."),
+        }
 
         // Exit with a non-zero status code to indicate an error.
         return Err(anyhow::anyhow!("Missing required privileges."));


### PR DESCRIPTION
# Summary

Raises the workspace MSRV from 1.87 → 1.95, adds a CI job that actually enforces it, and applies the cleanups the newer baseline enables (let-chains, the built-in cfg_select! macro, and the resulting clippy/fmt tidy).

# Motivation

rust-version in Cargo.toml declares a support baseline, but nothing enforced it — the build/test jobs run on latest stable, so code using a feature newer than the declared MSRV would compile in CI yet break for anyone actually on that MSRV. This PR makes the baseline
real: it moves it up to where the code wants to be (let-chains, cfg_select!) and adds a job that fails if the workspace stops building on the declared version.

# What's in it

- MSRV bump — rust-version = "1.95" (via 1.94 → 1.95).
- CI enforcement — new msrv job reads rust-version from Cargo.toml, installs that toolchain, and runs cargo check --locked --all-features --workspace.
- Let-chain adoption — collapse nested if let/if let Err into if let … && let … where clippy's collapsible_if now expects it (bpa filter/registry, storage backends, tcpclv4).
- cfg_select! — replace the cfg-if crate with the built-in macro in the bpa-fuzz harness's storage-backend selection, and drop the cfg-if dependency.
- cargo fmt across the touched crates.

# Files

 .github/workflows/rust.yml                                         │ +msrv validation job
Cargo.toml / Cargo.lock                                            │ MSRV 1.87→1.95; drop cfg-if
bpa/src/filter/{rfc9171,validity}.rs, bpa/src/services/registry.rs │ let-chain collapse
localdisk-storage, s3-storage, tcpclv4/src/connection.rs           │ let-chain collapse
bpa/fuzz/{Cargo.toml,src/lib.rs}                                   │ cfg_if! → cfg_select!
bpa/benches/bundle_bench.rs, bpa/tests/pipeline.rs                 │ fmt                         

# Notes

- Split out of the interop PR (feat/interop-version-capture), which is intentionally kept at 1.87. Merge this first (or rebase the interop branch on it): once CI's clippy is new enough to flag collapsible_if, the interop PR needs these fixes to stay green.
- No behavioural changes — purely toolchain baseline, lint style, and a dependency swap. Validated by the standard fmt/clippy/build/test gates plus the new msrv check.
