### PR TITLE
fix(bpa/rib): store poll_waiting wakeups instead of dropping them

### DIFF
--- a/bpa/src/routing/rib.rs
+++ b/bpa/src/routing/rib.rs
@@ -459,7 +459,10 @@ impl Rib {
     }
 
     async fn notify_updated(&self) {
-        self.poll_waiting_notify.notify_waiters();
+        // notify_one() stores a permit if the poll_waiting_task is mid-scan,
+        // so a route change during an in-flight scan triggers a re-scan rather
+        // than being lost (notify_waiters() stores nothing).
+        self.poll_waiting_notify.notify_one();
     }
 
     async fn reset_peer_queues(&self, peers: HashSet<u32>) -> bool {

--- a/bpa/src/routing/rib.rs
+++ b/bpa/src/routing/rib.rs
@@ -249,7 +249,7 @@ impl Rib {
             }
         };
         if changed {
-            self.notify_updated().await;
+            self.poll_waiting_notify.notify_one();
         }
         Ok(true)
     }
@@ -286,16 +286,16 @@ impl Rib {
                 if let Some(peers) = self.find_peers(to)
                     && self.reset_peer_queues(peers).await
                 {
-                    self.notify_updated().await;
+                    self.poll_waiting_notify.notify_one();
                 }
             }
             Action::Internal(InternalAction::Forward(peer))
                 if self.store.reset_peer_queue(peer).await =>
             {
-                self.notify_updated().await;
+                self.poll_waiting_notify.notify_one();
             }
             Action::Internal(InternalAction::Local(_)) => {
-                self.notify_updated().await;
+                self.poll_waiting_notify.notify_one();
             }
             _ => {}
         }
@@ -332,7 +332,7 @@ impl Rib {
             }
         }
         if changed {
-            self.notify_updated().await;
+            self.poll_waiting_notify.notify_one();
         }
     }
 
@@ -456,13 +456,6 @@ impl Rib {
             )),
             other => other,
         }
-    }
-
-    async fn notify_updated(&self) {
-        // notify_one() stores a permit if the poll_waiting_task is mid-scan,
-        // so a route change during an in-flight scan triggers a re-scan rather
-        // than being lost (notify_waiters() stores nothing).
-        self.poll_waiting_notify.notify_one();
     }
 
     async fn reset_peer_queues(&self, peers: HashSet<u32>) -> bool {


### PR DESCRIPTION
notify_updated() used notify_waiters(), which stores no permit: a route event arriving while the single poll_waiting_task consumer was mid-scan was silently lost, stranding the Waiting backlog until the next route event — or lifetime expiry in a static topology. notify_one() stores the permit so the scan re-runs, matching every other single-consumer wakeup in the crate.