### PR TITLE
fix(bpa/rib): wake the Waiting poller on every Route addition

### DIFF
--- a/bpa/src/routing/rib.rs
+++ b/bpa/src/routing/rib.rs
@@ -232,26 +232,20 @@ impl Rib {
             vias
         };
 
-        let changed = match action {
-            Action::Internal(InternalAction::AdminEndpoint) => false,
-            Action::Internal(InternalAction::Local(_))
-            | Action::Internal(InternalAction::Forward(_)) => true,
-            Action::Route(_) => {
-                // Preempt any queues now resolving through the new route, but
-                // notify regardless: a new route is a new forwarding
-                // opportunity for Waiting bundles even when every impacted
-                // peer queue is idle.
-                for v in vias {
-                    if let Some(peers) = self.find_peers(&v) {
-                        self.reset_peer_queues(peers).await;
-                    }
+        if matches!(action, Action::Route(_)) {
+            // Preempt any queues now resolving through the new route
+            for v in vias {
+                if let Some(peers) = self.find_peers(&v) {
+                    self.reset_peer_queues(peers).await;
                 }
-                true
             }
-        };
-        if changed {
+        }
+
+        // notify if not AdminEndpoint
+        if !matches!(action, Action::Internal(InternalAction::AdminEndpoint)) {
             self.poll_waiting_notify.notify_one();
         }
+
         Ok(true)
     }
 

--- a/bpa/src/routing/rib.rs
+++ b/bpa/src/routing/rib.rs
@@ -237,15 +237,16 @@ impl Rib {
             Action::Internal(InternalAction::Local(_))
             | Action::Internal(InternalAction::Forward(_)) => true,
             Action::Route(_) => {
-                let mut changed = false;
+                // Preempt any queues now resolving through the new route, but
+                // notify regardless: a new route is a new forwarding
+                // opportunity for Waiting bundles even when every impacted
+                // peer queue is idle.
                 for v in vias {
-                    if let Some(peers) = self.find_peers(&v)
-                        && self.reset_peer_queues(peers).await
-                    {
-                        changed = true;
+                    if let Some(peers) = self.find_peers(&v) {
+                        self.reset_peer_queues(peers).await;
                     }
                 }
-                changed
+                true
             }
         };
         if changed {
@@ -883,6 +884,32 @@ mod tests {
         assert!(
             matches!(result, Ok(true)),
             "Default route should be accepted, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_route_add_wakes_waiting_poller() {
+        let rib = make_rib();
+
+        // A connected but idle peer for ipn:0.2.0 — no queued bundles, so
+        // reset_peer_queues() flips nothing.
+        add_local_forward(&rib, ipn_node(2), 42);
+
+        let mut notified = core::pin::pin!(rib.poll_waiting_notify.notified());
+        assert!(futures::poll!(notified.as_mut()).is_pending());
+
+        rib.add(
+            "ipn:0.7.*".parse().unwrap(),
+            "test".into(),
+            Action::Route(RouteAction::Via("ipn:0.2.0".parse().unwrap())),
+            10,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            futures::poll!(notified.as_mut()).is_ready(),
+            "Route add must wake the Waiting poller even when no peer queue was preempted"
         );
     }
 }


### PR DESCRIPTION
Rib::add only notified the poll_waiting task when adding a route preempted a non-empty peer queue. Adding a Via route toward a connected but idle peer — the normal TVR contact-window case — flipped no queues, so bundles already parked in Waiting for the newly-routable destination were never re-dispatched and the contact was missed.

A new route is a new forwarding opportunity regardless of queue state: notify unconditionally, as the Local/Forward arms already do. Queue preemption for impacted vias is retained as a parallel effect.