### PR TITLE
fix(bpa/storage): validate fragment coverage and 32-bit range safety …

### DIFF
--- a/bpa/docs/TODO.md
+++ b/bpa/docs/TODO.md
@@ -1,0 +1,25 @@
+# bpa TODO
+
+## RFC 9171 §5.9 material-extents reassembly (overlapping fragments)
+
+### Background
+
+`Store::reassemble()` (`src/storage/adu_reassembly.rs`) requires the received fragments to tile `[0, total_adu_length)` exactly: contiguous, non-overlapping and complete. Overlapping fragment sets are rejected and the fragments dropped as `ReassemblyResult::Failed`.
+
+RFC 9171 §5.9 is more permissive: overlapping fragments are legal on the wire (e.g. the same bundle refragmented differently on divergent paths), and a conformant reassembler computes each arriving fragment's "material extents" — the byte ranges not already covered by previously received fragments — completing when the material extents concatenate to the full ADU. First-received bytes win; overlap is trimmed, not rejected.
+
+Hardy has never accepted overlap: the pre-tiling-check code also failed overlapping sets (payload-length sum ≠ total), except for the length-sum coincidence that silently delivered a corrupt ADU (2026-07-08 review findings #1/#4). The tiling check makes rejection deterministic and safe, but Hardy remains non-conformant for legitimately overlapping fragment sets.
+
+### What full §5.9 support needs
+
+- `FragmentSet` must hold *trimmed* ranges decided at insert time by arrival order: on insert, clip the new fragment's payload range against the extents already covered (possibly splitting it), rather than keying whole fragments by raw offset.
+- The completeness gate in `poll_fragments()` (`adu_totals >= total_adu_len`) must sum material extents, not raw payload lengths, or completion fires early on overlapping sets.
+- The copy loop in `reassemble()` then slices each stored payload sub-range; the tiling invariant holds by construction.
+- §5.9 requires the reassembled ADU to replace the payload of the fragment whose material extents include offset zero — the current "fragment 0" special-casing needs re-deriving from material extents, not from a raw offset-0 key.
+
+## Deletion status reports on reassembly failure
+
+When reassembly fails (`ReassemblyResult::Failed`), `Store::adu_reassemble` deletes the held fragments directly against storage (`delete_data` + `tombstone_metadata`) and the dispatcher's `Failed` arm returns without action — no deletion status reports are generated. RFC 9171 §5.10 says a deletion status report SHOULD be generated per deleted bundle (each fragment is its own bundle, reported to its own report-to EID with its fragment offset/length) when the report flag is set and reporting is enabled.
+
+The fix is plumbing, not policy: `adu_reassemble` should hand the fragment `Bundle`s back on failure instead of consuming them, so `Dispatcher::reassemble` can route each through `drop_bundle(bundle, reason)` (which already does the flag-gated `report_bundle_deletion` + delete). Reason-code selection per failure mode needs deciding: `DepletedStorage` fits the length-not-addressable case; coverage gaps/overlaps have no exact RFC 9171 reason code (`NoAdditionalInformation` or `BlockUnintelligible` are the candidates).
+

--- a/bpa/src/storage/adu_reassembly.rs
+++ b/bpa/src/storage/adu_reassembly.rs
@@ -182,13 +182,57 @@ impl Store {
             .trace_expect("Fragment 0 missing fragment_info in reassembly?!")
             .total_adu_length;
 
+        // total_adu_length and fragment offsets are wire-derived u64s: all
+        // range arithmetic below is done in u64, and values are only narrowed
+        // to usize via try_from once proven in range, so nothing truncates on
+        // 32-bit targets.
+        let Ok(adu_len) = usize::try_from(total_adu_length) else {
+            debug!(
+                "Total ADU length {total_adu_length} is not addressable: {:?}",
+                first.0
+            );
+            return None;
+        };
+
+        // The fragments must tile [0, total_adu_length) exactly: contiguous,
+        // non-overlapping and complete. Summing payload lengths instead would
+        // accept overlapping fragments whose lengths happen to total the ADU
+        // length, delivering zero-filled gaps as payload.
+        let mut extents = results
+            .adus
+            .iter()
+            .map(|(offset, (_, _, payload))| (*offset, payload.len() as u64))
+            .collect::<Vec<_>>();
+        extents.sort_unstable();
+        let mut covered: u64 = 0;
+        for (offset, len) in extents {
+            if offset != covered {
+                debug!(
+                    "Fragment at offset {offset} {} covered length {covered}: {:?}",
+                    if offset > covered {
+                        "leaves a gap below"
+                    } else {
+                        "overlaps"
+                    },
+                    first.0
+                );
+                return None;
+            }
+            covered = covered.saturating_add(len);
+        }
+        if covered != total_adu_length {
+            debug!(
+                "Total reassembled ADU does not match fragment info: {:?}",
+                first.0
+            );
+            return None;
+        }
+
         // Reassemble payload by writing each fragment at its ADU offset.
         // Fragment 0's data is already in old_data — copy its payload first,
         // then load remaining fragments. This avoids reloading fragment 0
         // (load_data takes from storage, so a second load would return None).
-        let adu_len = total_adu_length as usize;
         let mut new_data: Vec<u8> = vec![0; adu_len];
-        let mut bytes_written: u64 = 0;
 
         // Copy fragment 0's payload from old_data (already loaded)
         {
@@ -198,7 +242,6 @@ impl Store {
                 return None;
             }
             new_data[..len].copy_from_slice(&old_data[first.2.clone()]);
-            bytes_written = bytes_written.saturating_add(len as u64);
         }
 
         for (bundle_id, storage_name, payload) in results.adus.values() {
@@ -218,24 +261,18 @@ impl Store {
                 return None;
             }
 
-            let offset = fi.offset as usize;
             let len = payload.len();
-            if offset.saturating_add(len) > adu_len {
+            if fi.offset.saturating_add(len as u64) > total_adu_length {
                 debug!("Fragment extends beyond total ADU length: {bundle_id}");
                 return None;
             }
+            let Ok(offset) = usize::try_from(fi.offset) else {
+                debug!("Fragment offset is not addressable: {bundle_id}");
+                return None;
+            };
 
             let adu = self.load_data(storage_name).await?.slice(payload.clone());
             new_data[offset..offset + len].copy_from_slice(adu.as_ref());
-            bytes_written = bytes_written.saturating_add(len as u64);
-        }
-
-        if bytes_written != total_adu_length {
-            debug!(
-                "Total reassembled ADU does not match fragment info: {:?}",
-                first.0
-            );
-            return None;
         }
 
         // Rewrite primary block
@@ -418,6 +455,64 @@ mod tests {
         assert!(
             result.is_none(),
             "Should reject when bytes_written < total_adu_length"
+        );
+    }
+
+    // Overlapping fragments whose payload lengths sum to total_adu_length
+    // must not pass coverage validation: [3..5) would be double-written and
+    // [8..10) would be delivered as zero-fill.
+    #[tokio::test]
+    async fn reassemble_rejects_overlapping_fragments() {
+        let store = make_store();
+        let ts = CreationTimestamp::now();
+
+        let data = b"HelloWorld";
+        let name0 = store_bytes(&store, data).await;
+        let name1 = store_bytes(&store, data).await;
+
+        let id0 = make_id("ipn:0.1.1", &ts, 0, 10);
+        let id1 = make_id("ipn:0.1.1", &ts, 3, 10);
+
+        store_fragment_metadata(&store, &id0, &name0).await;
+
+        let fragments = FragmentSet {
+            received_at: OffsetDateTime::now_utc(),
+            adus: [(0, (id0, name0, 0..5)), (3, (id1, name1, 0..5))].into(),
+        };
+
+        let result = store.reassemble(&fragments).await;
+        assert!(
+            result.is_none(),
+            "Should reject overlapping fragments even when lengths sum to total"
+        );
+    }
+
+    // Fragment offsets are wire-derived u64 values: an offset >= 2^32 must be
+    // rejected as a coverage gap, not wrapped into range by a usize cast on
+    // 32-bit targets.
+    #[tokio::test]
+    async fn reassemble_rejects_offset_beyond_u32() {
+        let store = make_store();
+        let ts = CreationTimestamp::now();
+
+        let data = b"HelloWorld";
+        let name0 = store_bytes(&store, data).await;
+        let name1 = store_bytes(&store, data).await;
+
+        let id0 = make_id("ipn:0.1.1", &ts, 0, 10);
+        let id1 = make_id("ipn:0.1.1", &ts, 1 << 32, 10);
+
+        store_fragment_metadata(&store, &id0, &name0).await;
+
+        let fragments = FragmentSet {
+            received_at: OffsetDateTime::now_utc(),
+            adus: [(0, (id0, name0, 0..5)), (1 << 32, (id1, name1, 0..5))].into(),
+        };
+
+        let result = store.reassemble(&fragments).await;
+        assert!(
+            result.is_none(),
+            "Should reject fragment with offset beyond u32 range"
         );
     }
 

--- a/bpa/src/storage/adu_reassembly.rs
+++ b/bpa/src/storage/adu_reassembly.rs
@@ -230,8 +230,8 @@ impl Store {
 
         // Reassemble payload by writing each fragment at its ADU offset.
         // Fragment 0's data is already in old_data — copy its payload first,
-        // then load remaining fragments. This avoids reloading fragment 0
-        // (load_data takes from storage, so a second load would return None).
+        // then load remaining fragments, avoiding a redundant load of
+        // fragment 0.
         let mut new_data: Vec<u8> = vec![0; adu_len];
 
         // Copy fragment 0's payload from old_data (already loaded)


### PR DESCRIPTION
…in reassembly

reassemble() validated fragment completeness by summing payload lengths against total_adu_length, so overlapping fragments whose lengths happened to sum to the total passed the check and a silently corrupt ADU (zero-filled gaps, double-written overlaps) was delivered to the local service. Replace the sum with a tiling check: sorted fragment extents must cover [0, total_adu_length) contiguously with no overlap.

total_adu_length and fragment offsets were also narrowed with `as usize`, truncating wire-derived u64 values on 32-bit targets and letting bounds checks pass on wrapped values. All range arithmetic is now done in u64, narrowing via try_from only after the value is proven in range.

The strict tiling check remains non-conformant with RFC 9171 §5.9 material-extents reassembly (legally overlapping fragment sets are rejected rather than trimmed), as the previous code always was outside the corrupting coincidence. That, and the absence of deletion status reports on reassembly failure, are recorded in bpa/docs/TODO.md.