### PR TITLE
fix(bpa/storage): make mem-backend load() non-destructive

### DIFF
--- a/bpa/src/storage/backend.rs
+++ b/bpa/src/storage/backend.rs
@@ -162,6 +162,11 @@ pub trait BundleStorage: Send + Sync {
     async fn recover(&self, stream: &dyn Sender<RecoveryResponse>) -> Result<()>;
 
     /// Loads the bundle stored under `storage_name`, or `None` if absent.
+    ///
+    /// Loading is non-destructive: repeated loads of the same name return
+    /// the same data until [`delete`](BundleStorage::delete) or
+    /// [`replace`](BundleStorage::replace). The BPA re-loads on every
+    /// forwarding retry.
     async fn load(&self, storage_name: &str) -> Result<Option<Bytes>>;
 
     /// Saves bundle `data`, returning the generated storage name.

--- a/bpa/src/storage/bundle_mem.rs
+++ b/bpa/src/storage/bundle_mem.rs
@@ -155,6 +155,7 @@ impl BundleStorage for BundleMemStorage {
             .capacity
             .saturating_sub(old_len)
             .saturating_add(new_len);
+        metrics::gauge!("bpa.mem_store.bundles").set(inner.cache.len() as f64);
         metrics::gauge!("bpa.mem_store.bytes").set(inner.capacity as f64);
         Ok(())
     }

--- a/bpa/src/storage/bundle_mem.rs
+++ b/bpa/src/storage/bundle_mem.rs
@@ -85,21 +85,19 @@ impl BundleStorage for BundleMemStorage {
         Ok(())
     }
 
-    // SAFETY: load() is always the final storage access before delete().
-    // Taking from the cache (rather than cloning) ensures the returned Bytes
-    // has a single refcount, enabling in-place mutation via try_into_mut()
-    // in the Editor's flatten_inplace() path.
-    // bundle_mem has no crash recovery, so there is no secondary load path
-    // that could observe the missing entry.
+    // Bytes::clone is a refcount bump, not a data copy. The entry stays in
+    // the cache until delete() so the forwarding retry paths can load the
+    // data again after a failed CLA send. Because the cache retains a
+    // reference, editors rewriting loaded data take the copying
+    // Chunk::flatten path rather than mutating the buffer in place via
+    // try_into_mut() — the retained copy must survive the rewrite.
     async fn load(&self, storage_name: &str) -> Result<Option<Bytes>> {
-        let mut inner = self.inner.lock();
-        let Some((_, data)) = inner.cache.pop(storage_name) else {
-            return Ok(None);
-        };
-        inner.capacity = inner.capacity.saturating_sub(data.len());
-        metrics::gauge!("bpa.mem_store.bundles").set(inner.cache.len() as f64);
-        metrics::gauge!("bpa.mem_store.bytes").set(inner.capacity as f64);
-        Ok(Some(data))
+        Ok(self
+            .inner
+            .lock()
+            .cache
+            .get(storage_name)
+            .map(|(_, data)| data.clone()))
     }
 
     async fn save(&self, data: Bytes) -> Result<Arc<str>> {
@@ -201,7 +199,6 @@ mod tests {
             storage.load(&name1).await.unwrap().is_none(),
             "Oldest bundle should be evicted"
         );
-        // load() takes — subsequent loads of name2/name3 confirm they survived eviction
         assert!(storage.load(&name2).await.unwrap().is_some());
         assert!(storage.load(&name3).await.unwrap().is_some());
     }
@@ -243,7 +240,6 @@ mod tests {
 
         // Total capacity = 150 > 100, but we have exactly min_bundles (3) entries
         // So no eviction should occur despite exceeding byte capacity
-        // load() takes, so each call confirms the entry survived then removes it
         assert!(
             storage.load(&name1).await.unwrap().is_some(),
             "min_bundles should protect from eviction"

--- a/bpa/src/storage/cached.rs
+++ b/bpa/src/storage/cached.rs
@@ -48,12 +48,12 @@ impl BundleStorage for CachedBundleStorage {
         self.inner.recover(stream).await
     }
 
-    // SAFETY: load() is always the final storage access before delete().
-    // Taking from the cache (rather than cloning) ensures the returned Bytes
-    // has a single refcount, enabling in-place mutation via try_into_mut()
-    // in the Editor's flatten_inplace() path.
-    // On a cache miss, the inner backend (disk/sqlite) returns a fresh
-    // Bytes with refcount=1, so we do not re-populate the cache.
+    // A cache hit pops the entry: the returned Bytes is then usually
+    // uniquely owned, letting editors mutate it in place via try_into_mut().
+    // The durable copy in the inner backend keeps load() non-destructive
+    // per the BundleStorage contract — a repeated load is simply a cache
+    // miss served by the inner backend, which is also why a miss does not
+    // re-populate the cache.
     async fn load(&self, storage_name: &str) -> Result<Option<Bytes>> {
         if let Some(data) = self.lru.lock().pop(storage_name) {
             metrics::counter!("bpa.store.cache.hits").increment(1);

--- a/tests/storage/src/bundle_suite.rs
+++ b/tests/storage/src/bundle_suite.rs
@@ -70,3 +70,26 @@ pub async fn blob_04_recovery_scan(store: Arc<dyn BundleStorage>) {
         );
     }
 }
+
+/// BLOB-05: Repeatable Load
+///
+/// Loading is non-destructive: the BPA re-loads on every forwarding retry,
+/// so the entry must survive until `delete()`.
+pub async fn blob_05_repeatable_load(store: Arc<dyn BundleStorage>) {
+    let data = fixtures::random_payload(1024);
+    let name = store.save(data.clone()).await.unwrap();
+
+    let first = store.load(&name).await.unwrap();
+    assert_eq!(
+        first.as_ref(),
+        Some(&data),
+        "first load should return the saved bytes"
+    );
+
+    let second = store.load(&name).await.unwrap();
+    assert_eq!(
+        second.as_ref(),
+        Some(&data),
+        "load must be repeatable until delete()"
+    );
+}

--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -281,6 +281,7 @@ macro_rules! storage_blob_tests {
             blob_test!(blob_02_delete);
             blob_test!(blob_03_missing_load);
             blob_test!(blob_04_recovery_scan);
+            blob_test!(blob_05_repeatable_load);
         }
     };
 }
@@ -340,6 +341,7 @@ macro_rules! storage_blob_tests_async {
             blob_test!(blob_02_delete);
             blob_test!(blob_03_missing_load);
             blob_test!(blob_04_recovery_scan);
+            blob_test!(blob_05_repeatable_load);
         }
     };
 }


### PR DESCRIPTION
BundleMemStorage::load destructively popped the cache entry, on the premise that load is always the final access before delete. The forwarding retry paths break that premise: forward_bundle re-loads on every attempt, so a single transient CLA failure (session drop mid-send) destroyed the payload and the bundle was later dropped as DepletedStorage despite being unexpired — permanent data loss from a routine link flap, in the default (no backend configured) build.

load() now clones the Bytes handle (a refcount bump, not a data copy) and the entry lives until delete(). The cost is that editors rewriting loaded data fall back from in-place mutation to a copying flatten, since the retained copy must survive the rewrite — a bundle-sized memcpy per forward, in exchange for not losing the bundle.

The non-destructive contract is now documented on BundleStorage::load and enforced across all backends by BLOB-05 in the compliance suite.