### PR TITLE
fix(bpa/filter): run filter tasks on a dedicated engine pool

### DIFF
--- a/bpa/docs/filter_subsystem_design.md
+++ b/bpa/docs/filter_subsystem_design.md
@@ -212,9 +212,11 @@ The registry holds pre-built `FilterChain`s wrapped in an `Arc`. On each `exec` 
 
 This prevents writer starvation, is Send-safe for async runtimes, and avoids per-bundle rebuilds of the execution structure.
 
-### Rate-Limited Execution
+### Filter Task Scheduling
 
-ReadFilter parallelism is bounded by the dispatcher's `processing_pool` (a `BoundedTaskPool`). Bundle processing itself runs inline in the caller's context — for CLA ingress, backpressure comes from the RpcProxy's handler pool; for dispatch queue consumers and reassembly, from the dispatcher's processing pool spawns.
+ReadFilter tasks run on the filter engine's own dedicated unbounded `TaskPool`, shared by all chains. This pool is deliberately separate from the dispatcher's `processing_pool`: `exec()` callers hold processing-pool permits (`process_bundle` → reassembly/delivery → `exec`), and spawning filter tasks onto that same pool self-deadlocks once it saturates — every permit holder parks waiting for a permit only another parked holder could release. The dedicated pool is unbounded, so no such cycle can form; concurrency remains transitively bounded by the callers because every spawned filter task is awaited within `exec()`.
+
+Bundle processing itself runs inline in the caller's context — for CLA ingress, backpressure comes from the RpcProxy's handler pool; for dispatch queue consumers and reassembly, from the dispatcher's processing pool spawns.
 
 ### Parallelism Rules
 

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -36,13 +36,7 @@ impl Dispatcher {
         // - On Drop result: call drop_bundle() and return early
         let (bundle, data) = match self
             .filter_engine
-            .exec(
-                filter::Hook::Egress,
-                bundle,
-                data,
-                self.key_provider(),
-                &self.processing_pool,
-            )
+            .exec(filter::Hook::Egress, bundle, data, self.key_provider())
             .await
         {
             Ok(filter::ExecResult::Continue(_, bundle, data)) => (bundle, data),

--- a/bpa/src/dispatcher/ingress.rs
+++ b/bpa/src/dispatcher/ingress.rs
@@ -202,13 +202,7 @@ impl Dispatcher {
         // Ingress filter hook (includes bundle-validity: flags, lifetime, hop-count)
         match self
             .filter_engine
-            .exec(
-                filter::Hook::Ingress,
-                bundle,
-                data,
-                self.key_provider(),
-                &self.processing_pool,
-            )
+            .exec(filter::Hook::Ingress, bundle, data, self.key_provider())
             .await
             // TODO: Recover gracefully once filter error handling is redesigned
             .trace_expect("Ingress filter execution failed")

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -15,13 +15,7 @@ impl Dispatcher {
     ) -> Result<Option<(bundle::Bundle, Bytes)>, crate::Error> {
         match self
             .filter_engine
-            .exec(
-                filter::Hook::Originate,
-                bundle,
-                data,
-                self.key_provider(),
-                &self.processing_pool,
-            )
+            .exec(filter::Hook::Originate, bundle, data, self.key_provider())
             .await
             .inspect_err(|_e| {
                 error!("Originate filter execution failed");
@@ -182,13 +176,7 @@ impl Dispatcher {
         // Deliver filter hook
         let (bundle, data) = match self
             .filter_engine
-            .exec(
-                filter::Hook::Deliver,
-                bundle,
-                data,
-                self.key_provider(),
-                &self.processing_pool,
-            )
+            .exec(filter::Hook::Deliver, bundle, data, self.key_provider())
             .await
         {
             Ok(filter::ExecResult::Continue(_, bundle, data)) => (bundle, data),

--- a/bpa/src/filter/chain.rs
+++ b/bpa/src/filter/chain.rs
@@ -1,6 +1,6 @@
 use core::ops::ControlFlow;
 
-use hardy_async::BoundedTaskPool;
+use hardy_async::TaskPool;
 use hardy_bpv7::bpsec::key::KeySource;
 use hardy_bpv7::bundle::{Bundle as Bpv7Bundle, CheckedBundle};
 use hardy_bpv7::status_report::ReasonCode;
@@ -173,11 +173,17 @@ struct Level {
 }
 
 impl Level {
-    /// Run all readers in parallel. Takes ownership to avoid cloning,
-    /// returns the bundle and data back via `Arc::try_unwrap`.
+    /// Run all readers in parallel on `pool`. Takes ownership to avoid
+    /// cloning, returns the bundle and data back via `Arc::try_unwrap`.
+    ///
+    /// `pool` must be the filter engine's dedicated unbounded pool, never
+    /// one whose permits exec() callers may already hold (such as the
+    /// dispatcher's processing pool): permit-holding tasks parked waiting
+    /// for further permits from the same semaphore deadlock the whole pool
+    /// once it saturates.
     async fn run_readers(
         &self,
-        pool: &BoundedTaskPool,
+        pool: &TaskPool,
         bundle: Bundle,
         data: Bytes,
     ) -> Result<(Bundle, Bytes, ControlFlow<Option<ReasonCode>>), crate::Error> {
@@ -202,13 +208,10 @@ impl Level {
         for filter in &self.readers {
             let shared = shared.clone();
             let filter = filter.clone();
-            handles.push(
-                hardy_async::spawn!(pool, "filter_task", async move {
-                    let (bundle, data) = &*shared;
-                    filter.filter(bundle, data.as_ref()).await
-                })
-                .await,
-            );
+            handles.push(hardy_async::spawn!(pool, "filter_task", async move {
+                let (bundle, data) = &*shared;
+                filter.filter(bundle, data.as_ref()).await
+            }));
         }
 
         let mut results = Vec::new();
@@ -280,7 +283,7 @@ pub struct FilterChain {
 impl FilterChain {
     pub async fn exec<F>(
         &self,
-        pool: &hardy_async::BoundedTaskPool,
+        pool: &TaskPool,
         mut bundle: Bundle,
         mut data: Bytes,
         key_provider: F,
@@ -518,7 +521,7 @@ mod tests {
 
     async fn run_chain(builder: &FilterChainBuilder) -> ExecResult {
         let chain = builder.build();
-        let pool = hardy_async::BoundedTaskPool::new(core::num::NonZeroUsize::new(4).unwrap());
+        let pool = hardy_async::TaskPool::new();
         let bundle = Bundle {
             bundle: Default::default(),
             metadata: Default::default(),

--- a/bpa/src/filter/engine.rs
+++ b/bpa/src/filter/engine.rs
@@ -60,6 +60,15 @@ pub struct FilterEngine {
     builders: Mutex<Builders>,
     /// Lock-free access to the current built filter chains.
     filters: ArcSwap<Filters>,
+    /// Dedicated unbounded pool for parallel ReadFilter execution, shared by
+    /// all chains. Deliberately NOT the dispatcher's processing pool:
+    /// exec() callers hold processing-pool permits (process_bundle →
+    /// reassembly/delivery → exec), and spawning filter tasks onto that pool
+    /// self-deadlocks once it saturates. Unbounded is safe here because
+    /// every spawned task is awaited within exec(), so concurrency is
+    /// transitively bounded by the callers and the pool is idle between
+    /// calls — and with no semaphore, no permit cycle can form at all.
+    pool: hardy_async::TaskPool,
 }
 
 impl FilterEngine {
@@ -67,7 +76,11 @@ impl FilterEngine {
         let builders = Mutex::new(Builders::default());
         let filters = ArcSwap::from_pointee(Filters::default());
 
-        Self { builders, filters }
+        Self {
+            builders,
+            filters,
+            pool: hardy_async::TaskPool::new(),
+        }
     }
 
     pub fn clear(&self) {
@@ -110,7 +123,6 @@ impl FilterEngine {
         bundle: Bundle,
         data: Bytes,
         key_provider: F,
-        pool: &hardy_async::BoundedTaskPool,
     ) -> Result<ExecResult, crate::Error>
     where
         F: Fn(&Bpv7Bundle, &[u8]) -> Box<dyn KeySource> + Clone + Send,
@@ -119,7 +131,7 @@ impl FilterEngine {
         let filters = self.filters.load();
         let result = filters
             .chain(&hook)
-            .exec(pool, bundle, data, key_provider)
+            .exec(&self.pool, bundle, data, key_provider)
             .await;
 
         match &result {
@@ -137,5 +149,73 @@ impl FilterEngine {
         }
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hardy_async::async_trait;
+
+    use super::*;
+    use crate::filter::ReadResult;
+
+    struct PassFilter;
+
+    #[async_trait]
+    impl crate::filter::ReadFilter for PassFilter {
+        async fn filter(&self, _bundle: &Bundle, _data: &[u8]) -> Result<ReadResult, crate::Error> {
+            Ok(ReadResult::Continue)
+        }
+    }
+
+    // exec() must complete even when every caller holds a permit of a
+    // saturated BoundedTaskPool: filter tasks run on the engine's own
+    // dedicated pool, never the callers'. Spawning them on the callers'
+    // pool deadlocks this exact arrangement (all permits held by tasks
+    // parked waiting for another permit).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exec_completes_from_saturated_caller_pool() {
+        let engine = Arc::new(FilterEngine::new());
+        engine
+            .register(Hook::Ingress, "a", &[], Filter::Read(Arc::new(PassFilter)))
+            .unwrap();
+        engine
+            .register(Hook::Ingress, "b", &[], Filter::Read(Arc::new(PassFilter)))
+            .unwrap();
+
+        let caller_pool =
+            hardy_async::BoundedTaskPool::new(core::num::NonZeroUsize::new(2).unwrap());
+
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let engine = engine.clone();
+            handles.push(
+                hardy_async::spawn!(caller_pool, "outer_task", async move {
+                    let bundle = Bundle {
+                        bundle: Default::default(),
+                        metadata: Default::default(),
+                    };
+                    let result = engine
+                        .exec(
+                            Hook::Ingress,
+                            bundle,
+                            Bytes::new(),
+                            hardy_bpv7::bpsec::no_keys,
+                        )
+                        .await
+                        .unwrap();
+                    assert!(matches!(result, ExecResult::Continue(..)));
+                })
+                .await,
+            );
+        }
+
+        tokio::time::timeout(core::time::Duration::from_secs(5), async {
+            for handle in handles {
+                handle.await.unwrap();
+            }
+        })
+        .await
+        .expect("exec() deadlocked while callers held all pool permits");
     }
 }


### PR DESCRIPTION
run_readers spawned per-filter tasks on the caller-supplied pool, and every dispatcher call site passed the shared processing pool — whose permits some exec() callers already hold (process_bundle → reassembly/ delivery → exec). Once the pool saturated with permit-holding tasks all parked waiting for filter-task permits from the same semaphore, bundle processing deadlocked permanently; every shipped config has two Ingress readers at level 0, so the spawn path ran on every ingress. Remotely triggerable by withholding final fragments of N ADUs then releasing them together.

The FilterEngine now owns a dedicated unbounded TaskPool shared by all chains, and exec() no longer takes a pool parameter. Unbounded is safe: every spawned task is awaited within exec(), so concurrency is bounded transitively by the callers — and with no semaphore, the permit-holder-awaits-permit cycle cannot form. Regression test spawns exec() from callers holding all permits of a saturated BoundedTaskPool.