### PR TITLE
fix(bpv7): drop time "formatting" feature to restore no_std; add no_std CI gate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,49 @@ jobs:
       - name: Build all tests
         run: cargo test --no-run --locked --all-features --workspace
 
+  no-std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Rust toolchain (32-bit bare-metal target)
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: thumbv7em-none-eabihf
+
+      - name: Use cached dependencies and artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: no-std
+
+      # thumbv7em-none-eabihf is a bare-metal target (no std) that is also
+      # 32-bit (usize == u32), so this one job guards BOTH no_std compatibility
+      # AND 32-bit-pointer-width compilation. --no-default-features keeps the
+      # `std` feature off, so a dependency that silently pulls std — e.g. an
+      # accidental `time/formatting` — fails here instead of shipping a broken
+      # no_std build. This is a COMPILE check: it does not run tests, so it does
+      # not catch runtime `as usize` truncation (a 32-bit *test* run would).
+      #
+      # bpv7's GLOBAL_COUNTER is an AtomicU64, which Cortex-M lacks natively, so
+      # bpv7 (and eid-patterns, which depends on it) build with the
+      # `critical-section` feature; a library (rlib) build compiles without a
+      # critical-section impl — only final binaries need one.
+      # TODO: extend to hardy-bpa once its --no-default-features build is
+      # confirmed clean on this target.
+      - name: Build cbor (no_std, 32-bit)
+        run: >
+          cargo build --locked --no-default-features
+          -p hardy-cbor
+          --target thumbv7em-none-eabihf
+
+      - name: Build bpv7 + eid-patterns (no_std, 32-bit)
+        run: >
+          cargo build --locked --no-default-features
+          --features hardy-bpv7/critical-section
+          -p hardy-bpv7
+          -p hardy-eid-patterns
+          --target thumbv7em-none-eabihf
+
   test:
     runs-on: ubuntu-latest
     needs: build

--- a/bpv7/Cargo.toml
+++ b/bpv7/Cargo.toml
@@ -39,7 +39,7 @@ bpsec = []
 [dependencies]
 hardy-cbor = { version = "1", path = "../cbor" }
 thiserror = { version = "2", default-features = false }
-time = { version = "0.3", default-features = false, features = ["formatting", "macros"] }
+time = { version = "0.3", default-features = false, features = ["macros"] }
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 percent-encoding = { version = "2", default-features = false, features = ["alloc"] }
 crc = "3"


### PR DESCRIPTION
time's `formatting` feature force-enables `time/std`, so bpv7 always linked std — silently breaking no_std for bare-metal targets. It was masked because `cargo build --no-default-features` on a std host still succeeds; the break only shows when building where std is absent. `formatting` was unused; drop it (keep `macros`, used by dtn_time's datetime!). The `std` feature already gates `time/std`.

Add a `no-std` CI job building cbor + bpv7 + eid-patterns --no-default-features for thumbv7em-none-eabihf — a bare-metal, 32-bit target — so an accidental std-pulling dependency feature fails in CI instead of shipping. bpv7's AtomicU64 needs the `critical-section` feature on Cortex-M (rlib build needs no impl). Compile-only: does not catch runtime `as usize` truncation.