### PR TITLE
fix(eid-patterns): correct scheme parsing, scheme/glob matching, and …

### DIFF
--- a/eid-patterns/src/dtn_pattern.rs
+++ b/eid-patterns/src/dtn_pattern.rs
@@ -255,8 +255,13 @@ fn parse_dtn_glob(input: &mut &str) -> ModalResult<DtnPatternItem> {
 }
 
 fn do_glob(node_name: &str, demux: &str, pattern: &glob::Pattern) -> bool {
+    // The glob pattern is built as `{node_name}/{demux}` (single separator, see
+    // parse_dtn_glob / new_glob), so the match target must use a single slash
+    // too — otherwise, with require_literal_separator, a single `*` cannot cross
+    // the extra `/` and single-star globs (`dtn://node/*`, `dtn://*/svc`) match
+    // nothing.
     pattern.matches_with(
-        &format!("{node_name}//{demux}"),
+        &format!("{node_name}/{demux}"),
         glob::MatchOptions {
             case_sensitive: false,
             require_literal_separator: true,

--- a/eid-patterns/src/lib.rs
+++ b/eid-patterns/src/lib.rs
@@ -94,13 +94,14 @@ impl EidPattern {
 
     /// Harmonized Specificity Score.
     ///
-    /// Returns `None` for union sets (multiple items) or patterns violating
-    /// monotonic constraints.
+    /// A union set scores as its *broadest* (least specific) member, since it
+    /// matches the union of its members and is therefore only as narrow as the
+    /// widest one. Returns `None` for an empty set or if any member is
+    /// unscoreable.
     pub fn specificity_score(&self) -> Option<u32> {
         match self {
             EidPattern::Any => Some(0),
-            EidPattern::Set(items) if items.len() == 1 => items[0].specificity_score(),
-            EidPattern::Set(_) => None, // Union sets not valid for scoring
+            EidPattern::Set(items) => items.iter().map(|i| i.specificity_score()).min().flatten(),
         }
     }
 
@@ -300,6 +301,28 @@ impl core::fmt::Display for EidPattern {
     }
 }
 
+/// The canonical numeric scheme code of an EID (`dtn` = 1, `ipn` = 2), or the
+/// raw code for an unrecognised scheme. The null endpoint is scheme-ambiguous
+/// (`dtn:none` / `ipn:0.0`) and is matched by the concrete ipn/dtn pattern
+/// arms rather than by scheme-family wildcards, so it maps to `None` here.
+fn eid_numeric_scheme(eid: &Eid) -> Option<u64> {
+    match eid {
+        Eid::Null => None,
+        Eid::LocalNode(_) | Eid::LegacyIpn { .. } | Eid::Ipn { .. } => Some(2),
+        Eid::Dtn { .. } => Some(1),
+        Eid::Unknown { scheme, .. } => Some(*scheme),
+    }
+}
+
+/// The numeric code for a text scheme name, for the schemes that have both forms.
+fn numeric_scheme_of_text(scheme: &str) -> Option<u64> {
+    match scheme {
+        "dtn" => Some(1),
+        "ipn" => Some(2),
+        _ => None,
+    }
+}
+
 /// A single scheme-specific EID pattern within an [`EidPattern`] union set.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum EidPatternItem {
@@ -321,7 +344,12 @@ impl EidPatternItem {
             EidPatternItem::IpnPatternItem(i) => i.matches(eid),
             #[cfg(feature = "dtn-pat-item")]
             EidPatternItem::DtnPatternItem(i) => i.matches(eid),
-            _ => false,
+            // Scheme-family wildcards (`N:**` / `scheme:**`) match any EID of
+            // that scheme — including an `Eid::Unknown` decoded from the wire.
+            EidPatternItem::AnyNumericScheme(n) => eid_numeric_scheme(eid) == Some(*n),
+            EidPatternItem::AnyTextScheme(s) => {
+                eid_numeric_scheme(eid) == numeric_scheme_of_text(s)
+            }
         }
     }
 

--- a/eid-patterns/src/lib.rs
+++ b/eid-patterns/src/lib.rs
@@ -30,7 +30,7 @@ mod parse;
 mod dtn_pattern;
 
 #[cfg(test)]
-mod str_tests;
+mod tests;
 
 /// Errors produced by EID pattern parsing and conversion.
 #[derive(Error, Debug)]

--- a/eid-patterns/src/lib.rs
+++ b/eid-patterns/src/lib.rs
@@ -347,8 +347,12 @@ impl EidPatternItem {
             // Scheme-family wildcards (`N:**` / `scheme:**`) match any EID of
             // that scheme — including an `Eid::Unknown` decoded from the wire.
             EidPatternItem::AnyNumericScheme(n) => eid_numeric_scheme(eid) == Some(*n),
+            // A text scheme with no numeric code (anything but `dtn`/`ipn`)
+            // matches nothing: guard on `numeric_scheme_of_text` so an unknown
+            // scheme does not fall through to `None == None` and wrongly match
+            // the null endpoint (whose `eid_numeric_scheme` is also `None`).
             EidPatternItem::AnyTextScheme(s) => {
-                eid_numeric_scheme(eid) == numeric_scheme_of_text(s)
+                numeric_scheme_of_text(s).is_some_and(|n| eid_numeric_scheme(eid) == Some(n))
             }
         }
     }

--- a/eid-patterns/src/parse.rs
+++ b/eid-patterns/src/parse.rs
@@ -91,7 +91,8 @@ where
     T: core::str::FromStr,
     <T as core::str::FromStr>::Err: core::error::Error + Send + Sync + 'static,
 {
-    (one_of('1'..'9'), digit0)
+    // Inclusive '1'..='9' per the grammar (%x31-39); '1'..'9' would exclude 9.
+    (one_of('1'..='9'), digit0)
         .take()
         .try_map(|v: &str| v.parse::<T>())
         .parse_next(input)

--- a/eid-patterns/src/str_tests.rs
+++ b/eid-patterns/src/str_tests.rs
@@ -245,11 +245,17 @@ fn tests() {
         // Scheme wildcard
         assert!(dtn_match("dtn:**", "dtn://anything/here"));
 
-        // NOTE: Glob-based DTN matching (dtn://node/*, dtn://node/**, dtn://**/service)
-        // is known-incomplete — see dtn_pattern.rs:17 TODO. The glob pattern uses a
-        // single slash separator but do_glob matches against a double-slash form,
-        // causing mismatches with require_literal_separator. Glob parsing is tested
-        // above via struct equality; matching tests deferred until the glob rework.
+        // Glob-based DTN matching (single-slash separator, R-13).
+        // Single-star matches one demux segment but not across a separator.
+        assert!(dtn_match("dtn://node/*", "dtn://node/service"));
+        assert!(!dtn_match("dtn://node/*", "dtn://other/service"));
+        assert!(!dtn_match("dtn://node/*", "dtn://node/pre/post"));
+        // Authority-position single-star.
+        assert!(dtn_match("dtn://*/service", "dtn://node/service"));
+        assert!(!dtn_match("dtn://*/service", "dtn://node/other"));
+        // Double-star spans separators.
+        assert!(dtn_match("dtn://node/**", "dtn://node/pre/post"));
+        assert!(dtn_match("dtn://**/some/serv", "dtn://node/some/serv"));
 
         assert_eq!(
             "dtn:none".parse::<EidPattern>().expect("Failed to parse"),
@@ -281,6 +287,65 @@ fn tests() {
             )
         );
     }
+}
+
+// R-11: a numeric scheme whose first digit is 9 must parse (grammar is
+// %x31-39 inclusive); '1'..'9' would exclude it.
+#[test]
+fn scheme_beginning_with_nine_parses() {
+    for s in ["9:**", "91:**", "900:**"] {
+        let pat: EidPattern = s
+            .parse()
+            .unwrap_or_else(|e| panic!("{s} should parse: {e}"));
+        assert_eq!(
+            pat,
+            EidPattern::Set(
+                [EidPatternItem::AnyNumericScheme(
+                    s[..s.len() - 3].parse().unwrap()
+                )]
+                .into()
+            )
+        );
+    }
+}
+
+// R-12: a scheme-family wildcard must match an unknown-scheme EID (the RIB
+// routing table relies on this).
+#[test]
+fn scheme_wildcard_matches_unknown_scheme_eid() {
+    use hardy_bpv7::eid::Eid;
+
+    let pat: EidPattern = "88:**".parse().unwrap();
+    assert!(pat.matches(&Eid::Unknown {
+        scheme: 88,
+        data: Box::default(),
+    }));
+    assert!(!pat.matches(&Eid::Unknown {
+        scheme: 89,
+        data: Box::default(),
+    }));
+}
+
+// R-21: a multi-item union must sort as more specific than the `*:**` default
+// so it can override broader routes at the same priority.
+#[test]
+fn union_sorts_more_specific_than_any() {
+    let union: EidPattern = "ipn:0.5.*|ipn:0.6.*".parse().unwrap();
+    let any: EidPattern = "*:**".parse().unwrap();
+
+    assert_eq!(
+        union.specificity_score(),
+        "ipn:0.5.*"
+            .parse::<EidPattern>()
+            .unwrap()
+            .specificity_score(),
+        "a union scores as its broadest member, not None"
+    );
+    // Ord: more specific compares Less (sorted first in the RIB BTreeMap).
+    assert!(
+        union < any,
+        "union route must order before the default route"
+    );
 }
 
 fn ipn_match(pattern: &str, eid: &str) -> bool {
@@ -392,13 +457,15 @@ fn test_specificity_score() {
     // Invalid: range node with specific service
     assert_eq!(score("ipn:100.[10-13].5"), None);
 
-    // Invalid: union set (multiple items)
+    // Union set scores as its broadest (min-scoring) member (R-21), not None.
+    let a = score("ipn:100.1.*");
+    let b = score("ipn:200.1.*");
     assert_eq!(
         "ipn:100.1.*|ipn:200.1.*"
             .parse::<EidPattern>()
             .unwrap()
             .specificity_score(),
-        None
+        a.min(b),
     );
 }
 

--- a/eid-patterns/src/tests.rs
+++ b/eid-patterns/src/tests.rs
@@ -5,7 +5,7 @@ use ipn_pattern::*;
 use dtn_pattern::*;
 
 #[test]
-fn tests() {
+fn parse_tests() {
     ipn_parse("ipn:0.3.4", IpnPatternItem::new(0, 3, Some(4)));
     assert!(ipn_match("ipn:0.3.4", "ipn:0.3.4"));
     assert!(!ipn_match("ipn:0.3.4", "ipn:0.4.0"));
@@ -287,65 +287,6 @@ fn tests() {
             )
         );
     }
-}
-
-// R-11: a numeric scheme whose first digit is 9 must parse (grammar is
-// %x31-39 inclusive); '1'..'9' would exclude it.
-#[test]
-fn scheme_beginning_with_nine_parses() {
-    for s in ["9:**", "91:**", "900:**"] {
-        let pat: EidPattern = s
-            .parse()
-            .unwrap_or_else(|e| panic!("{s} should parse: {e}"));
-        assert_eq!(
-            pat,
-            EidPattern::Set(
-                [EidPatternItem::AnyNumericScheme(
-                    s[..s.len() - 3].parse().unwrap()
-                )]
-                .into()
-            )
-        );
-    }
-}
-
-// R-12: a scheme-family wildcard must match an unknown-scheme EID (the RIB
-// routing table relies on this).
-#[test]
-fn scheme_wildcard_matches_unknown_scheme_eid() {
-    use hardy_bpv7::eid::Eid;
-
-    let pat: EidPattern = "88:**".parse().unwrap();
-    assert!(pat.matches(&Eid::Unknown {
-        scheme: 88,
-        data: Box::default(),
-    }));
-    assert!(!pat.matches(&Eid::Unknown {
-        scheme: 89,
-        data: Box::default(),
-    }));
-}
-
-// R-21: a multi-item union must sort as more specific than the `*:**` default
-// so it can override broader routes at the same priority.
-#[test]
-fn union_sorts_more_specific_than_any() {
-    let union: EidPattern = "ipn:0.5.*|ipn:0.6.*".parse().unwrap();
-    let any: EidPattern = "*:**".parse().unwrap();
-
-    assert_eq!(
-        union.specificity_score(),
-        "ipn:0.5.*"
-            .parse::<EidPattern>()
-            .unwrap()
-            .specificity_score(),
-        "a union scores as its broadest member, not None"
-    );
-    // Ord: more specific compares Less (sorted first in the RIB BTreeMap).
-    assert!(
-        union < any,
-        "union route must order before the default route"
-    );
 }
 
 fn ipn_match(pattern: &str, eid: &str) -> bool {

--- a/eid-patterns/tests/patterns.rs
+++ b/eid-patterns/tests/patterns.rs
@@ -1,0 +1,59 @@
+use hardy_bpv7::eid::Eid;
+use hardy_eid_patterns::{EidPattern, EidPatternItem};
+
+// R-11: a numeric scheme whose first digit is 9 must parse (grammar is
+// %x31-39 inclusive); '1'..'9' would exclude it.
+#[test]
+fn scheme_beginning_with_nine_parses() {
+    for s in ["9:**", "91:**", "900:**"] {
+        let pat: EidPattern = s
+            .parse()
+            .unwrap_or_else(|e| panic!("{s} should parse: {e}"));
+        assert_eq!(
+            pat,
+            EidPattern::Set(
+                [EidPatternItem::AnyNumericScheme(
+                    s[..s.len() - 3].parse().unwrap()
+                )]
+                .into()
+            )
+        );
+    }
+}
+
+// R-12: a scheme-family wildcard must match an unknown-scheme EID (the RIB
+// routing table relies on this).
+#[test]
+fn scheme_wildcard_matches_unknown_scheme_eid() {
+    let pat: EidPattern = "88:**".parse().unwrap();
+    assert!(pat.matches(&Eid::Unknown {
+        scheme: 88,
+        data: Box::default(),
+    }));
+    assert!(!pat.matches(&Eid::Unknown {
+        scheme: 89,
+        data: Box::default(),
+    }));
+}
+
+// R-21: a multi-item union must sort as more specific than the `*:**` default
+// so it can override broader routes at the same priority.
+#[test]
+fn union_sorts_more_specific_than_any() {
+    let union: EidPattern = "ipn:0.5.*|ipn:0.6.*".parse().unwrap();
+    let any: EidPattern = "*:**".parse().unwrap();
+
+    assert_eq!(
+        union.specificity_score(),
+        "ipn:0.5.*"
+            .parse::<EidPattern>()
+            .unwrap()
+            .specificity_score(),
+        "a union scores as its broadest member, not None"
+    );
+    // Ord: more specific compares Less (sorted first in the RIB BTreeMap).
+    assert!(
+        union < any,
+        "union route must order before the default route"
+    );
+}

--- a/eid-patterns/tests/patterns.rs
+++ b/eid-patterns/tests/patterns.rs
@@ -36,6 +36,19 @@ fn scheme_wildcard_matches_unknown_scheme_eid() {
     }));
 }
 
+// A text scheme with no numeric code (anything but `dtn`/`ipn`) has no
+// representable EID, so `scheme:**` matches nothing — in particular it must not
+// match the null endpoint, whose numeric scheme is also `None`.
+#[test]
+fn unknown_text_scheme_matches_nothing() {
+    let pat: EidPattern = "foo:**".parse().unwrap();
+    assert!(!pat.matches(&Eid::Null));
+    assert!(!pat.matches(&Eid::Unknown {
+        scheme: 88,
+        data: Box::default(),
+    }));
+}
+
 // R-21: a multi-item union must sort as more specific than the `*:**` default
 // so it can override broader routes at the same priority.
 #[test]


### PR DESCRIPTION
…union specificity

Four confirmed rescan findings, all in the published eid-patterns crate, each of which silently broke a documented pattern form in the RIB:

- R-11 parse.rs: parse_non_zero_decimal used exclusive '1'..'9', so a numeric scheme beginning with 9 (9:**, 91:**) failed to parse. Use the inclusive '1'..='9' per the %x31-39 grammar.
- R-12 lib.rs: EidPatternItem::matches fell through to `_ => false` for AnyNumericScheme/AnyTextScheme, so scheme-family wildcards matched nothing — including an Eid::Unknown decoded from the wire. Match against the EID's scheme (dtn=1, ipn=2, else the raw code).
- R-13 dtn_pattern.rs: do_glob matched against a double-slash target while patterns are built with a single slash, so single-star globs (dtn://node/*, dtn://*/svc) matched nothing under
require_literal_separator. Use a single slash; ** still spans separators.
- R-21 lib.rs: specificity_score returned None for multi-item unions, so a union route sorted as least-specific (behind *:**) and could not override broader routes. Score a union as its broadest (min) member.

Enables the deferred DTN glob-matching tests and adds regression tests.