### PR TITLE
fix(cbor): encode NaN as canonical half-precision f97e00

### DIFF
--- a/cbor/src/encode.rs
+++ b/cbor/src/encode.rs
@@ -652,7 +652,13 @@ impl ToCbor for f64 {
     type Result = ();
 
     fn to_cbor(&self, encoder: &mut Encoder) -> Self::Result {
-        if let Some(f) = lossless_float_coerce::<half::f16>(*self) {
+        if self.is_nan() {
+            // RFC 8949 §4.2.2: NaN encodes canonically as the half-precision
+            // 0xf97e00. lossless_float_coerce can't narrow a NaN (NaN != NaN),
+            // so handle it here to avoid emitting a non-canonical full-width NaN.
+            encoder.data.push((7 << 5) | 25);
+            encoder.data.extend(half::f16::NAN.to_be_bytes())
+        } else if let Some(f) = lossless_float_coerce::<half::f16>(*self) {
             encoder.data.push((7 << 5) | 25);
             encoder.data.extend(f.to_be_bytes())
         } else if let Some(f) = lossless_float_coerce::<f32>(*self) {
@@ -669,7 +675,12 @@ impl ToCbor for f32 {
     type Result = ();
 
     fn to_cbor(&self, encoder: &mut Encoder) -> Self::Result {
-        if let Some(f) = lossless_float_coerce::<half::f16>(*self as f64) {
+        if self.is_nan() {
+            // RFC 8949 §4.2.2: NaN encodes canonically as the half-precision
+            // 0xf97e00 (see the f64 impl).
+            encoder.data.push((7 << 5) | 25);
+            encoder.data.extend(half::f16::NAN.to_be_bytes())
+        } else if let Some(f) = lossless_float_coerce::<half::f16>(*self as f64) {
             encoder.data.push((7 << 5) | 25);
             encoder.data.extend(f.to_be_bytes())
         } else {

--- a/cbor/tests/encode.rs
+++ b/cbor/tests/encode.rs
@@ -46,8 +46,10 @@ fn rfc_tests() {
     assert_eq!(*emit(&half::f16::INFINITY).0, hex!("f97c00"));
     assert_eq!(*emit(&half::f16::NAN).0, hex!("f97e00"));
     assert_eq!(*emit(&half::f16::NEG_INFINITY).0, hex!("f9fc00"));
-    assert_eq!(*emit(&f32::NAN).0, hex!("fa7fc00000"));
-    assert_eq!(*emit(&f64::NAN).0, hex!("fb7ff8000000000000"));
+    // RFC 8949 §4.2.2: NaN canonically encodes as the half-precision 0xf97e00,
+    // like the infinities in §4.2.1 above (was previously emitted full-width).
+    assert_eq!(*emit(&f32::NAN).0, hex!("f97e00"));
+    assert_eq!(*emit(&f64::NAN).0, hex!("f97e00"));
 
     /* According to https://www.rfc-editor.org/rfc/rfc8949.html#section-4.2.1
     +-INF data should go smaller when canonically encoding */


### PR DESCRIPTION
lossless_float_coerce rejects every narrowing of a NaN because the value-preservation check (into(f) == value) is always false for NaN, so f64::NAN emitted the 9-byte fb7ff8… form and f32::NAN the 5-byte fa7fc0… form — non-canonical output that the crate's own decoder flags as non-shortest. RFC 8949 §4.2.2 canonicalises NaN to the half-precision 0xf97e00, like the infinities in §4.2.1. Special-case is_nan() in the f64/f32 ToCbor impls to emit f97e00 for any NaN. Updates the two tests that asserted the old full-width bytes.