### PR TITLE
fix(bpv7/builder): don't panic in release when caller sets is_fragment

### DIFF
--- a/bpv7/src/builder.rs
+++ b/bpv7/src/builder.rs
@@ -62,8 +62,10 @@ impl<'a> Builder<'a> {
     pub fn with_flags(mut self, flags: bundle::Flags) -> Self {
         self.bundle_flags = flags;
 
-        // Do not allow the fragment flag to be set
-        assert!(!self.bundle_flags.is_fragment);
+        // The fragment flag is owned by the fragmentation logic, not the
+        // caller: flag it in debug builds to catch API misuse, but always
+        // normalise rather than panic in release (this is public API).
+        debug_assert!(!self.bundle_flags.is_fragment);
         self.bundle_flags.is_fragment = false;
 
         self


### PR DESCRIPTION
Builder::with_flags used a plain assert! on is_fragment — a release-build panic on a public-API call — even though the next line already normalises the flag to false. The fragment flag is owned by the fragmentation logic, not the caller. Use debug_assert! so misuse is still caught in debug builds while release normalises rather than crashes.