### PR TITLE
fix(bpv7/bpsec): lock down OperationSet construction against empty sets

### DIFF
--- a/bpv7/src/bpsec/bcb.rs
+++ b/bpv7/src/bpsec/bcb.rs
@@ -149,9 +149,10 @@ impl hardy_cbor::encode::ToCbor for OperationSet {
         // Targets
         encoder.emit(targets.as_slice());
 
-        // Context (an OperationSet is non-empty by construction)
+        // Context
         operations
             .first()
+            // SAFETY: An OperationSet is non-empty by construction
             .expect("OperationSet must contain at least one operation")
             .emit_context(encoder, &self.source);
 

--- a/bpv7/src/bpsec/bcb.rs
+++ b/bpv7/src/bpsec/bcb.rs
@@ -96,15 +96,32 @@ impl Operation {
 }
 
 /// A set of BCB operations sharing a common security source.
+///
+/// Fields are crate-private: an `OperationSet` is only ever produced by the
+/// parser or by `Encryptor`, both of which guarantee it is non-empty (`to_cbor`
+/// relies on that invariant). External code builds BCBs via `Encryptor` and reads
+/// via the [`source`](Self::source)/[`operations`](Self::operations) accessors.
 #[derive(Debug)]
 pub struct OperationSet {
-    /// The EID of the security source.
-    pub source: eid::Eid,
-    /// Operations keyed by target block number.
-    pub operations: HashMap<u64, Operation>,
+    // The EID of the security source.
+    pub(crate) source: eid::Eid,
+    // Operations keyed by target block number.
+    pub(crate) operations: HashMap<u64, Operation>,
 }
 
 impl OperationSet {
+    /// The EID of the security source.
+    #[inline]
+    pub fn source(&self) -> &eid::Eid {
+        &self.source
+    }
+
+    /// The operations in this set, keyed by target block number.
+    #[inline]
+    pub fn operations(&self) -> &HashMap<u64, Operation> {
+        &self.operations
+    }
+
     /// Returns `true` if any operation in this set uses an unrecognised context.
     pub fn is_unsupported(&self) -> bool {
         self.operations.values().any(|op| op.is_unsupported())
@@ -132,10 +149,10 @@ impl hardy_cbor::encode::ToCbor for OperationSet {
         // Targets
         encoder.emit(targets.as_slice());
 
-        // Context
+        // Context (an OperationSet is non-empty by construction)
         operations
             .first()
-            .unwrap()
+            .expect("OperationSet must contain at least one operation")
             .emit_context(encoder, &self.source);
 
         // Results

--- a/bpv7/src/bpsec/bib.rs
+++ b/bpv7/src/bpsec/bib.rs
@@ -117,9 +117,10 @@ impl hardy_cbor::encode::ToCbor for OperationSet {
         // Targets
         encoder.emit(targets.as_slice());
 
-        // Context (an OperationSet is non-empty by construction)
+        // Context
         operations
             .first()
+            // SAFETY: An OperationSet is non-empty by construction
             .expect("OperationSet must contain at least one operation")
             .emit_context(encoder, &self.source);
 

--- a/bpv7/src/bpsec/bib.rs
+++ b/bpv7/src/bpsec/bib.rs
@@ -75,14 +75,31 @@ impl Operation {
 }
 
 /// A set of BIB operations sharing a common security source.
+///
+/// Fields are crate-private: an `OperationSet` is only ever produced by the
+/// parser or by `Signer`, both of which guarantee it is non-empty (`to_cbor`
+/// relies on that invariant). External code builds BIBs via `Signer` and reads
+/// via the [`source`](Self::source)/[`operations`](Self::operations) accessors.
 pub struct OperationSet {
-    /// The EID of the security source.
-    pub source: eid::Eid,
-    /// Operations keyed by target block number.
-    pub operations: HashMap<u64, Operation>,
+    // The EID of the security source.
+    pub(crate) source: eid::Eid,
+    // Operations keyed by target block number.
+    pub(crate) operations: HashMap<u64, Operation>,
 }
 
 impl OperationSet {
+    /// The EID of the security source.
+    #[inline]
+    pub fn source(&self) -> &eid::Eid {
+        &self.source
+    }
+
+    /// The operations in this set, keyed by target block number.
+    #[inline]
+    pub fn operations(&self) -> &HashMap<u64, Operation> {
+        &self.operations
+    }
+
     /// Returns `true` if any operation in this set uses an unrecognised context.
     pub fn is_unsupported(&self) -> bool {
         self.operations.values().any(|op| op.is_unsupported())
@@ -100,10 +117,10 @@ impl hardy_cbor::encode::ToCbor for OperationSet {
         // Targets
         encoder.emit(targets.as_slice());
 
-        // Context
+        // Context (an OperationSet is non-empty by construction)
         operations
             .first()
-            .unwrap()
+            .expect("OperationSet must contain at least one operation")
             .emit_context(encoder, &self.source);
 
         // Results

--- a/bpv7/tools/src/cmd/inspect.rs
+++ b/bpv7/tools/src/cmd/inspect.rs
@@ -380,10 +380,10 @@ fn dump_bcb(data: &[u8], output: &io::Output) -> anyhow::Result<()> {
     let ops = hardy_cbor::decode::parse::<bpsec::bcb::OperationSet>(data)?;
     output.append_str(format!(
         "### BCB Data\n\nSecurity Source: {}\n\n",
-        ops.source
+        ops.source()
     ))?;
 
-    match ops.operations.values().next().unwrap() {
+    match ops.operations().values().next().unwrap() {
         bpsec::bcb::Operation::AES_GCM(op) => {
             output.append_str(format!(
                 "Context: BCB-AES-GCM {:?}\n\n",
@@ -430,7 +430,7 @@ fn dump_bcb(data: &[u8], output: &io::Output) -> anyhow::Result<()> {
         }
     }
 
-    for (target, op) in ops.operations {
+    for (target, op) in ops.operations() {
         output.append_str(format!("#### Target Block {target}\n\n"))?;
 
         match op {
@@ -456,10 +456,10 @@ fn dump_bib(data: &[u8], output: &io::Output) -> anyhow::Result<()> {
     let ops = hardy_cbor::decode::parse::<bpsec::bib::OperationSet>(data)?;
     output.append_str(format!(
         "### BIB Data\n\nSecurity Source: {}\n\n",
-        ops.source
+        ops.source()
     ))?;
 
-    match ops.operations.values().next().unwrap() {
+    match ops.operations().values().next().unwrap() {
         bpsec::bib::Operation::HMAC_SHA2(op) => {
             output.append_str(format!(
                 "Context: BIB-HMAC-SHA2 {:?}\n\n",
@@ -501,7 +501,7 @@ fn dump_bib(data: &[u8], output: &io::Output) -> anyhow::Result<()> {
         }
     }
 
-    for (target, op) in ops.operations {
+    for (target, op) in ops.operations() {
         output.append_str(format!("#### Target Block: {target}\n\n"))?;
 
         match op {


### PR DESCRIPTION
bib/bcb OperationSet had pub source/operations fields, so external code could build one with an empty operations map and hit the first().unwrap() panic in to_cbor (a public-API panic in published bpv7). Make the fields pub(crate) so only the crate (parser, Signer, Encryptor — all of which guarantee non-empty) can construct one, and add #[inline] pub source()/operations() accessors so external readers (the bundle inspect tool) can still inspect a parsed set. Harden the emit unwrap to an expect documenting the invariant.