### PR TITLE
fix(bpv7): remove target CRC when signing the primary block (RFC 9173 §3.8.1)

### DIFF
--- a/bpv7/src/bpsec/rfc9173/mod.rs
+++ b/bpv7/src/bpsec/rfc9173/mod.rs
@@ -16,9 +16,6 @@ fn rand_bytes<const N: usize>() -> Result<Box<[u8]>, Error> {
     Ok(buf)
 }
 
-#[cfg(all(test, feature = "serde"))]
-mod tests;
-
 /// Scope flags controlling which bundle fields are included in the IPPT (RFC 9173 Section 3.3/4.3).
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
 pub struct ScopeFlags {

--- a/bpv7/src/bpsec/rfc9173/tests.rs
+++ b/bpv7/src/bpsec/rfc9173/tests.rs
@@ -973,9 +973,10 @@ fn test_encrypt_bib_directly_fails() {
 
 #[test]
 fn test_sign_primary_block_with_crc() {
-    // Test that signing the primary block (block 0) works even when
-    // the primary block has a CRC. RFC 9171 Section 4.3.1 allows
-    // both CRC and BIB on the primary block.
+    // Test that signing the primary block (block 0) removes its CRC.
+    // RFC 9173 Section 3.8.1 requires the target's CRC to be removed before
+    // the IPPT is generated, with no exemption for the primary block; RFC 9171
+    // Section 4.3.1 permits the primary to carry no CRC when a BIB targets it.
 
     // 1. Create a bundle (primary block will have a CRC by default)
     let (bundle, bundle_bytes) =
@@ -1027,11 +1028,11 @@ fn test_sign_primary_block_with_crc() {
         "Should have 1 BIB after signing primary block"
     );
 
-    // 5. Verify the primary block still has its CRC (RFC 9171 allows this)
+    // 5. Verify the primary block's CRC was removed (RFC 9173 Section 3.8.1)
     let signed_primary = parsed.bundle.blocks.get(&0).expect("Primary block missing");
     assert!(
-        !matches!(signed_primary.crc_type, crate::crc::CrcType::None),
-        "Primary block should still have CRC after signing"
+        matches!(signed_primary.crc_type, crate::crc::CrcType::None),
+        "Primary block CRC must be removed after signing (RFC 9173 Section 3.8.1)"
     );
 
     // 6. Verify the signature

--- a/bpv7/src/bpsec/signer.rs
+++ b/bpv7/src/bpsec/signer.rs
@@ -172,12 +172,27 @@ impl<'a> Signer<'a> {
                     .blocks
                     .get(target)
                     .expect("Missing target block");
-                if *target != 0 && !matches!(target_block.crc_type, crc::CrcType::None) {
-                    editor = editor
-                        .update_block_inner(*target)
-                        .map_err(|(_, e)| e)?
-                        .with_crc_type(crc::CrcType::None)
-                        .rebuild();
+                if !matches!(target_block.crc_type, crc::CrcType::None) {
+                    // The rule applies to every target, including the primary
+                    // (RFC 9171 permits the primary to carry no CRC when a BIB
+                    // targets it).
+                    if *target == 0 {
+                        // Re-emit the primary canonically with no CRC and
+                        // register the bytes, so the IPPT (which reads the
+                        // primary via `block(0)`) and the rebuilt bundle agree
+                        // on the CRC-removed form.
+                        let mut primary = self.original.clone();
+                        primary.crc_type = crc::CrcType::None;
+                        let canonical = crate::bundle::primary_block::PrimaryBlock::emit(&primary)
+                            .map_err(editor::Error::from)?;
+                        editor.set_canonical_primary(canonical.into());
+                    } else {
+                        editor = editor
+                            .update_block_inner(*target)
+                            .map_err(|(_, e)| e)?
+                            .with_crc_type(crc::CrcType::None)
+                            .rebuild();
+                    }
                 }
             }
 

--- a/bpv7/src/bpsec/signer.rs
+++ b/bpv7/src/bpsec/signer.rs
@@ -181,9 +181,11 @@ impl<'a> Signer<'a> {
                         // register the bytes, so the IPPT (which reads the
                         // primary via `block(0)`) and the rebuilt bundle agree
                         // on the CRC-removed form.
-                        let mut primary = self.original.clone();
-                        primary.crc_type = crc::CrcType::None;
-                        let canonical = crate::bundle::primary_block::PrimaryBlock::emit(&primary)
+                        let canonical =
+                            crate::bundle::primary_block::PrimaryBlock::emit_with_crc_type(
+                                self.original,
+                                crc::CrcType::None,
+                            )
                             .map_err(editor::Error::from)?;
                         editor.set_canonical_primary(canonical.into());
                     } else {

--- a/bpv7/src/bundle/primary_block.rs
+++ b/bpv7/src/bundle/primary_block.rs
@@ -247,11 +247,21 @@ impl PrimaryBlock {
     /// This function is used during bundle creation to serialize the primary block
     /// based on the data in a `bundle::Bundle` struct.
     pub fn emit(bundle: &bundle::Bundle) -> Result<Vec<u8>, Error> {
+        Self::emit_with_crc_type(bundle, bundle.crc_type)
+    }
+
+    // Emits the primary block using `crc_type` in place of `bundle.crc_type`,
+    // so callers can emit a CRC-stripped form (RFC 9173 Section 3.8.1) without
+    // cloning the bundle.
+    pub fn emit_with_crc_type(
+        bundle: &bundle::Bundle,
+        crc_type: crc::CrcType,
+    ) -> Result<Vec<u8>, Error> {
         crc::append_crc_value(
-            bundle.crc_type,
+            crc_type,
             hardy_cbor::encode::emit_array(
                 Some({
-                    let mut count = if let crc::CrcType::None = bundle.crc_type {
+                    let mut count = if let crc::CrcType::None = crc_type {
                         8
                     } else {
                         9
@@ -264,7 +274,7 @@ impl PrimaryBlock {
                 |a| {
                     a.emit(&7);
                     a.emit(&bundle.flags);
-                    a.emit(&bundle.crc_type);
+                    a.emit(&crc_type);
                     a.emit(&bundle.destination);
                     a.emit(&bundle.id.source);
                     a.emit(&bundle.report_to);
@@ -278,7 +288,7 @@ impl PrimaryBlock {
                     }
 
                     // CRC
-                    if let crc::CrcType::None = bundle.crc_type {
+                    if let crc::CrcType::None = crc_type {
                     } else {
                         a.skip_value();
                     }

--- a/bpv7/src/editor.rs
+++ b/bpv7/src/editor.rs
@@ -837,6 +837,12 @@ impl<'a> Editor<'a> {
                         .with_data(hardy_cbor::encode::emit(&opset).0.into())
                         .rebuild();
                 }
+
+                // The target is no longer covered by this BIB. Clear its
+                // coverage so `rebuild_bundle()` does not report a dangling
+                // reference to a BIB that has been removed or rewritten.
+                self.bib_overrides
+                    .insert(target_block, block::BibCoverage::None);
             }
         }
         Ok(self)

--- a/bpv7/tests/rfc9173.rs
+++ b/bpv7/tests/rfc9173.rs
@@ -1,14 +1,22 @@
-#![cfg(test)]
+//! Integration tests for the RFC 9173 default security contexts
+//! (BIB-HMAC-SHA2 and BCB-AES-GCM), including the Appendix A test vectors.
+//!
+//! These exercise the public `Signer`/`Encryptor` + `Editor` surface, so they
+//! require a security context (`rfc9173`, which enables `bpsec`) and `serde`
+//! for the JWK key literals. The whole file is gated so `--no-default-features`
+//! builds do not attempt to reference the feature-gated modules.
+#![cfg(all(feature = "rfc9173", feature = "serde"))]
 
-use super::*;
-use crate::bpsec::{encryptor, key, signer};
-use crate::builder::Builder;
-use crate::bundle;
-use crate::creation_timestamp::CreationTimestamp;
-use crate::editor::{Chunk, Editor};
+use hardy_bpv7::{
+    bpsec::{encryptor, key, rfc9173::ScopeFlags, signer},
+    builder::Builder,
+    bundle,
+    creation_timestamp::CreationTimestamp,
+    editor::{Chunk, Editor},
+};
 
 // Helper function to count blocks of a specific type
-fn count_blocks_of_type(bundle: &bundle::Bundle, block_type: crate::block::Type) -> usize {
+fn count_blocks_of_type(bundle: &bundle::Bundle, block_type: hardy_bpv7::block::Type) -> usize {
     bundle
         .blocks
         .values()
@@ -336,7 +344,7 @@ fn test_sign_then_encrypt() {
 
     // Attempt to decrypt the BIB first to isolate decryption issues from verification issues
     if let Some(bib_num) = parsed_enc.bundle.blocks.get(&1).and_then(|b| match b.bib {
-        crate::block::BibCoverage::Some(n) => Some(n),
+        hardy_bpv7::block::BibCoverage::Some(n) => Some(n),
         _ => None,
     }) {
         // println!("Found BIB at block {bib_num}");
@@ -444,14 +452,16 @@ fn test_rfc9173_decrypt_payload_leaves_bib_encrypted() {
         .expect("Failed to parse encrypted bundle");
 
     // Verify we have 2 BCB blocks (separate BCBs for payload and BIB)
-    let bcb_count = count_blocks_of_type(&parsed_enc.bundle, crate::block::Type::BlockSecurity);
+    let bcb_count =
+        count_blocks_of_type(&parsed_enc.bundle, hardy_bpv7::block::Type::BlockSecurity);
     assert_eq!(
         bcb_count, 2,
         "BCB-AES-GCM should create 2 separate BCBs (one for payload, one for BIB)"
     );
 
     // Verify we have 1 BIB block (encrypted by its own BCB)
-    let bib_count = count_blocks_of_type(&parsed_enc.bundle, crate::block::Type::BlockIntegrity);
+    let bib_count =
+        count_blocks_of_type(&parsed_enc.bundle, hardy_bpv7::block::Type::BlockIntegrity);
     assert_eq!(bib_count, 1, "Should have 1 BIB block");
 
     // 4. Remove BCB from payload only
@@ -469,16 +479,20 @@ fn test_rfc9173_decrypt_payload_leaves_bib_encrypted() {
 
     // 5. Assert: 1 BCB remains (the BIB's BCB is still present)
     // This is expected RFC 9173 behavior - separate BCBs mean separate operations
-    let bcb_count_after =
-        count_blocks_of_type(&parsed_decrypted.bundle, crate::block::Type::BlockSecurity);
+    let bcb_count_after = count_blocks_of_type(
+        &parsed_decrypted.bundle,
+        hardy_bpv7::block::Type::BlockSecurity,
+    );
     assert_eq!(
         bcb_count_after, 1,
         "BIB's BCB should remain (RFC 9173 creates separate BCBs due to IV uniqueness)"
     );
 
     // 6. Assert: 1 BIB remains (still encrypted by its BCB)
-    let bib_count_after =
-        count_blocks_of_type(&parsed_decrypted.bundle, crate::block::Type::BlockIntegrity);
+    let bib_count_after = count_blocks_of_type(
+        &parsed_decrypted.bundle,
+        hardy_bpv7::block::Type::BlockIntegrity,
+    );
     assert_eq!(
         bib_count_after, 1,
         "BIB should remain encrypted (RFC 9173 creates separate BCBs)"
@@ -500,7 +514,7 @@ fn test_rfc9173_decrypt_payload_leaves_bib_encrypted() {
 
     // 8. Verify payload does NOT have CRC (BIB provides integrity protection)
     assert!(
-        matches!(payload_block.crc_type, crate::crc::CrcType::None),
+        matches!(payload_block.crc_type, hardy_bpv7::crc::CrcType::None),
         "Payload should not have CRC when BIB exists"
     );
 }
@@ -547,7 +561,10 @@ fn test_bib_removal_and_readd() {
         .verify_block(1, &signed_bytes, &keys)
         .expect("Signature verification should succeed");
 
-    let bib_count = count_blocks_of_type(&parsed_signed.bundle, crate::block::Type::BlockIntegrity);
+    let bib_count = count_blocks_of_type(
+        &parsed_signed.bundle,
+        hardy_bpv7::block::Type::BlockIntegrity,
+    );
     assert_eq!(bib_count, 1, "Should have 1 BIB after signing");
 
     // 4. Remove BIB using Editor::remove_integrity
@@ -564,8 +581,10 @@ fn test_bib_removal_and_readd() {
         .expect("Failed to parse unsigned bundle");
 
     // 5. Assert: No BIB blocks exist
-    let bib_count_after =
-        count_blocks_of_type(&parsed_unsigned.bundle, crate::block::Type::BlockIntegrity);
+    let bib_count_after = count_blocks_of_type(
+        &parsed_unsigned.bundle,
+        hardy_bpv7::block::Type::BlockIntegrity,
+    );
     assert_eq!(bib_count_after, 0, "Should have 0 BIBs after removal");
 
     // 6. Verify signature fails (no BIB)
@@ -731,8 +750,8 @@ fn test_signature_tamper_detection() {
     assert!(
         matches!(
             parse_result,
-            Err(crate::Error::InvalidBPSec(
-                crate::bpsec::Error::IntegrityCheckFailed
+            Err(hardy_bpv7::Error::InvalidBPSec(
+                hardy_bpv7::bpsec::Error::IntegrityCheckFailed
             ))
         ),
         "Tampered bundle should fail to parse with IntegrityCheckFailed, got: {:?}",
@@ -785,7 +804,8 @@ fn test_bcb_without_bib_removal() {
         .expect("Failed to parse encrypted bundle");
 
     // Verify BCB exists
-    let bcb_count = count_blocks_of_type(&parsed_enc.bundle, crate::block::Type::BlockSecurity);
+    let bcb_count =
+        count_blocks_of_type(&parsed_enc.bundle, hardy_bpv7::block::Type::BlockSecurity);
     assert_eq!(bcb_count, 1, "Should have 1 BCB after encryption");
 
     // 3. Remove BCB using Editor::remove_encryption
@@ -802,8 +822,10 @@ fn test_bcb_without_bib_removal() {
         .expect("Failed to parse decrypted bundle");
 
     // 4. Assert: 0 BCBs, payload is decrypted
-    let bcb_count_after =
-        count_blocks_of_type(&parsed_decrypted.bundle, crate::block::Type::BlockSecurity);
+    let bcb_count_after = count_blocks_of_type(
+        &parsed_decrypted.bundle,
+        hardy_bpv7::block::Type::BlockSecurity,
+    );
     assert_eq!(bcb_count_after, 0, "Should have 0 BCBs after removal");
 
     // 5. Payload content matches original
@@ -846,7 +868,7 @@ fn test_remove_encryption_fails_on_unencrypted_block() {
             .expect("Failed to build bundle");
 
     // Verify no BCBs exist
-    let bcb_count = count_blocks_of_type(&bundle, crate::block::Type::BlockSecurity);
+    let bcb_count = count_blocks_of_type(&bundle, hardy_bpv7::block::Type::BlockSecurity);
     assert_eq!(bcb_count, 0, "Should have 0 BCBs (bundle is not encrypted)");
 
     // Attempt to remove encryption from payload block (which is not encrypted)
@@ -876,7 +898,7 @@ fn test_remove_integrity_fails_on_unsigned_block() {
             .expect("Failed to build bundle");
 
     // Verify no BIBs exist
-    let bib_count = count_blocks_of_type(&bundle, crate::block::Type::BlockIntegrity);
+    let bib_count = count_blocks_of_type(&bundle, hardy_bpv7::block::Type::BlockIntegrity);
     assert_eq!(bib_count, 0, "Should have 0 BIBs (bundle is not signed)");
 
     // Attempt to remove integrity from payload block (which is not signed)
@@ -937,7 +959,7 @@ fn test_encrypt_bib_directly_fails() {
         .blocks
         .get(&1)
         .and_then(|b| match b.bib {
-            crate::block::BibCoverage::Some(n) => Some(n),
+            hardy_bpv7::block::BibCoverage::Some(n) => Some(n),
             _ => None,
         })
         .expect("BIB not found on payload block");
@@ -988,7 +1010,7 @@ fn test_sign_primary_block_with_crc() {
     // Verify primary block has a CRC
     let primary = bundle.blocks.get(&0).expect("Primary block missing");
     assert!(
-        !matches!(primary.crc_type, crate::crc::CrcType::None),
+        !matches!(primary.crc_type, hardy_bpv7::crc::CrcType::None),
         "Primary block should have a CRC"
     );
 
@@ -1022,7 +1044,7 @@ fn test_sign_primary_block_with_crc() {
         .expect("Failed to parse signed bundle");
 
     // 4. Verify BIB exists and targets block 0
-    let bib_count = count_blocks_of_type(&parsed.bundle, crate::block::Type::BlockIntegrity);
+    let bib_count = count_blocks_of_type(&parsed.bundle, hardy_bpv7::block::Type::BlockIntegrity);
     assert_eq!(
         bib_count, 1,
         "Should have 1 BIB after signing primary block"
@@ -1031,7 +1053,7 @@ fn test_sign_primary_block_with_crc() {
     // 5. Verify the primary block's CRC was removed (RFC 9173 Section 3.8.1)
     let signed_primary = parsed.bundle.blocks.get(&0).expect("Primary block missing");
     assert!(
-        matches!(signed_primary.crc_type, crate::crc::CrcType::None),
+        matches!(signed_primary.crc_type, hardy_bpv7::crc::CrcType::None),
         "Primary block CRC must be removed after signing (RFC 9173 Section 3.8.1)"
     );
 
@@ -1103,7 +1125,7 @@ fn test_sign_removes_crc_from_target_block() {
     // Verify payload block (block 1) has a CRC before signing
     let payload_block = bundle.blocks.get(&1).expect("Payload block missing");
     assert!(
-        !matches!(payload_block.crc_type, crate::crc::CrcType::None),
+        !matches!(payload_block.crc_type, hardy_bpv7::crc::CrcType::None),
         "Payload block should have a CRC before signing"
     );
 
@@ -1138,7 +1160,7 @@ fn test_sign_removes_crc_from_target_block() {
 
     let signed_payload = parsed.bundle.blocks.get(&1).expect("Payload block missing");
     assert!(
-        matches!(signed_payload.crc_type, crate::crc::CrcType::None),
+        matches!(signed_payload.crc_type, hardy_bpv7::crc::CrcType::None),
         "Payload block CRC type should be None after signing, got {:?}",
         signed_payload.crc_type
     );

--- a/bpv7/tests/signer.rs
+++ b/bpv7/tests/signer.rs
@@ -1,0 +1,141 @@
+//! Integration tests for the BPSec signing/integrity API.
+//!
+//! These exercise the public `Signer` + `Editor` surface, so they require a
+//! security context (`rfc9173`, which enables `bpsec`) and `serde` for the JWK
+//! key literals. The whole file is gated so `--no-default-features` builds do
+//! not attempt to reference the feature-gated modules.
+#![cfg(all(feature = "rfc9173", feature = "serde"))]
+
+use hardy_bpv7::{
+    block,
+    bpsec::{key, rfc9173::ScopeFlags, signer},
+    builder::Builder,
+    bundle, crc,
+    creation_timestamp::CreationTimestamp,
+    editor::Editor,
+};
+
+// Signing the primary block must remove its CRC before generating the IPPT
+// (RFC 9173 §3.8.1 — the target's CRC MUST be removed; no primary exemption),
+// and the resulting signature must verify (sign and verify compute the IPPT over
+// the same CRC-removed canonical primary).
+#[test]
+fn sign_primary_removes_crc_and_verifies() {
+    let (bundle, bundle_bytes) =
+        Builder::new("ipn:1.2".parse().unwrap(), "ipn:2.1".parse().unwrap())
+            .with_payload(b"sign-primary test".as_slice().into())
+            .build(CreationTimestamp::now())
+            .unwrap();
+    assert_ne!(
+        bundle.blocks[&0].crc_type,
+        crc::CrcType::None,
+        "primary starts with a CRC"
+    );
+
+    let key: key::Key = serde_json::from_value(serde_json::json!({
+        "kid": "ipn:2.1",
+        "kty": "oct",
+        "alg": "HS256",
+        "key_ops": ["sign", "verify"],
+        "k": "c2VjcmV0X3NpZ25pbmdfa2V5"
+    }))
+    .unwrap();
+    let keys = key::KeySet::new(vec![key.clone()]);
+
+    let signed_bytes = signer::Signer::new(&bundle, &bundle_bytes)
+        .sign_block(
+            0,
+            signer::Context::HMAC_SHA2(ScopeFlags::default()),
+            "ipn:2.1".parse().unwrap(),
+            &key,
+        )
+        .map_err(|(_, e)| e)
+        .expect("Failed to sign")
+        .rebuild()
+        .expect("Failed to rebuild");
+
+    // Round-trip: the signature must verify.
+    let parsed = bundle::ParsedBundle::parse_with_keys(&signed_bytes, &keys)
+        .expect("signed primary bundle must verify");
+
+    // §3.8.1: the primary's CRC must have been removed before signing.
+    assert_eq!(
+        parsed.bundle.blocks[&0].crc_type,
+        crc::CrcType::None,
+        "signing the primary must remove its CRC (RFC 9173 §3.8.1)"
+    );
+    assert!(matches!(
+        parsed.bundle.blocks[&0].bib,
+        block::BibCoverage::Some(_)
+    ));
+}
+
+// remove_integrity must clear the target's BIB coverage in the rebuilt Bundle,
+// not leave a dangling reference to the removed BIB.
+#[test]
+fn remove_integrity_clears_target_coverage() {
+    let (bundle, bundle_bytes) =
+        Builder::new("ipn:1.2".parse().unwrap(), "ipn:2.1".parse().unwrap())
+            .with_payload(b"remove-integrity coverage test".as_slice().into())
+            .build(CreationTimestamp::now())
+            .unwrap();
+
+    let key: key::Key = serde_json::from_value(serde_json::json!({
+        "kid": "ipn:2.1",
+        "kty": "oct",
+        "alg": "HS256",
+        "key_ops": ["sign", "verify"],
+        "k": "c2VjcmV0X3NpZ25pbmdfa2V5"
+    }))
+    .unwrap();
+    let keys = key::KeySet::new(vec![key.clone()]);
+
+    // Sign the payload block, then re-parse (verifies the signature).
+    let signed_bytes = signer::Signer::new(&bundle, &bundle_bytes)
+        .sign_block(
+            1,
+            signer::Context::HMAC_SHA2(ScopeFlags::default()),
+            "ipn:2.1".parse().unwrap(),
+            &key,
+        )
+        .map_err(|(_, e)| e)
+        .expect("Failed to sign")
+        .rebuild()
+        .expect("Failed to rebuild");
+
+    let parsed = bundle::ParsedBundle::parse_with_keys(&signed_bytes, &keys)
+        .expect("Failed to parse signed bundle");
+    assert!(
+        matches!(parsed.bundle.blocks[&1].bib, block::BibCoverage::Some(_)),
+        "payload block should report BIB coverage after signing"
+    );
+    // Default scope flags include the primary block in the IPPT, but the primary
+    // is not the BIB target here — RFC 9173 §3.8.1 removes only the *target's*
+    // CRC, so the primary retains its CRC (included as-is per §3.7 step 2).
+    assert_ne!(
+        parsed.bundle.blocks[&0].crc_type,
+        crc::CrcType::None,
+        "primary is IPPT scope context, not a target, so its CRC is retained"
+    );
+
+    // remove_integrity() takes the *target* block number, not the BIB's.
+    let (rebuilt, _chunks) = Editor::new(&parsed.bundle, &signed_bytes)
+        .remove_integrity(1)
+        .map_err(|(_, e)| e)
+        .expect("Failed to remove integrity")
+        .rebuild_bundle()
+        .expect("Failed to rebuild bundle");
+
+    assert_eq!(
+        rebuilt.blocks[&1].bib,
+        block::BibCoverage::None,
+        "coverage must be cleared after remove_integrity"
+    );
+    assert!(
+        !rebuilt
+            .blocks
+            .values()
+            .any(|b| b.block_type == block::Type::BlockIntegrity),
+        "no BIB block should remain after remove_integrity"
+    );
+}


### PR DESCRIPTION
BIB-HMAC-SHA2 signing removed the CRC from non-primary targets before generating the IPPT (RFC 9173 §3.8.1) but exempted the primary block, leaving its CRC in place. The IPPT was therefore computed over the CRC-bearing primary, producing a signature that would not interoperate with a conformant verifier (which computes the IPPT over the CRC-removed primary). RFC 9171 §4.3.1 permits the primary to carry no CRC when a BIB targets it.

Remove the primary's CRC on signing by re-emitting it canonically with no CRC and registering the bytes via set_canonical_primary, so the IPPT, the stored block, and the verifier all use the same form. The removal stays scoped to the BIB target: a primary included in the IPPT as scope context (§3.7 step 2) retains its CRC.

Also clear a removed target's BIB coverage in remove_from_bib_targets so rebuild_bundle never reports a dangling reference to a BIB that no longer exists.

Update the primary-signing test to assert the CRC is removed; add signer integration tests covering the target/context CRC cases and coverage clearing.

Signed-off-by: Rick Taylor <rtaylor@aalyria.com>