### PR TITLE
fix(bpa): don't set report_on_failure on blocks added to admin-record bundles

### DIFF
--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -89,12 +89,19 @@ impl Dispatcher {
         bundle: &bundle::Bundle,
         source_data: Bytes,
     ) -> Result<(hardy_bpv7::bundle::Bundle, Bytes), hardy_bpv7::editor::Error> {
+        // RFC 9171 §4.2.3-4/-5: report_on_failure MUST NOT be set on any block
+        // of an admin-record or anonymous bundle — the receiver has nowhere
+        // meaningful to report to, and a conformant parser (ours included)
+        // rejects the combination.
+        let report_on_failure =
+            !bundle.bundle.flags.is_admin_record && !bundle.bundle.id.source.is_null();
+
         // Previous Node Block
         let mut editor = hardy_bpv7::editor::Editor::new(&bundle.bundle, &source_data)
             .insert_block(hardy_bpv7::block::Type::PreviousNode)
             .map_err(|(_, e)| e)?
             .with_flags(hardy_bpv7::block::Flags {
-                report_on_failure: true,
+                report_on_failure,
                 ..Default::default()
             })
             .with_data(
@@ -112,7 +119,7 @@ impl Dispatcher {
                 .insert_block(hardy_bpv7::block::Type::HopCount)
                 .map_err(|(_, e)| e)?
                 .with_flags(hardy_bpv7::block::Flags {
-                    report_on_failure: true,
+                    report_on_failure,
                     must_replicate: true,
                     ..Default::default()
                 })
@@ -139,7 +146,7 @@ impl Dispatcher {
                 .insert_block(hardy_bpv7::block::Type::BundleAge)
                 .map_err(|(_, e)| e)?
                 .with_flags(hardy_bpv7::block::Flags {
-                    report_on_failure: true,
+                    report_on_failure,
                     must_replicate: true,
                     ..Default::default()
                 })


### PR DESCRIPTION
The forwarding path set the report_on_failure flag unconditionally on the PreviousNode, HopCount, and BundleAge blocks it adds to a transiting bundle. RFC 9171 sections 4.2.3-4/-5 forbid that flag on any block of a bundle that is an administrative record or has an anonymous source - the receiver has nowhere meaningful to report to - and our own ingress parser enforces exactly that, so a status report forwarded through a second Hardy node was rejected by it as InvalidFlags.

Set the flag only when the bundle's primary block permits reporting.

(ported from e2af3ad0 on refactor/parse, where the regression pipeline test lives)