### PR TITLE
fix(bpa): date the reassembled bundle from its earliest fragment arrival

### DIFF
--- a/bpa/src/dispatcher/reassemble.rs
+++ b/bpa/src/dispatcher/reassemble.rs
@@ -6,7 +6,7 @@ use crate::storage::adu_reassembly::ReassemblyResult;
 
 impl Dispatcher {
     pub async fn reassemble(&self, mut bundle: Bundle) {
-        let (storage_name, data) = match self.store.adu_reassemble(&bundle).await {
+        let (storage_name, data, received_at) = match self.store.adu_reassemble(&bundle).await {
             ReassemblyResult::NotReady => {
                 let status = BundleStatus::AduFragment {
                     source: bundle.bundle.id.source.clone(),
@@ -19,7 +19,11 @@ impl Dispatcher {
                 debug!("Fragment reassembly failed for bundle {}", bundle.bundle.id);
                 return;
             }
-            ReassemblyResult::Done(storage_name, data) => (storage_name, data),
+            ReassemblyResult::Done {
+                storage_name,
+                data,
+                received_at,
+            } => (storage_name, data, received_at),
         };
 
         metrics::counter!("bpa.bundle.reassembled").increment(1);
@@ -28,7 +32,7 @@ impl Dispatcher {
             storage_name: Some(storage_name),
             status: BundleStatus::New,
             read_only: ReadOnlyMetadata {
-                received_at: bundle.metadata.read_only.received_at,
+                received_at,
                 ..Default::default()
             },
             ..Default::default()

--- a/bpa/src/storage/adu_reassembly.rs
+++ b/bpa/src/storage/adu_reassembly.rs
@@ -20,7 +20,16 @@ pub enum ReassemblyResult {
     /// Caller should transition the bundle to `AduFragment` and wait.
     NotReady,
     /// All fragments arrived and the ADU was successfully reassembled.
-    Done(Arc<str>, Bytes),
+    /// `received_at` is the earliest arrival time across the fragment set: the
+    /// ADU has been arriving since its first fragment, and the ingress gate's
+    /// expiry estimate for no-clock sources (creation = received_at − age)
+    /// under-ages the bundle by the whole reassembly window if the reassembled
+    /// bundle carries a later fragment's arrival time.
+    Done {
+        storage_name: Arc<str>,
+        data: Bytes,
+        received_at: OffsetDateTime,
+    },
     /// All fragments arrived but reassembly failed (corrupt/misaligned data).
     /// Fragment data has already been deleted; caller should drop the trigger bundle.
     Failed,
@@ -51,10 +60,12 @@ impl Store {
             metrics::gauge!("bpa.bundle.status", "state" => crate::otel_metrics::status_label(&status)).decrement(1.0);
         }
 
-        // TODO: It would be good to capture the aggregate received at value across all the fragments, and use that as the received_at for the reassembled bundle
-
         match result {
-            Some((storage_name, data)) => ReassemblyResult::Done(storage_name, data),
+            Some((storage_name, data)) => ReassemblyResult::Done {
+                storage_name,
+                data,
+                received_at: fragments.received_at,
+            },
             None => ReassemblyResult::Failed,
         }
     }


### PR DESCRIPTION
poll_fragments already computed the minimum received_at across the fragment set but dropped it; ReassemblyResult::Done now carries it and the dispatcher stamps it on the re-entry metadata, so the ingress expiry check for no-clock sources (creation = received_at − age) is anchored to the first fragment's arrival rather than the trigger fragment's.

(cherry picked from commit a607f17f, docs hunk dropped)