### PR TITLE
refactor(bpv7): use Arc for BPSec parameters so parse results are Send

### DIFF
--- a/bpv7/src/bpsec/parse.rs
+++ b/bpv7/src/bpsec/parse.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::error::HasInvalidField;
-use alloc::rc::Rc;
+use alloc::sync::Arc;
 use core::ops::Range;
 use smallvec::SmallVec;
 
@@ -58,7 +58,7 @@ fn parse_ranges<const D: usize>(
 
 #[derive(Debug)]
 pub struct UnknownOperation {
-    pub parameters: Rc<HashMap<u64, Box<[u8]>>>,
+    pub parameters: Arc<HashMap<u64, Box<[u8]>>>,
     pub results: HashMap<u64, Box<[u8]>>,
 }
 
@@ -87,7 +87,7 @@ impl UnknownOperation {
         for (id, range) in asb.parameters {
             parameters.insert(id, bounded_slice(source_data, range)?.into());
         }
-        let parameters = Rc::from(parameters);
+        let parameters = Arc::from(parameters);
 
         // Unpack results
         let mut operations = HashMap::with_capacity(asb.results.len());

--- a/bpv7/src/bpsec/rfc9173/bcb_aes_gcm.rs
+++ b/bpv7/src/bpsec/rfc9173/bcb_aes_gcm.rs
@@ -1,4 +1,4 @@
-use alloc::rc::Rc;
+use alloc::sync::Arc;
 
 use aes_gcm::{
     KeyInit,
@@ -213,7 +213,7 @@ fn encrypt_inner<C: aes_gcm::aead::Aead>(
 
 #[derive(Debug)]
 pub struct Operation {
-    pub parameters: Rc<Parameters>,
+    pub parameters: Arc<Parameters>,
     pub results: Results,
 }
 
@@ -325,7 +325,7 @@ impl Operation {
 
         Ok((
             Self {
-                parameters: Rc::new(Parameters {
+                parameters: Arc::new(Parameters {
                     iv,
                     variant,
                     key,
@@ -501,7 +501,7 @@ pub fn parse(
     asb: parse::AbstractSyntaxBlock,
     data: &[u8],
 ) -> Result<(eid::Eid, HashMap<u64, bcb::Operation>), Error> {
-    let parameters = Rc::from(
+    let parameters = Arc::from(
         Parameters::from_cbor(asb.parameters, data)
             .map_field_err::<Error>("RFC9173 AES-GCM parameters")?,
     );
@@ -524,7 +524,7 @@ pub fn parse(
 #[cfg(test)]
 mod tests {
     use aes_gcm::KeyInit;
-    use alloc::rc::Rc;
+    use alloc::sync::Arc;
     use core::ops::Range;
 
     use super::*;
@@ -549,7 +549,7 @@ mod tests {
                 let (ct, _) = encrypt_inner(cipher, iv.clone(), aad, plaintext).unwrap();
                 let (ciphertext, tag) = ct.split_at(ct.len() - 16);
                 let op = Operation {
-                    parameters: Rc::new(Parameters {
+                    parameters: Arc::new(Parameters {
                         iv,
                         variant: AesVariant::A256GCM,
                         key: None,

--- a/bpv7/src/bpsec/rfc9173/bib_hmac_sha2.rs
+++ b/bpv7/src/bpsec/rfc9173/bib_hmac_sha2.rs
@@ -1,5 +1,5 @@
 use super::*;
-use alloc::rc::Rc;
+use alloc::sync::Arc;
 use hmac::{KeyInit, Mac};
 
 #[allow(clippy::upper_case_acronyms)]
@@ -244,7 +244,7 @@ fn as_variant(alg: Option<key::KeyAlgorithm>) -> Option<ShaVariant> {
 
 #[derive(Debug)]
 pub struct Operation {
-    pub parameters: Rc<Parameters>,
+    pub parameters: Arc<Parameters>,
     pub results: Results,
 }
 
@@ -337,7 +337,7 @@ impl Operation {
         };
 
         Ok(Self {
-            parameters: Rc::new(Parameters {
+            parameters: Arc::new(Parameters {
                 variant,
                 key,
                 flags: scope_flags,
@@ -448,7 +448,7 @@ pub fn parse(
     asb: parse::AbstractSyntaxBlock,
     data: &[u8],
 ) -> Result<(eid::Eid, HashMap<u64, bib::Operation>), Error> {
-    let parameters = Rc::from(
+    let parameters = Arc::from(
         Parameters::from_cbor(asb.parameters, data)
             .map_field_err::<Error>("RFC9173 HMAC-SHA2 parameters")?,
     );


### PR DESCRIPTION
The BIB/BCB OperationSet parameter maps were reference-counted with Rc, which made every type holding them - the operation sets, and any parse result carrying them - !Send. Callers that parse a bundle and then await (delivery, admin record handling) have to scope the parse into a block so the operation sets drop before the await point.

Swap Rc for alloc::sync::Arc. The clone/equality semantics are unchanged and the maps are immutable after parse, so the only cost is atomic reference counting, paid once per security block.

(ported from refactor/parse, where the streaming ingress holds the parser across awaits and needs this)