### PR TITLE
fix(rib): record adjacent neighbour as next-hop for via chains

### DIFF
--- a/bpa/src/routing/rib.rs
+++ b/bpa/src/routing/rib.rs
@@ -575,6 +575,40 @@ mod tests {
     }
 
     #[test]
+    fn test_via_chain_next_hop_is_adjacent_neighbour() {
+        let rib = make_rib();
+
+        // Two levels of via indirection ending at a directly-connected neighbour:
+        //   ipn:0.50.* -> via ipn:0.40.0 -> via ipn:0.3.0 -> Forward(77)
+        add_route(
+            &rib,
+            "ipn:0.50.*",
+            "chain",
+            Action::Route(RouteAction::Via("ipn:0.40.0".parse().unwrap())),
+            10,
+        );
+        add_route(
+            &rib,
+            "ipn:0.40.*",
+            "chain",
+            Action::Route(RouteAction::Via("ipn:0.3.0".parse().unwrap())),
+            10,
+        );
+        add_local_forward(&rib, ipn_node(3), 77);
+
+        let mut bundle = make_bundle("ipn:0.50.1");
+        let result = rib.find(&mut bundle);
+        assert!(matches!(result, Some(DispatchAction::Forward(77))));
+
+        // The next-hop handed to egress filters must be the adjacent neighbour
+        // (ipn:0.3.0), not the first intermediate gateway (ipn:0.40.0).
+        assert_eq!(
+            bundle.metadata.read_only.next_hop,
+            Some("ipn:0.3.0".parse().unwrap()),
+        );
+    }
+
+    #[test]
     fn test_no_route() {
         let rib = make_rib();
         let mut bundle = make_bundle("ipn:0.50.1");

--- a/bpa/src/routing/table.rs
+++ b/bpa/src/routing/table.rs
@@ -219,13 +219,16 @@ impl RouteTable {
                                 let sub_result = self.find_recurse(via, reflect, trail);
                                 trail.remove(&to);
 
+                                // Carry each peer's resolved next-hop up unchanged: it is the
+                                // adjacent neighbour EID recorded at the Forward base case, which
+                                // is what egress filters need, not this intermediate via.
                                 match sub_result {
-                                    Some(LookupResult::Forward(sub_peer, _)) => {
-                                        sorted_insert(&mut peers, sub_peer, via);
+                                    Some(LookupResult::Forward(sub_peer, sub_next)) => {
+                                        sorted_insert(&mut peers, sub_peer, sub_next);
                                     }
                                     Some(LookupResult::ForwardEcmp(sub_peers)) => {
-                                        for (sub_peer, _) in sub_peers {
-                                            sorted_insert(&mut peers, sub_peer, via);
+                                        for (sub_peer, sub_next) in sub_peers {
+                                            sorted_insert(&mut peers, sub_peer, sub_next);
                                         }
                                     }
                                     Some(other) => return Some(other),


### PR DESCRIPTION
A multi-level Via chain recorded the outermost via EID in metadata.read_only.next_hop: each enclosing level overwrote the deeper resolution with its own via, so egress filters saw an intermediate gateway rather than the neighbour the bundle is handed to. Carry each peer's resolved next-hop up unchanged so the adjacent neighbour EID from the Forward base case survives to the top.

Forwarding (the selected peer) was already correct; only the next_hop metadata was affected.


(cherry picked from commit 480d3bd26716926f3328661dd68258152722f3a9)