### PR TITLE
Refactor/cbor parse tightening

### DIFF
--- a/bpv7/src/block.rs
+++ b/bpv7/src/block.rs
@@ -108,11 +108,7 @@ impl hardy_cbor::decode::FromCbor for Flags {
     type Error = Error;
 
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
-        let (value, shortest, len) =
-            hardy_cbor::decode::parse::<(u64, bool, usize)>(data).map_err(Error::InvalidCBOR)?;
-        if !shortest {
-            return Err(Error::NotCanonical);
-        }
+        let (value, len) = crate::error::parse_canonical::<u64, _>(data, Error::NotCanonical)?;
         Ok((value.into(), true, len))
     }
 }
@@ -181,11 +177,7 @@ impl hardy_cbor::decode::FromCbor for Type {
     type Error = Error;
 
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
-        let (value, shortest, len) =
-            hardy_cbor::decode::parse::<(u64, bool, usize)>(data).map_err(Error::InvalidCBOR)?;
-        if !shortest {
-            return Err(Error::NotCanonical);
-        }
+        let (value, len) = crate::error::parse_canonical::<u64, _>(data, Error::NotCanonical)?;
         Ok((value.into(), true, len))
     }
 }

--- a/bpv7/src/bpsec/error.rs
+++ b/bpv7/src/bpsec/error.rs
@@ -106,6 +106,15 @@ pub enum Error {
     #[error("Unsupported operation")]
     UnsupportedOperation,
 
+    #[error(
+        "BPSec parameter/result range {start}..{end} does not fit in source data of {source_len} bytes"
+    )]
+    SourceOutOfRange {
+        start: usize,
+        end: usize,
+        source_len: usize,
+    },
+
     #[error(transparent)]
     InvalidCBOR(#[from] hardy_cbor::decode::Error),
 

--- a/bpv7/src/bpsec/mod.rs
+++ b/bpv7/src/bpsec/mod.rs
@@ -67,11 +67,7 @@ impl hardy_cbor::decode::FromCbor for Context {
     type Error = Error;
 
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
-        let (value, shortest, len) =
-            hardy_cbor::decode::parse::<(u64, bool, usize)>(data).map_err(Error::InvalidCBOR)?;
-        if !shortest {
-            return Err(Error::NotCanonical);
-        }
+        let (value, len) = crate::error::parse_canonical::<u64, _>(data, Error::NotCanonical)?;
         Ok((
             match value {
                 #[cfg(feature = "rfc9173")]

--- a/bpv7/src/bpsec/parse.rs
+++ b/bpv7/src/bpsec/parse.rs
@@ -62,35 +62,46 @@ pub struct UnknownOperation {
     pub results: HashMap<u64, Box<[u8]>>,
 }
 
+/// Bounds-checked slice into a BPSec-related `source_data` buffer.
+///
+/// Every parameter/result range stored in an [`AbstractSyntaxBlock`]
+/// originally came from parsing `source_data`, so under normal use the
+/// range is in-bounds. The check guards against a caller passing a
+/// partial slice or a mismatched buffer — it converts a release-mode
+/// panic into a clean [`Error::SourceOutOfRange`].
+pub(super) fn bounded_slice(data: &[u8], range: Range<usize>) -> Result<&[u8], Error> {
+    data.get(range.clone()).ok_or(Error::SourceOutOfRange {
+        start: range.start,
+        end: range.end,
+        source_len: data.len(),
+    })
+}
+
 impl UnknownOperation {
     pub fn parse(
         asb: AbstractSyntaxBlock,
         source_data: &[u8],
     ) -> Result<(eid::Eid, HashMap<u64, Self>), Error> {
         let param_count = asb.parameters.len();
-        let parameters = Rc::from(asb.parameters.into_iter().fold(
-            HashMap::with_capacity(param_count),
-            |mut map, (id, range)| {
-                map.insert(id, source_data[range].into());
-                map
-            },
-        ));
+        let mut parameters = HashMap::with_capacity(param_count);
+        for (id, range) in asb.parameters {
+            parameters.insert(id, bounded_slice(source_data, range)?.into());
+        }
+        let parameters = Rc::from(parameters);
 
         // Unpack results
         let mut operations = HashMap::with_capacity(asb.results.len());
         for (target, results) in asb.results {
             let result_count = results.len();
+            let mut result_map = HashMap::with_capacity(result_count);
+            for (id, range) in results {
+                result_map.insert(id, bounded_slice(source_data, range)?.into());
+            }
             operations.insert(
                 target,
                 Self {
                     parameters: parameters.clone(),
-                    results: results.into_iter().fold(
-                        HashMap::with_capacity(result_count),
-                        |mut map, (id, range)| {
-                            map.insert(id, source_data[range].into());
-                            map
-                        },
-                    ),
+                    results: result_map,
                 },
             );
         }
@@ -240,7 +251,7 @@ impl hardy_cbor::decode::FromCbor for AbstractSyntaxBlock {
 /// indefinite-length byte strings are rejected with `NotCanonical`.
 #[cfg(feature = "rfc9173")]
 pub fn decode_box(range: Range<usize>, data: &[u8]) -> Result<Box<[u8]>, Error> {
-    let data = &data[range.start..range.end];
+    let data = bounded_slice(data, range)?;
     hardy_cbor::decode::parse_value(data, |v, s, tags| match v {
         hardy_cbor::decode::Value::Bytes(r) if s && tags.is_empty() => Ok(data[r].into()),
         hardy_cbor::decode::Value::Bytes(_) | hardy_cbor::decode::Value::ByteStream(_) => {

--- a/bpv7/src/bpsec/rfc9173/bcb_aes_gcm.rs
+++ b/bpv7/src/bpsec/rfc9173/bcb_aes_gcm.rs
@@ -63,9 +63,17 @@ impl Parameters {
         for (id, range) in parameters {
             match id {
                 1 => iv = Some(parse::decode_box(range, data)?),
-                2 => variant = Some(hardy_cbor::decode::parse(&data[range])?),
+                2 => {
+                    variant = Some(hardy_cbor::decode::parse(parse::bounded_slice(
+                        data, range,
+                    )?)?)
+                }
                 3 => key = Some(parse::decode_box(range, data)?),
-                4 => flags = Some(hardy_cbor::decode::parse(&data[range])?),
+                4 => {
+                    flags = Some(hardy_cbor::decode::parse(parse::bounded_slice(
+                        data, range,
+                    )?)?)
+                }
                 _ => return Err(Error::InvalidContextParameter(id)),
             }
         }

--- a/bpv7/src/bpsec/rfc9173/bcb_aes_gcm.rs
+++ b/bpv7/src/bpsec/rfc9173/bcb_aes_gcm.rs
@@ -33,11 +33,7 @@ impl hardy_cbor::decode::FromCbor for AesVariant {
     type Error = Error;
 
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
-        let (value, shortest, len) =
-            hardy_cbor::decode::parse::<(u64, bool, usize)>(data).map_err(Error::InvalidCBOR)?;
-        if !shortest {
-            return Err(Error::NotCanonical);
-        }
+        let (value, len) = crate::error::parse_canonical::<u64, _>(data, Error::NotCanonical)?;
         Ok((
             match value {
                 1 => Self::A128GCM,

--- a/bpv7/src/bpsec/rfc9173/bib_hmac_sha2.rs
+++ b/bpv7/src/bpsec/rfc9173/bib_hmac_sha2.rs
@@ -56,9 +56,11 @@ impl Parameters {
         let mut result = Self::default();
         for (id, range) in parameters {
             match id {
-                1 => result.variant = hardy_cbor::decode::parse(&data[range])?,
+                1 => {
+                    result.variant = hardy_cbor::decode::parse(parse::bounded_slice(data, range)?)?
+                }
                 2 => result.key = Some(parse::decode_box(range, data)?),
-                3 => result.flags = hardy_cbor::decode::parse(&data[range])?,
+                3 => result.flags = hardy_cbor::decode::parse(parse::bounded_slice(data, range)?)?,
                 _ => return Err(Error::InvalidContextParameter(id)),
             }
         }

--- a/bpv7/src/bpsec/rfc9173/bib_hmac_sha2.rs
+++ b/bpv7/src/bpsec/rfc9173/bib_hmac_sha2.rs
@@ -30,11 +30,7 @@ impl hardy_cbor::decode::FromCbor for ShaVariant {
     type Error = Error;
 
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
-        let (value, shortest, len) =
-            hardy_cbor::decode::parse::<(u64, bool, usize)>(data).map_err(Error::InvalidCBOR)?;
-        if !shortest {
-            return Err(Error::NotCanonical);
-        }
+        let (value, len) = crate::error::parse_canonical::<u64, _>(data, Error::NotCanonical)?;
         Ok((
             match value {
                 5 => Self::HMAC_256_256,

--- a/bpv7/src/bpsec/rfc9173/mod.rs
+++ b/bpv7/src/bpsec/rfc9173/mod.rs
@@ -53,11 +53,7 @@ impl hardy_cbor::decode::FromCbor for ScopeFlags {
     type Error = Error;
 
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
-        let (value, shortest, len) =
-            hardy_cbor::decode::parse::<(u64, bool, usize)>(data).map_err(Error::InvalidCBOR)?;
-        if !shortest {
-            return Err(Error::NotCanonical);
-        }
+        let (value, len) = crate::error::parse_canonical::<u64, _>(data, Error::NotCanonical)?;
         let mut flags = Self {
             include_primary_block: false,
             include_target_header: false,

--- a/bpv7/src/bundle_age.rs
+++ b/bpv7/src/bundle_age.rs
@@ -65,11 +65,7 @@ impl hardy_cbor::decode::FromCbor for BundleAge {
     ///   * Returns `shortest = true` on success (no encoder discretion
     ///     left to surface), so callers can drop the flag check.
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
-        let (v, shortest, len) =
-            hardy_cbor::decode::parse::<(u64, bool, usize)>(data).map_err(Error::InvalidCBOR)?;
-        if !shortest {
-            return Err(Error::NotCanonical);
-        }
+        let (v, len) = crate::error::parse_canonical::<u64, _>(data, Error::NotCanonical)?;
         Ok((Self(v), true, len))
     }
 }

--- a/bpv7/src/crc.rs
+++ b/bpv7/src/crc.rs
@@ -85,11 +85,8 @@ impl hardy_cbor::decode::FromCbor for CrcType {
     type Error = crate::Error;
 
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
-        let (value, shortest, len) = hardy_cbor::decode::parse::<(u64, bool, usize)>(data)
-            .map_err(crate::Error::InvalidCBOR)?;
-        if !shortest {
-            return Err(crate::Error::NotCanonical);
-        }
+        let (value, len) =
+            crate::error::parse_canonical::<u64, _>(data, crate::Error::NotCanonical)?;
         Ok((value.into(), true, len))
     }
 }

--- a/bpv7/src/dtn_time.rs
+++ b/bpv7/src/dtn_time.rs
@@ -63,11 +63,7 @@ impl hardy_cbor::decode::FromCbor for DtnTime {
     /// non-shortest encoding is rejected with `NotCanonical`, as are unexpected
     /// tags. Returns `shortest = true` on success.
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
-        let (millisecs, shortest, len) =
-            hardy_cbor::decode::parse::<(u64, bool, usize)>(data).map_err(Error::InvalidCBOR)?;
-        if !shortest {
-            return Err(Error::NotCanonical);
-        }
+        let (millisecs, len) = crate::error::parse_canonical::<u64, _>(data, Error::NotCanonical)?;
         Ok((Self(millisecs), true, len))
     }
 }

--- a/bpv7/src/editor.rs
+++ b/bpv7/src/editor.rs
@@ -810,20 +810,20 @@ impl<'a> Editor<'a> {
         bib_block: u64,
     ) -> Result<Self, (Self, Error)> {
         if let Some((_, Some(bib_payload))) = self.block(bib_block) {
-            let mut opset = match hardy_cbor::decode::parse::<bpsec::bib::OperationSet>(bib_payload)
-            {
-                Ok(opset) => opset,
-                Err(e) => {
-                    return Err((
-                        self,
-                        error::Error::InvalidField {
-                            field: "BIB Abstract Syntax Block",
-                            source: e.into(),
-                        }
-                        .into(),
-                    ));
-                }
-            };
+            let mut opset =
+                match hardy_cbor::decode::parse_exact::<bpsec::bib::OperationSet>(bib_payload) {
+                    Ok(opset) => opset,
+                    Err(e) => {
+                        return Err((
+                            self,
+                            error::Error::InvalidField {
+                                field: "BIB Abstract Syntax Block",
+                                source: e.into(),
+                            }
+                            .into(),
+                        ));
+                    }
+                };
 
             // Remove the target from the BIB
             if opset.operations.remove(&target_block).is_some() {
@@ -857,20 +857,20 @@ impl<'a> Editor<'a> {
         bcb_block: u64,
     ) -> Result<Self, (Self, Error)> {
         if let Some((_, Some(bcb_payload))) = self.block(bcb_block) {
-            let mut opset = match hardy_cbor::decode::parse::<bpsec::bcb::OperationSet>(bcb_payload)
-            {
-                Ok(opset) => opset,
-                Err(e) => {
-                    return Err((
-                        self,
-                        error::Error::InvalidField {
-                            field: "BCB Abstract Syntax Block",
-                            source: e.into(),
-                        }
-                        .into(),
-                    ));
-                }
-            };
+            let mut opset =
+                match hardy_cbor::decode::parse_exact::<bpsec::bcb::OperationSet>(bcb_payload) {
+                    Ok(opset) => opset,
+                    Err(e) => {
+                        return Err((
+                            self,
+                            error::Error::InvalidField {
+                                field: "BCB Abstract Syntax Block",
+                                source: e.into(),
+                            }
+                            .into(),
+                        ));
+                    }
+                };
 
             // Remove the target from the BCB
             if opset.operations.remove(&target_block).is_some() {

--- a/bpv7/src/error.rs
+++ b/bpv7/src/error.rs
@@ -161,3 +161,25 @@ where
         Ok((t, true)) => Ok(t),
     }
 }
+
+/// Decode a `T` from the start of `data` in its canonical (shortest) form,
+/// returning the value and the bytes consumed. A non-canonical encoding —
+/// `T::from_cbor` reporting `shortest == false` — is rejected with
+/// `not_canonical`. The whole-slice counterpart of [`require_canonical`] (which
+/// decodes an array element), shared by leaf `FromCbor` impls whose wire form is
+/// a single bare value: block/CRC type codes, lifetimes, DTN times, BPSec
+/// context and variant ids. Generic over the caller's error so each keeps its
+/// own `NotCanonical`.
+pub(crate) fn parse_canonical<T, E>(data: &[u8], not_canonical: E) -> Result<(T, usize), E>
+where
+    T: hardy_cbor::decode::FromCbor,
+    T::Error: From<hardy_cbor::decode::Error>,
+    E: From<T::Error>,
+{
+    let (value, shortest, len) = hardy_cbor::decode::parse::<(T, bool, usize)>(data)?;
+    if shortest {
+        Ok((value, len))
+    } else {
+        Err(not_canonical)
+    }
+}

--- a/bpv7/src/lifetime.rs
+++ b/bpv7/src/lifetime.rs
@@ -66,11 +66,7 @@ impl hardy_cbor::decode::FromCbor for Lifetime {
     ///   * Returns `shortest = true` on success (no encoder discretion
     ///     left to surface), so callers can drop the flag check.
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error> {
-        let (v, shortest, len) =
-            hardy_cbor::decode::parse::<(u64, bool, usize)>(data).map_err(Error::InvalidCBOR)?;
-        if !shortest {
-            return Err(Error::NotCanonical);
-        }
+        let (v, len) = crate::error::parse_canonical::<u64, _>(data, Error::NotCanonical)?;
         Ok((Self(v), true, len))
     }
 }

--- a/bpv7/tools/src/cmd/inspect.rs
+++ b/bpv7/tools/src/cmd/inspect.rs
@@ -377,7 +377,7 @@ fn dump_unknown(mut data: &[u8], output: &io::Output) -> anyhow::Result<()> {
 }
 
 fn dump_bcb(data: &[u8], output: &io::Output) -> anyhow::Result<()> {
-    let ops = hardy_cbor::decode::parse::<bpsec::bcb::OperationSet>(data)?;
+    let ops = hardy_cbor::decode::parse_exact::<bpsec::bcb::OperationSet>(data)?;
     output.append_str(format!(
         "### BCB Data\n\nSecurity Source: {}\n\n",
         ops.source()
@@ -453,7 +453,7 @@ fn dump_bcb(data: &[u8], output: &io::Output) -> anyhow::Result<()> {
 }
 
 fn dump_bib(data: &[u8], output: &io::Output) -> anyhow::Result<()> {
-    let ops = hardy_cbor::decode::parse::<bpsec::bib::OperationSet>(data)?;
+    let ops = hardy_cbor::decode::parse_exact::<bpsec::bib::OperationSet>(data)?;
     output.append_str(format!(
         "### BIB Data\n\nSecurity Source: {}\n\n",
         ops.source()

--- a/cbor/src/decode/mod.rs
+++ b/cbor/src/decode/mod.rs
@@ -195,6 +195,19 @@ pub trait FromCbor: Sized {
     /// - The decoded value.
     /// - A boolean indicating if the value was encoded in its shortest, canonical form.
     /// - The number of bytes consumed from the slice.
+    ///
+    /// Decoding reads a single item from the **front** of `data` and stops; the
+    /// slice is not required to contain exactly one item, and the returned length
+    /// is how many bytes that item occupied. Anything after it is left untouched.
+    /// This is what makes decoders composable — an enclosing array, map or
+    /// sequence decodes a field, then advances by the returned length to the next.
+    ///
+    /// A consequence is that `from_cbor` is **not**, on its own, a guard against
+    /// trailing data: only implementations that consume to the end of the slice
+    /// (those built on [`parse_sequence`]) reject it; implementations built on a
+    /// single value, array or map silently ignore any bytes past their item. When
+    /// `data` is a standalone slice that must hold exactly one item, compare the
+    /// returned length against `data.len()` yourself, or use [`parse_exact`].
     fn from_cbor(data: &[u8]) -> Result<(Self, bool, usize), Self::Error>;
 }
 
@@ -593,6 +606,10 @@ where
 /// This function is a shorthand for `T::from_cbor(data).map(|v| v.0)`. It
 /// decodes the value and discards the `shortest` and `len` information,
 /// returning only the decoded object.
+///
+/// Because `len` is discarded, any bytes after the first item are ignored. Use
+/// [`parse_exact`] instead when `data` must hold exactly one item, so that
+/// trailing bytes can't be smuggled past the decoder.
 #[inline]
 pub fn parse<T>(data: &[u8]) -> Result<T, T::Error>
 where
@@ -600,4 +617,25 @@ where
     T::Error: From<self::Error>,
 {
     T::from_cbor(data).map(|v| v.0)
+}
+
+/// Decode a single value of type `T`, requiring it to consume the **whole**
+/// slice: any trailing bytes after the item are rejected as
+/// [`Error::AdditionalItems`].
+///
+/// Use this — rather than [`parse`], which ignores trailing data — when `data`
+/// must hold exactly one item (e.g. the body of a bundle block), so that extra
+/// bytes can't be smuggled past the decoder.
+#[inline]
+pub fn parse_exact<T>(data: &[u8]) -> Result<T, T::Error>
+where
+    T: FromCbor,
+    T::Error: From<self::Error>,
+{
+    let (value, _, len) = T::from_cbor(data)?;
+    if len == data.len() {
+        Ok(value)
+    } else {
+        Err(self::Error::AdditionalItems.into())
+    }
 }

--- a/tools/src/ping/service.rs
+++ b/tools/src/ping/service.rs
@@ -418,7 +418,7 @@ impl Service {
     fn handle_status_report(&self, payload_data: &[u8], report_source: &Eid) {
         use hardy_bpv7::status_report::ReasonCode;
 
-        let report = match hardy_cbor::decode::parse::<AdministrativeRecord>(payload_data) {
+        let report = match hardy_cbor::decode::parse_exact::<AdministrativeRecord>(payload_data) {
             Ok(AdministrativeRecord::BundleStatusReport(r)) => r,
             _ => return,
         };


### PR DESCRIPTION
Three related hardenings of bpv7's CBOR decode surface, extracted from the v0.3.0 refactor stack so they can be reviewed on their own:

- **`feat(cbor): add parse_exact`** — a decode helper for "exactly one item, no trailing bytes" that rejects anything after the decoded value.
- **`refactor(bpv7): route one-shot decodes through parse_canonical/parse_exact`** — adds a `parse_canonical` helper for leaf `FromCbor` impls whose wire form is a single bare value (block/CRC type codes, flags, lifetimes, DTN times, bundle age, BPSec context/scope/variant ids), decoding in canonical shortest form and rejecting non-shortest encodings, and adopts it across those impls in place of the hand-rolled decode-and-check patterns. Mechanical; no acceptance change where a check already existed.
- **`fix(bpv7): bounds-check wire-derived BPSec parameter/result ranges`** — the parameter/result ranges recorded in an `AbstractSyntaxBlock` were sliced into `source_data` unchecked, so a partial or mismatched buffer is a release-mode panic; every such slice now goes through `bounded_slice`, returning a clean `Error::SourceOutOfRange` instead. Defence in depth on main; the incoming streaming ingress makes partial buffers genuinely reachable.