### PR TITLE
perf(sqlite-storage): run WAL connections at synchronous=NORMAL

### DIFF
--- a/sqlite-storage/CHANGELOG.md
+++ b/sqlite-storage/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+- Run all connections at `PRAGMA synchronous = NORMAL` (previously the SQLite default, `FULL`). Under WAL this stops fsyncing the log on every commit — a significant win on fsync-expensive storage, since the metadata store commits on each bundle status transition. Consistency across a crash is unaffected; at most the un-checkpointed tail of commits is lost, which restart recovery already tolerates (bundle data storage is ground truth, and data whose metadata is missing is re-ingested at startup).
+
 ## [0.6.0]
 
 ### Changed

--- a/sqlite-storage/src/storage.rs
+++ b/sqlite-storage/src/storage.rs
@@ -49,8 +49,14 @@ impl ConnectionPool {
 
         // journal_mode cannot be changed inside a transaction (migrations run
         // in one), so WAL is applied per connection here, not in the schema.
+        // synchronous is a per-connection pragma; NORMAL under WAL fsyncs at
+        // checkpoint rather than per commit. A crash loses at most the
+        // un-checkpointed tail of commits, never consistency — and bundle data
+        // storage is ground truth: restart replay re-ingests anything whose
+        // metadata the tail forgot.
         conn.execute_batch(
             "PRAGMA journal_mode = WAL;
+            PRAGMA synchronous = NORMAL;
             PRAGMA foreign_keys = ON;
             PRAGMA optimize = 0x10002;",
         )
@@ -144,9 +150,13 @@ impl Storage {
 
         // journal_mode cannot be changed inside a transaction (migrations run
         // in one), so WAL is applied here, before migrate(), not in the schema.
+        // synchronous is a per-connection pragma; NORMAL under WAL fsyncs at
+        // checkpoint rather than per commit (see new_connection for the
+        // durability rationale).
         connection
             .execute_batch(
                 "PRAGMA journal_mode = WAL;
+                PRAGMA synchronous = NORMAL;
                 PRAGMA foreign_keys = ON;
                 PRAGMA optimize = 0x10002;",
             )


### PR DESCRIPTION
synchronous is a per-connection pragma (unlike the persistent WAL journal mode), so it is set in the same per-connection batch at both connection sites: the pool's new_connection and the initial open.

At the SQLite default of FULL, every commit fsyncs the WAL, and the metadata store commits on each bundle status transition — on fsync-expensive storage (network-attached disks in particular) those per-commit syncs dominate the per-bundle forwarding path. NORMAL fsyncs at checkpoint instead: a crash preserves consistency and loses at most the un-checkpointed tail of commits, which restart recovery already tolerates — bundle data storage is ground truth, and data whose metadata is missing is re-ingested at startup.