### PR TITLE
perf(bpa): avoid heap allocation in CBOR precheck error path

### DIFF
--- a/bpa/src/cbor.rs
+++ b/bpa/src/cbor.rs
@@ -1,26 +1,38 @@
 //! Fast CBOR pre-checks before full bundle parsing.
 
-use hardy_bpv7::Error as BpvError;
-use hardy_cbor::decode::Error as CborError;
-
 use crate::Bytes;
+
+/// Rejection reason from the CBOR precheck.
+///
+/// Uses `&'static str` to avoid heap allocation on the error path — under
+/// adversarial traffic every malformed packet would otherwise allocate.
+#[derive(Debug)]
+pub(crate) enum PrecheckError {
+    Empty,
+    PossibleBpv6,
+    NotCborArray,
+}
+
+impl core::fmt::Display for PrecheckError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Empty => f.write_str("empty payload"),
+            Self::PossibleBpv6 => f.write_str("possible BPv6 bundle"),
+            Self::NotCborArray => f.write_str("not a CBOR array"),
+        }
+    }
+}
 
 /// Reject obviously malformed data before attempting a full parse.
 ///
 /// Checks the first byte to catch empty payloads, BPv6 bundles, and
 /// data that cannot be a CBOR array (the required outer structure of a BPv7 bundle).
 #[inline(always)]
-pub(crate) fn precheck(data: &Bytes) -> Result<(), BpvError> {
+pub(crate) fn precheck(data: &Bytes) -> Result<(), PrecheckError> {
     match data.first() {
-        None => Err(BpvError::InvalidCBOR(CborError::NeedMoreData(1))),
-        Some(0x06) => Err(BpvError::InvalidCBOR(CborError::IncorrectType(
-            "BPv7 bundle".to_string(),
-            "Possible BPv6 bundle".to_string(),
-        ))),
+        None => Err(PrecheckError::Empty),
+        Some(0x06) => Err(PrecheckError::PossibleBpv6),
         Some(0x80..=0x9F) => Ok(()),
-        Some(_) => Err(BpvError::InvalidCBOR(CborError::IncorrectType(
-            "BPv7 bundle".to_string(),
-            "Invalid CBOR".to_string(),
-        ))),
+        Some(_) => Err(PrecheckError::NotCborArray),
     }
 }


### PR DESCRIPTION
Replace BpvError/CborError (which allocate String per error) with a dedicated PrecheckError enum using &'static str via Display. Under adversarial traffic, every malformed packet no longer triggers a heap allocation.