### PR TITLE
perf(bpa): remove unnecessary Arc clone from key_provider closure

### DIFF
--- a/bpa/src/dispatcher/mod.rs
+++ b/bpa/src/dispatcher/mod.rs
@@ -183,10 +183,9 @@ impl Dispatcher {
 
     fn key_provider(
         &self,
-    ) -> impl Fn(&hardy_bpv7::bundle::Bundle, &[u8]) -> Box<dyn hardy_bpv7::bpsec::key::KeySource> + Clone
+    ) -> impl Fn(&hardy_bpv7::bundle::Bundle, &[u8]) -> Box<dyn hardy_bpv7::bpsec::key::KeySource> + '_
     {
-        let key_provider = self.key_provider.clone();
-        move |bundle, data| key_provider.key_source(bundle, data)
+        |bundle, data| self.key_provider.key_source(bundle, data)
     }
 
     fn key_source(

--- a/bpa/src/filter/chain.rs
+++ b/bpa/src/filter/chain.rs
@@ -289,7 +289,7 @@ impl FilterChain {
         key_provider: F,
     ) -> Result<ExecResult, crate::Error>
     where
-        F: Fn(&Bpv7Bundle, &[u8]) -> Box<dyn KeySource> + Clone + Send,
+        F: Fn(&Bpv7Bundle, &[u8]) -> Box<dyn KeySource>,
     {
         let mut mutation = Mutation::default();
 

--- a/bpa/src/filter/engine.rs
+++ b/bpa/src/filter/engine.rs
@@ -125,7 +125,7 @@ impl FilterEngine {
         key_provider: F,
     ) -> Result<ExecResult, crate::Error>
     where
-        F: Fn(&Bpv7Bundle, &[u8]) -> Box<dyn KeySource> + Clone + Send,
+        F: Fn(&Bpv7Bundle, &[u8]) -> Box<dyn KeySource>,
     {
         let hook_label = hook.label();
         let filters = self.filters.load();


### PR DESCRIPTION
The filter engine's exec() method required Clone + Send on the key_provider closure but never actually cloned it. Remove those bounds and return a borrowing closure from Dispatcher::key_provider(), eliminating one Arc::clone (atomic refcount bump) per filter invocation on the hot path.