### PR TITLE
perf(bpa): use SmallVec in filter chain to avoid per-bundle heap allo…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "metrics",
  "rand 0.10.2",
  "serde",
+ "smallvec",
  "thiserror",
  "time",
  "tokio",

--- a/bpa/Cargo.toml
+++ b/bpa/Cargo.toml
@@ -53,6 +53,7 @@ foldhash = { version = "0.2", default-features = false }
 lru = { version = "0.18", default-features = false }
 thiserror = { version = "2", default-features = false }
 arc-swap = "1"
+smallvec = "1"
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 serde = { version = "1", default-features = false, features = ["derive","rc","alloc"], optional = true }
 base64 = { version = "0.22", default-features = false, features = ["alloc"], optional = true }

--- a/bpa/src/filter/chain.rs
+++ b/bpa/src/filter/chain.rs
@@ -4,6 +4,7 @@ use hardy_async::TaskPool;
 use hardy_bpv7::bpsec::key::KeySource;
 use hardy_bpv7::bundle::{Bundle as Bpv7Bundle, CheckedBundle};
 use hardy_bpv7::status_report::ReasonCode;
+use smallvec::SmallVec;
 use trace_err::*;
 use tracing::debug;
 
@@ -204,7 +205,7 @@ impl Level {
         // Multiple readers: spawn in parallel
         let shared = Arc::new((bundle, data));
 
-        let mut handles = Vec::new();
+        let mut handles = SmallVec::<[_; 4]>::new();
         for filter in &self.readers {
             let shared = shared.clone();
             let filter = filter.clone();
@@ -214,7 +215,7 @@ impl Level {
             }));
         }
 
-        let mut results = Vec::new();
+        let mut results = SmallVec::<[_; 4]>::new();
         for handle in handles {
             results.push(handle.await.trace_expect("filter spawn failed!")?);
         }


### PR DESCRIPTION
…cation

Replace Vec with SmallVec<[_; 4]> for the handles and results collections in Level::run_readers(). Most filter levels have ≤4 readers, so the common case stays entirely on the stack.