### PR TITLE
perf(bpa): use SmallVec in route table lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "metrics",
  "rand 0.10.2",
  "serde",
+ "smallvec",
  "thiserror",
  "time",
  "tokio",

--- a/bpa/Cargo.toml
+++ b/bpa/Cargo.toml
@@ -53,6 +53,7 @@ foldhash = { version = "0.2", default-features = false }
 lru = { version = "0.18", default-features = false }
 thiserror = { version = "2", default-features = false }
 arc-swap = "1"
+smallvec = "1"
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 serde = { version = "1", default-features = false, features = ["derive","rc","alloc"], optional = true }
 base64 = { version = "0.22", default-features = false, features = ["alloc"], optional = true }

--- a/bpa/src/routing/rib.rs
+++ b/bpa/src/routing/rib.rs
@@ -13,6 +13,7 @@ use hardy_bpv7::{
     status_report::ReasonCode,
 };
 use hardy_eid_patterns::EidPattern;
+use smallvec::SmallVec;
 use tracing::{debug, info, trace};
 
 #[cfg(feature = "instrument")]
@@ -137,18 +138,29 @@ impl Rib {
     pub fn find(&self, bundle: &mut Bundle) -> Option<DispatchAction> {
         let table = self.snapshot.load();
 
-        let result = table.find_recurse(&bundle.bundle.destination, true, &mut HashSet::new())?;
+        // Perform lookup. The SmallVec inside ForwardEcmp has a Drop impl
+        // that extends the borrow scope, so we extract the dispatch-relevant
+        // data (peer, next_hop clone) before the LookupResult is dropped.
+        let destination = bundle.bundle.destination.clone();
+        let result = table.find_recurse(&destination, true, &mut HashSet::new())?;
 
-        let previous;
-        let result = if matches!(result, LookupResult::Reflect) {
-            previous = bundle
+        if matches!(result, LookupResult::Reflect) {
+            drop(result);
+            let previous = bundle
                 .previous_node()
                 .unwrap_or_else(|| bundle.bundle.id.source.clone());
-            table.find_recurse(&previous, false, &mut HashSet::new())?
-        } else {
-            result
-        };
+            let result = table.find_recurse(&previous, false, &mut HashSet::new())?;
+            return self.dispatch_from_lookup(result, bundle);
+        }
 
+        self.dispatch_from_lookup(result, bundle)
+    }
+
+    fn dispatch_from_lookup(
+        &self,
+        result: LookupResult<'_>,
+        bundle: &mut Bundle,
+    ) -> Option<DispatchAction> {
         match result {
             LookupResult::AdminEndpoint => Some(DispatchAction::AdminEndpoint),
             LookupResult::Deliver(service) => Some(DispatchAction::Deliver(service)),
@@ -174,7 +186,7 @@ impl Rib {
 
     fn select_peer(
         &self,
-        mut peers: Vec<(u32, &Eid)>,
+        mut peers: SmallVec<[(u32, &Eid); 4]>,
         bundle: &Bpv7Bundle,
         metadata: &mut BundleMetadata,
     ) -> Option<DispatchAction> {

--- a/bpa/src/routing/table.rs
+++ b/bpa/src/routing/table.rs
@@ -2,6 +2,7 @@ use core::cmp::Ordering;
 
 use hardy_bpv7::{eid::Eid, status_report::ReasonCode};
 use hardy_eid_patterns::EidPattern;
+use smallvec::SmallVec;
 use tracing::trace;
 
 #[cfg(feature = "instrument")]
@@ -38,7 +39,7 @@ pub(super) enum LookupResult<'a> {
     AdminEndpoint,
     Deliver(Arc<Service>),
     Forward(u32, &'a Eid),
-    ForwardEcmp(Vec<(u32, &'a Eid)>),
+    ForwardEcmp(SmallVec<[(u32, &'a Eid); 4]>),
     Drop(Option<ReasonCode>),
     Reflect,
 }
@@ -194,7 +195,7 @@ impl RouteTable {
     ) -> Option<LookupResult<'a>> {
         trace!("Looking for route for {to}");
 
-        let mut peers: Vec<(u32, &'a Eid)> = Vec::new();
+        let mut peers: SmallVec<[(u32, &'a Eid); 4]> = SmallVec::new();
         for entries in self.routes.values() {
             for (pattern, actions) in entries {
                 if pattern.matches(to) {
@@ -286,7 +287,7 @@ impl RouteTable {
     }
 }
 
-fn sorted_insert<'a>(peers: &mut Vec<(u32, &'a Eid)>, peer: u32, next_hop: &'a Eid) {
+fn sorted_insert<'a>(peers: &mut SmallVec<[(u32, &'a Eid); 4]>, peer: u32, next_hop: &'a Eid) {
     if let Err(idx) = peers.binary_search_by_key(&peer, |(p, _)| *p) {
         peers.insert(idx, (peer, next_hop));
     }


### PR DESCRIPTION
Replace `Vec<(u32, &Eid)>` with `SmallVec<[(u32, &Eid); 4]>` in `find_recurse()` and `select_peer()`.

Most routes resolve to 1–4 ECMP peers, so the common case stays entirely on the stack — no heap allocation per bundle dispatch.

**Note:** `SmallVec`'s `Drop` impl extends borrow scopes beyond what `Vec` requires. To satisfy the borrow checker, `Rib::find()` is restructured into `find()` + `dispatch_from_lookup()` with a destination clone to break the `&bundle` ↔ `LookupResult<'_>` lifetime cycle. The clone is a single `Eid` (typically a few bytes for IPN) and happens once per dispatch — far cheaper than the heap allocation it replaces.

**Changes:**
- `bpa/src/routing/table.rs`: `SmallVec<4>` for peers vec + `sorted_insert`
- `bpa/src/routing/rib.rs`: restructured `find()`, updated `select_peer()` signature

**Testing:**
- `cargo test -p hardy-bpa --all-features` — 112 tests pass
- `cargo clippy -p hardy-bpa --all-features -- -D warnings` clean