### PR TITLE
bench(cbor): add criterion benchmark for Encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,32 @@ dependencies = [
 
 [[package]]
 name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
@@ -1138,7 +1164,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
+ "criterion-plot 0.8.2",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -1150,6 +1176,16 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1837,7 +1873,7 @@ dependencies = [
  "arc-swap",
  "base64 0.23.0",
  "bytes",
- "criterion",
+ "criterion 0.8.2",
  "flume",
  "foldhash 0.2.0",
  "futures",
@@ -1969,6 +2005,7 @@ dependencies = [
 name = "hardy-cbor"
 version = "2.0.0"
 dependencies = [
+ "criterion 0.5.1",
  "half",
  "hex-literal",
  "num-traits",
@@ -2346,6 +2383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,10 +2732,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"

--- a/cbor/Cargo.toml
+++ b/cbor/Cargo.toml
@@ -23,3 +23,8 @@ smallvec = "1"
 
 [dev-dependencies]
 hex-literal = "1"
+criterion = "0.5"
+
+[[bench]]
+name = "encode_bench"
+harness = false

--- a/cbor/benches/encode_bench.rs
+++ b/cbor/benches/encode_bench.rs
@@ -1,0 +1,201 @@
+//! Criterion benchmarks for the CBOR encoder.
+//!
+//! Measures emit_uint_minor (the highest-frequency encoder function) and
+//! full bundle-like encoding workloads.
+
+use criterion::*;
+use hardy_cbor::encode::{self, Encoder};
+
+/// Benchmark encoding a single u64 value across different magnitude ranges.
+fn bench_emit_uint(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode/uint");
+
+    // Tiny value (inline, 1 byte total)
+    group.bench_function("u8_inline", |b| {
+        b.iter(|| {
+            let mut e = Encoder::new();
+            e.emit(black_box(&23u64));
+            black_box(e.build());
+        })
+    });
+
+    // 1-byte value (2 bytes total: marker + 1)
+    group.bench_function("u8_extended", |b| {
+        b.iter(|| {
+            let mut e = Encoder::new();
+            e.emit(black_box(&200u64));
+            black_box(e.build());
+        })
+    });
+
+    // 2-byte value (3 bytes total: marker + 2)
+    group.bench_function("u16", |b| {
+        b.iter(|| {
+            let mut e = Encoder::new();
+            e.emit(black_box(&1000u64));
+            black_box(e.build());
+        })
+    });
+
+    // 4-byte value (5 bytes total: marker + 4)
+    group.bench_function("u32", |b| {
+        b.iter(|| {
+            let mut e = Encoder::new();
+            e.emit(black_box(&100_000u64));
+            black_box(e.build());
+        })
+    });
+
+    // 8-byte value (9 bytes total: marker + 8)
+    group.bench_function("u64", |b| {
+        b.iter(|| {
+            let mut e = Encoder::new();
+            e.emit(black_box(&(u64::MAX - 1)));
+            black_box(e.build());
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmark encoding a sequence of mixed integers (simulates encoding
+/// a bundle's primary block fields).
+fn bench_emit_mixed_integers(c: &mut Criterion) {
+    c.bench_function("encode/mixed_integers_10", |b| {
+        b.iter(|| {
+            let mut e = Encoder::new();
+            // Simulate primary block: version, flags, crc, dest, source, etc.
+            e.emit(black_box(&7u64)); // version
+            e.emit(black_box(&0u64)); // flags
+            e.emit(black_box(&1u64)); // crc type
+            e.emit(black_box(&2u64)); // dest scheme
+            e.emit(black_box(&1u64)); // dest allocator
+            e.emit(black_box(&42u64)); // dest node
+            e.emit(black_box(&7u64)); // dest service
+            e.emit(black_box(&1000u64)); // creation time (ms)
+            e.emit(black_box(&3600000u64)); // lifetime (ms)
+            e.emit(black_box(&0u64)); // sequence
+            black_box(e.build());
+        })
+    });
+}
+
+/// Benchmark encoding a CBOR array with nested integers (bundle structure).
+fn bench_emit_array(c: &mut Criterion) {
+    c.bench_function("encode/array_10_elements", |b| {
+        b.iter(|| {
+            let mut e = Encoder::new();
+            e.emit_array(Some(10), |a| {
+                a.emit(black_box(&7u64));
+                a.emit(black_box(&0u64));
+                a.emit(black_box(&1u64));
+                a.emit(black_box(&2u64));
+                a.emit(black_box(&1u64));
+                a.emit(black_box(&42u64));
+                a.emit(black_box(&7u64));
+                a.emit(black_box(&1000u64));
+                a.emit(black_box(&3600000u64));
+                a.emit(black_box(&0u64));
+            });
+            black_box(e.build());
+        })
+    });
+}
+
+/// Benchmark encoding a byte string (simulates payload block).
+fn bench_emit_bytes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode/bytes");
+
+    let small_payload = vec![0xABu8; 64];
+    let medium_payload = vec![0xABu8; 1024];
+    let large_payload = vec![0xABu8; 65536];
+
+    group.bench_function("64B", |b| {
+        b.iter(|| {
+            let (bytes, _) = encode::emit(&encode::Bytes(black_box(&small_payload)));
+            black_box(bytes);
+        })
+    });
+
+    group.bench_function("1KB", |b| {
+        b.iter(|| {
+            let (bytes, _) = encode::emit(&encode::Bytes(black_box(&medium_payload)));
+            black_box(bytes);
+        })
+    });
+
+    group.bench_function("64KB", |b| {
+        b.iter(|| {
+            let (bytes, _) = encode::emit(&encode::Bytes(black_box(&large_payload)));
+            black_box(bytes);
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmark encoding a realistic bundle-like structure:
+/// array(primary_block, payload_block)
+fn bench_emit_bundle_like(c: &mut Criterion) {
+    let payload = vec![0x42u8; 1024];
+
+    c.bench_function("encode/bundle_like_1KB", |b| {
+        b.iter(|| {
+            let mut e = Encoder::new();
+            e.emit_array(Some(2), |a| {
+                // Primary block (array of integers)
+                a.emit_array(Some(8), |primary| {
+                    primary.emit(&7u64); // version
+                    primary.emit(&0u64); // flags
+                    primary.emit(&1u64); // crc type
+                    primary.emit(&2u64); // dest scheme
+                    primary.emit(&42u64); // dest node
+                    primary.emit(&7u64); // dest service
+                    primary.emit(&1000u64); // creation time
+                    primary.emit(&3600000u64); // lifetime
+                });
+                // Payload block (byte string)
+                a.emit(&encode::Bytes(black_box(&payload)));
+            });
+            black_box(e.build());
+        })
+    });
+}
+
+/// Benchmark with_capacity vs new for known-size encoding.
+fn bench_with_capacity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode/capacity");
+
+    group.bench_function("new_then_encode_50B", |b| {
+        b.iter(|| {
+            let mut e = Encoder::new();
+            for i in 0..10u64 {
+                e.emit(black_box(&i));
+            }
+            black_box(e.build());
+        })
+    });
+
+    group.bench_function("with_capacity_then_encode_50B", |b| {
+        b.iter(|| {
+            let mut e = Encoder::with_capacity(50);
+            for i in 0..10u64 {
+                e.emit(black_box(&i));
+            }
+            black_box(e.build());
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_emit_uint,
+    bench_emit_mixed_integers,
+    bench_emit_array,
+    bench_emit_bytes,
+    bench_emit_bundle_like,
+    bench_with_capacity,
+);
+criterion_main!(benches);


### PR DESCRIPTION
Adds a criterion benchmark suite for the CBOR encoder, covering:

- `emit_uint_minor` across all magnitude ranges (inline, u8, u16, u32, u64)
- Mixed-integer sequences (simulates primary block fields)
- Array encoding with nested integers
- Byte string payloads (64B, 1KB, 64KB)
- Bundle-like structure (primary block + 1KB payload)
- `with_capacity` vs `new` comparison

Run with: `cargo bench -p hardy-cbor --bench encode_bench`

Requested in #648 to inform the emit_uint_minor codegen discussion.

**Changes:**
- `cbor/Cargo.toml`: add criterion dev-dependency + bench target
- `cbor/benches/encode_bench.rs`: benchmark suite