### PR TITLE
perf: pre-size Vecs where capacity is known (#653 safe-now group)

### DIFF
--- a/bpa/src/node_ids.rs
+++ b/bpa/src/node_ids.rs
@@ -209,7 +209,7 @@ impl<'de> serde::Deserialize<'de> for NodeIds {
             where
                 A: serde::de::SeqAccess<'de>,
             {
-                let mut endpoints = Vec::new();
+                let mut endpoints = Vec::with_capacity(seq.size_hint().unwrap_or(0));
                 while let Some(eid) = seq.next_element::<String>()? {
                     endpoints.push(eid.parse().map_err(serde::de::Error::custom)?);
                 }

--- a/bpa/src/routing/rib.rs
+++ b/bpa/src/routing/rib.rs
@@ -411,7 +411,12 @@ impl Rib {
     }
 
     pub(crate) async fn shutdown_agents(&self) {
-        let agents = self.agents.lock().drain().collect::<Vec<_>>();
+        let agents = {
+            let mut locked = self.agents.lock();
+            let mut v = Vec::with_capacity(locked.len());
+            v.extend(locked.drain());
+            v
+        };
 
         if !agents.is_empty() {
             metrics::gauge!("bpa.rib.agents").decrement(agents.len() as f64);

--- a/proto/src/client/routing.rs
+++ b/proto/src/client/routing.rs
@@ -133,10 +133,11 @@ pub async fn register_routing_agent(
         }
     };
 
-    let node_ids = response
-        .node_ids
+    let node_ids_vec = response.node_ids;
+    let count = node_ids_vec.len();
+    let node_ids = node_ids_vec
         .into_iter()
-        .try_fold(Vec::new(), |mut v, node_id| {
+        .try_fold(Vec::with_capacity(count), |mut v, node_id| {
             v.push(node_id.parse::<hardy_bpv7::eid::NodeId>()?);
             Ok::<_, hardy_bpv7::eid::Error>(v)
         })


### PR DESCRIPTION
The "safe now" group from #653 — conflict-free with the in-flight streaming refactor.

**Changes:**

1. **`proto/src/client/routing.rs`** — capture `node_ids.len()` before `into_iter()`, use `Vec::with_capacity(count)` in the try_fold
2. **`bpa/src/node_ids.rs`** — use `seq.size_hint()` in serde `visit_seq` to pre-allocate the endpoints vec
3. **`bpa/src/routing/rib.rs`** — pre-size the agents vec in `shutdown_agents()` from the map length before draining

**Testing:**
- `cargo fmt --check` clean
- `cargo clippy --all-features --all-targets -- -D warnings` clean
- `cargo test -p hardy-bpa -p hardy-proto --all-features` passes