### PR TITLE
feat(bpa): add Cla::forward_streamed, the streamed egress door

### DIFF
--- a/bpa/docs/streaming_pipeline_design.md
+++ b/bpa/docs/streaming_pipeline_design.md
@@ -785,6 +785,8 @@ Each step is a `mac.update()` or AAD accumulation call. The filter provides thes
 
 ### 6.2. CLA Egress: Cla::forward and Cla::write
 
+> **Landed state (2026-08, `feat/cla-forward-streamed`).** The streaming variant landed as `Cla::forward_streamed`, following the `dispatch_streamed`/`send_streamed` naming rather than the `write()` naming sketched below, and it keeps `forward`'s `bundle_id` correlation parameter, which the sketch predates. The non-streaming adapter is the trait's provided default body: it buffers the stream via `concat_stream`, capped at `total_len` (with a `usize` pre-flight for 32-bit targets), maps truncation to `StreamCancelled` and overrun to `PayloadTooLarge`, then delegates to `forward()`. The dispatcher now always forwards through the streamed door, wrapping the loaded bundle as a single `Final` segment with `total_len = data.len()`. The egress executor, streamed storage `load`, and the Transformer-derived `total_len` below remain pending.
+
 The existing `Cla::forward(Bytes)` method is retained for CLAs that expect a complete bundle in memory. A new streaming variant takes a `Receiver<Segment>` from which the CLA pulls chunks, mirroring `Sink::write` from §5.1:
 
 ```rust

--- a/bpa/src/cla/mod.rs
+++ b/bpa/src/cla/mod.rs
@@ -165,8 +165,8 @@ pub enum TransferOutcome {
 /// transport, such as TCP, UDP, or a custom link-layer protocol. It handles the
 /// transmission and reception of bundles over its specific medium.
 ///
-/// CLAs are often wrapped by an [`EgressPolicy`] to add more complex behaviors like
-/// rate limiting or prioritization.
+/// CLAs are often wrapped by an [`EgressPolicy`](crate::policy::EgressPolicy)
+/// to add more complex behaviors like rate limiting or prioritization.
 ///
 /// # Sink Lifecycle
 ///
@@ -257,6 +257,67 @@ pub trait Cla: Send + Sync {
         bundle_id: &Id,
         bundle: Bytes,
     ) -> Result<ForwardBundleResult>;
+
+    /// Forwards a bundle, delivered as a stream of segments, to a specific CLA
+    /// address over a given queue.
+    ///
+    /// The streaming counterpart of [`forward`](Self::forward), mirroring
+    /// [`Sink::dispatch_streamed`] on the egress side: the implementation
+    /// pulls [`Segment::Next`] items from `stream` until [`Segment::Final`]
+    /// (which may carry empty bytes) completes the transfer.
+    ///
+    /// A pull returning `Err(`[`RecvError`](crate::stream::RecvError)`)`
+    /// before `Final` means the producer aborted the transfer: the CLA must
+    /// tear down without delivering a partial bundle to the peer, and must
+    /// not return `Ok` — a truncated transfer surfaced as success would let
+    /// the peer treat delivery as complete.
+    ///
+    /// `total_len` is the exact number of bundle bytes the stream will
+    /// deliver — the sum of all segment payload lengths. It is a framing
+    /// hint for transports that must announce a length up front (e.g. a
+    /// TCPCLv4 XFER_SEGMENT length), carried as `u64` so it remains valid on
+    /// 32-bit targets. Producers must be exact: an implementation may frame
+    /// the wire transfer from it before pulling the first segment.
+    ///
+    /// `bundle_id` plays the same role as in [`forward`](Self::forward): the
+    /// correlation key echoed via [`Sink::transfer_outcome`] when the CLA
+    /// answers [`ForwardBundleResult::Accepted`].
+    ///
+    /// The provided implementation buffers the stream — capped at
+    /// `total_len` — and delegates to [`forward`](Self::forward). An
+    /// implementation of `forward` must therefore not delegate here unless
+    /// it also overrides this method, or the pair would recurse. A truncated
+    /// stream yields [`Error::StreamCancelled`]; a stream exceeding
+    /// `total_len`, or a `total_len` that cannot fit in addressable memory,
+    /// yields [`Error::PayloadTooLarge`].
+    async fn forward_streamed(
+        &self,
+        queue: Option<u32>,
+        cla_addr: &ClaAddress,
+        bundle_id: &Id,
+        stream: &dyn crate::stream::Receiver<Segment>,
+        total_len: u64,
+    ) -> Result<ForwardBundleResult> {
+        // The buffered adapter's transport limit is a contiguous in-memory
+        // buffer: a total_len that is not indexable as usize (32-bit
+        // targets) cannot be assembled, and is rejected before pulling a
+        // segment. Both fields saturate to the representable maximum.
+        let Ok(max_size) = usize::try_from(total_len) else {
+            return Err(Error::PayloadTooLarge {
+                size: usize::MAX,
+                max: usize::MAX,
+            });
+        };
+        let data = crate::stream::concat_stream(stream, max_size)
+            .await
+            .map_err(|e| match e {
+                crate::stream::ConcatError::Cancelled => Error::StreamCancelled,
+                crate::stream::ConcatError::TooLarge { size, max } => {
+                    Error::PayloadTooLarge { size, max }
+                }
+            })?;
+        self.forward(queue, cla_addr, bundle_id, data).await
+    }
 }
 
 /// A communication channel from a CLA back to the main BPA components.

--- a/bpa/src/cla/mod.rs
+++ b/bpa/src/cla/mod.rs
@@ -36,6 +36,13 @@ pub enum Error {
     #[error("Bundle too large: {size} bytes exceeds the maximum of {max} bytes")]
     PayloadTooLarge { size: usize, max: usize },
 
+    /// A bundle stream completed with fewer bytes than its declared
+    /// `total_len`. A transport may frame the wire transfer from the
+    /// declared length before pulling the first segment, so a short
+    /// delivery is rejected rather than shorting the transfer on the wire.
+    #[error("Bundle stream delivered {size} bytes of the {expected} declared")]
+    PayloadUnderrun { size: usize, expected: usize },
+
     /// An internal error occurred.
     #[error(transparent)]
     Internal(#[from] Box<dyn core::error::Error + Send + Sync>),
@@ -289,7 +296,8 @@ pub trait Cla: Send + Sync {
     /// it also overrides this method, or the pair would recurse. A truncated
     /// stream yields [`Error::StreamCancelled`]; a stream exceeding
     /// `total_len`, or a `total_len` that cannot fit in addressable memory,
-    /// yields [`Error::PayloadTooLarge`].
+    /// yields [`Error::PayloadTooLarge`]; a stream completing with fewer
+    /// bytes than `total_len` yields [`Error::PayloadUnderrun`].
     async fn forward_streamed(
         &self,
         queue: Option<u32>,
@@ -316,6 +324,15 @@ pub trait Cla: Send + Sync {
                     Error::PayloadTooLarge { size, max }
                 }
             })?;
+        // Producers must deliver exactly total_len bytes: a transport may
+        // have framed the wire transfer from it, so an under-delivering
+        // producer fails here instead of shorting the transfer on the wire.
+        if data.len() != max_size {
+            return Err(Error::PayloadUnderrun {
+                size: data.len(),
+                expected: max_size,
+            });
+        }
         self.forward(queue, cla_addr, bundle_id, data).await
     }
 }

--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -98,8 +98,17 @@ impl Dispatcher {
             }
         };
 
-        // And pass to CLA
-        match cla.forward(queue, cla_addr, &bundle.bundle.id, data).await {
+        // And pass to CLA, always through the streamed door: the whole
+        // bundle is in hand, so it travels as a single Final segment.
+        let total_len = data.len() as u64;
+        let (tx, rx) = hardy_async::channel::bounded(1);
+        crate::stream::Sender::send(&tx, cla::Segment::Final(data))
+            .await
+            .trace_expect("bounded(1) send with live receiver cannot fail");
+        match cla
+            .forward_streamed(queue, cla_addr, &bundle.bundle.id, &rx, total_len)
+            .await
+        {
             Ok(cla::ForwardBundleResult::Sent) => {
                 metrics::counter!("bpa.bundle.forwarded").increment(1);
                 self.report_bundle_forwarded(&bundle).await;

--- a/bpa/tests/forward_streamed.rs
+++ b/bpa/tests/forward_streamed.rs
@@ -1,0 +1,500 @@
+//! Integration tests for `Cla::forward_streamed` — the streamed egress door
+//! and its buffered default adapter.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use hardy_bpa::{
+    Bytes, async_trait,
+    bpa::{Bpa, BpaRegistration},
+    cla::{self, Cla},
+    services,
+    stream::{Receiver, Segment},
+};
+use hardy_bpv7::eid::{Eid, IpnNodeId, NodeId};
+
+// ---------------------------------------------------------------------------
+// Events observed by the mock CLAs
+// ---------------------------------------------------------------------------
+
+enum Event {
+    /// `forward` was invoked with the whole bundle.
+    Forward(Bytes),
+    /// `forward_streamed` was invoked and pulled the stream to completion.
+    Streamed {
+        segments: Vec<Segment>,
+        total_len: u64,
+    },
+    /// `forward_streamed` failed the attempt.
+    Failed,
+}
+
+// ---------------------------------------------------------------------------
+// Mock CLAs
+// ---------------------------------------------------------------------------
+
+/// Overrides `forward_streamed`, recording every segment it pulls.
+struct StreamingCla {
+    sink: hardy_async::sync::spin::Once<Box<dyn cla::Sink>>,
+    events_tx: flume::Sender<Event>,
+    /// When set, the first `forward_streamed` call fails without pulling.
+    flaky: AtomicBool,
+}
+
+impl StreamingCla {
+    fn new(flaky: bool) -> (Arc<Self>, flume::Receiver<Event>) {
+        let (tx, rx) = flume::bounded(16);
+        (
+            Arc::new(Self {
+                sink: hardy_async::sync::spin::Once::new(),
+                events_tx: tx,
+                flaky: AtomicBool::new(flaky),
+            }),
+            rx,
+        )
+    }
+}
+
+#[async_trait]
+impl cla::Cla for StreamingCla {
+    async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
+        self.sink.call_once(|| sink);
+    }
+
+    async fn on_unregister(&self) {}
+
+    async fn forward(
+        &self,
+        _queue: Option<u32>,
+        _cla_addr: &cla::ClaAddress,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        bundle: Bytes,
+    ) -> cla::Result<cla::ForwardBundleResult> {
+        // A call here means the streamed door was bypassed — observable,
+        // so the test fails on the assertion rather than inside a BPA task.
+        let _ = self.events_tx.send(Event::Forward(bundle));
+        Ok(cla::ForwardBundleResult::Sent)
+    }
+
+    async fn forward_streamed(
+        &self,
+        _queue: Option<u32>,
+        _cla_addr: &cla::ClaAddress,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        stream: &dyn Receiver<Segment>,
+        total_len: u64,
+    ) -> cla::Result<cla::ForwardBundleResult> {
+        if self.flaky.swap(false, Ordering::SeqCst) {
+            let _ = self.events_tx.send(Event::Failed);
+            return Err(cla::Error::StreamCancelled);
+        }
+        let mut segments = Vec::new();
+        loop {
+            match stream.recv().await {
+                Ok(segment @ Segment::Next(_)) => segments.push(segment),
+                Ok(segment @ Segment::Final(_)) => {
+                    segments.push(segment);
+                    break;
+                }
+                Err(_) => {
+                    let _ = self.events_tx.send(Event::Failed);
+                    return Err(cla::Error::StreamCancelled);
+                }
+            }
+        }
+        let _ = self.events_tx.send(Event::Streamed {
+            segments,
+            total_len,
+        });
+        Ok(cla::ForwardBundleResult::Sent)
+    }
+}
+
+/// Relies on the provided `forward_streamed` — the buffered default adapter.
+struct BufferedCla {
+    sink: hardy_async::sync::spin::Once<Box<dyn cla::Sink>>,
+    events_tx: flume::Sender<Event>,
+}
+
+impl BufferedCla {
+    fn new() -> (Arc<Self>, flume::Receiver<Event>) {
+        let (tx, rx) = flume::bounded(16);
+        (
+            Arc::new(Self {
+                sink: hardy_async::sync::spin::Once::new(),
+                events_tx: tx,
+            }),
+            rx,
+        )
+    }
+}
+
+#[async_trait]
+impl cla::Cla for BufferedCla {
+    async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
+        self.sink.call_once(|| sink);
+    }
+
+    async fn on_unregister(&self) {}
+
+    async fn forward(
+        &self,
+        _queue: Option<u32>,
+        _cla_addr: &cla::ClaAddress,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        bundle: Bytes,
+    ) -> cla::Result<cla::ForwardBundleResult> {
+        let _ = self.events_tx.send(Event::Forward(bundle));
+        Ok(cla::ForwardBundleResult::Sent)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal application to originate bundles
+// ---------------------------------------------------------------------------
+
+struct SendOnlyApp {
+    sink: hardy_async::sync::spin::Once<Box<dyn services::ApplicationSink>>,
+}
+
+impl SendOnlyApp {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            sink: hardy_async::sync::spin::Once::new(),
+        })
+    }
+}
+
+#[async_trait]
+impl services::Application for SendOnlyApp {
+    async fn on_register(&self, _source: &Eid, sink: Box<dyn services::ApplicationSink>) {
+        self.sink.call_once(|| sink);
+    }
+
+    async fn on_unregister(&self) {}
+
+    async fn on_receive(
+        &self,
+        _source: Eid,
+        _expiry: time::OffsetDateTime,
+        _ack_requested: bool,
+        _payload: Bytes,
+    ) -> services::Result<()> {
+        Ok(())
+    }
+
+    async fn on_status_notify(
+        &self,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        _from: &Eid,
+        _kind: services::StatusNotify,
+        _reason: hardy_bpv7::status_report::ReasonCode,
+        _timestamp: Option<time::OffsetDateTime>,
+    ) {
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_bundle(
+    source: &Eid,
+    destination: &Eid,
+    payload: &[u8],
+) -> (hardy_bpv7::bundle::Bundle, Bytes) {
+    let (bundle, data) = hardy_bpv7::builder::Builder::new(source.clone(), destination.clone())
+        .with_payload(std::borrow::Cow::Borrowed(payload))
+        .build(hardy_bpv7::creation_timestamp::CreationTimestamp::now())
+        .expect("Failed to build bundle");
+    (bundle, Bytes::from(data))
+}
+
+/// A pre-filled segment stream. The sender is dropped on return, so a
+/// sequence not ending in `Final` reads as a truncated stream.
+async fn feed(segments: Vec<Segment>) -> hardy_async::channel::Receiver<Segment> {
+    let (tx, rx) = hardy_async::channel::bounded(segments.len().max(1));
+    for segment in segments {
+        hardy_async::channel::Sender::send(&tx, segment)
+            .await
+            .unwrap();
+    }
+    rx
+}
+
+fn remote_node(node_number: u32) -> NodeId {
+    NodeId::Ipn(IpnNodeId {
+        allocator_id: 0,
+        node_number,
+    })
+}
+
+async fn recv_event(rx: &flume::Receiver<Event>, secs: u64) -> Event {
+    tokio::time::timeout(tokio::time::Duration::from_secs(secs), rx.recv_async())
+        .await
+        .expect("Timed out waiting for CLA event")
+        .expect("CLA event channel closed")
+}
+
+/// Sends `payload` to ipn:0.2.99 via `app`, returning the destination EID.
+async fn originate(app: &SendOnlyApp, payload: &'static [u8]) -> Eid {
+    let dest: Eid = "ipn:0.2.99".parse().unwrap();
+    app.sink
+        .get()
+        .unwrap()
+        .send(
+            dest.clone(),
+            Bytes::from_static(payload),
+            core::time::Duration::from_secs(3600),
+            None,
+        )
+        .await
+        .unwrap();
+    dest
+}
+
+// ---------------------------------------------------------------------------
+// Full-path tests: dispatcher -> forward_streamed
+// ---------------------------------------------------------------------------
+
+/// A streaming CLA receives the whole bundle as a single `Final` segment
+/// with an exact `total_len`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_cla_receives_single_final_segment() {
+    let bpa = Bpa::builder().build().await.unwrap();
+    bpa.start(false);
+
+    let (cla, events_rx) = StreamingCla::new(false);
+    bpa.register_cla("stream".to_string(), cla.clone(), None)
+        .await
+        .unwrap();
+    cla.sink
+        .get()
+        .unwrap()
+        .add_peer(
+            cla::ClaAddress::Private("peer".as_bytes().into()),
+            &[remote_node(2)],
+        )
+        .await
+        .unwrap();
+
+    let app = SendOnlyApp::new();
+    let source_eid = bpa
+        .register_application(hardy_bpv7::eid::Service::Ipn(42), app.clone())
+        .await
+        .unwrap();
+    let dest = originate(&app, b"Hello remote").await;
+
+    let Event::Streamed {
+        segments,
+        total_len,
+    } = recv_event(&events_rx, 5).await
+    else {
+        panic!("Expected the streamed door, got another event");
+    };
+    assert_eq!(segments.len(), 1);
+    let Segment::Final(data) = &segments[0] else {
+        panic!("Expected a single Final segment");
+    };
+    assert_eq!(total_len, data.len() as u64);
+
+    let parsed = hardy_bpv7::bundle::ParsedBundle::parse(data, hardy_bpv7::bpsec::no_keys)
+        .expect("Failed to parse forwarded bundle");
+    assert_eq!(parsed.bundle.id.source, source_eid);
+    assert_eq!(parsed.bundle.destination, dest);
+
+    assert!(events_rx.is_empty());
+    bpa.shutdown().await;
+}
+
+/// A CLA that only implements `forward` still receives the whole bundle,
+/// through the buffered default adapter.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn buffered_cla_receives_whole_bundle_via_default_adapter() {
+    let bpa = Bpa::builder().build().await.unwrap();
+    bpa.start(false);
+
+    let (cla, events_rx) = BufferedCla::new();
+    bpa.register_cla("buffered".to_string(), cla.clone(), None)
+        .await
+        .unwrap();
+    cla.sink
+        .get()
+        .unwrap()
+        .add_peer(
+            cla::ClaAddress::Private("peer".as_bytes().into()),
+            &[remote_node(2)],
+        )
+        .await
+        .unwrap();
+
+    let app = SendOnlyApp::new();
+    let source_eid = bpa
+        .register_application(hardy_bpv7::eid::Service::Ipn(42), app.clone())
+        .await
+        .unwrap();
+    let dest = originate(&app, b"Hello adapter").await;
+
+    let Event::Forward(data) = recv_event(&events_rx, 5).await else {
+        panic!("Expected the buffered adapter to call forward");
+    };
+    let parsed = hardy_bpv7::bundle::ParsedBundle::parse(&data, hardy_bpv7::bpsec::no_keys)
+        .expect("Failed to parse forwarded bundle");
+    assert_eq!(parsed.bundle.id.source, source_eid);
+    assert_eq!(parsed.bundle.destination, dest);
+
+    bpa.shutdown().await;
+}
+
+/// A failed streamed attempt takes the established requeue path: the bundle
+/// returns to Waiting and a routing change re-dispatches it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_streamed_forward_is_requeued_and_retried() {
+    let bpa = Bpa::builder().build().await.unwrap();
+    bpa.start(false);
+
+    let (cla, events_rx) = StreamingCla::new(true);
+    bpa.register_cla("flaky".to_string(), cla.clone(), None)
+        .await
+        .unwrap();
+    cla.sink
+        .get()
+        .unwrap()
+        .add_peer(
+            cla::ClaAddress::Private("peer-a".as_bytes().into()),
+            &[remote_node(2)],
+        )
+        .await
+        .unwrap();
+
+    let app = SendOnlyApp::new();
+    bpa.register_application(hardy_bpv7::eid::Service::Ipn(42), app.clone())
+        .await
+        .unwrap();
+    originate(&app, b"Try again").await;
+
+    assert!(matches!(recv_event(&events_rx, 5).await, Event::Failed));
+
+    // Nudge the RIB so the Waiting bundle is re-polled. The failed attempt
+    // returns the bundle to Waiting *after* the CLA reports the failure, so
+    // a single nudge can race it; each fresh peer re-triggers the poll.
+    let mut retry = None;
+    for i in 0.. {
+        cla.sink
+            .get()
+            .unwrap()
+            .add_peer(
+                cla::ClaAddress::Private(format!("peer-{i}").into_bytes().into()),
+                &[remote_node(2)],
+            )
+            .await
+            .unwrap();
+        if let Ok(Ok(event)) = tokio::time::timeout(
+            tokio::time::Duration::from_millis(500),
+            events_rx.recv_async(),
+        )
+        .await
+        {
+            retry = Some(event);
+            break;
+        }
+        assert!(i < 20, "Timed out waiting for the retry");
+    }
+    let Some(Event::Streamed { segments, .. }) = retry else {
+        panic!("Expected a successful retry through the streamed door");
+    };
+    assert!(matches!(segments.last(), Some(Segment::Final(_))));
+
+    bpa.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// Direct-call tests: the default adapter body
+// ---------------------------------------------------------------------------
+
+fn direct_call_fixture() -> (
+    Arc<BufferedCla>,
+    flume::Receiver<Event>,
+    hardy_bpv7::bundle::Bundle,
+    Bytes,
+    cla::ClaAddress,
+) {
+    let (cla, events_rx) = BufferedCla::new();
+    let (bundle, data) = build_bundle(
+        &"ipn:0.1.1".parse().unwrap(),
+        &"ipn:0.2.99".parse().unwrap(),
+        b"payload",
+    );
+    let addr = cla::ClaAddress::Private("x".as_bytes().into());
+    (cla, events_rx, bundle, data, addr)
+}
+
+/// The default body reassembles a multi-segment stream before delegating.
+#[tokio::test]
+async fn default_body_concats_multi_segment_stream() {
+    let (cla, events_rx, bundle, data, addr) = direct_call_fixture();
+    let (head, tail) = (data.slice(..10), data.slice(10..));
+    let rx = feed(vec![Segment::Next(head), Segment::Final(tail)]).await;
+
+    let result = cla
+        .forward_streamed(None, &addr, &bundle.id, &rx, data.len() as u64)
+        .await
+        .unwrap();
+    assert!(matches!(result, cla::ForwardBundleResult::Sent));
+
+    let Ok(Event::Forward(received)) = events_rx.try_recv() else {
+        panic!("Expected forward to receive the reassembled bundle");
+    };
+    assert_eq!(received, data);
+}
+
+/// A single-`Final` stream passes through the default body zero-copy.
+#[tokio::test]
+async fn default_body_is_zero_copy_for_single_final() {
+    let (cla, events_rx, bundle, data, addr) = direct_call_fixture();
+    let rx = feed(vec![Segment::Final(data.clone())]).await;
+
+    cla.forward_streamed(None, &addr, &bundle.id, &rx, data.len() as u64)
+        .await
+        .unwrap();
+
+    let Ok(Event::Forward(received)) = events_rx.try_recv() else {
+        panic!("Expected forward to receive the bundle");
+    };
+    assert_eq!(received.as_ptr(), data.as_ptr());
+}
+
+/// A truncated stream is an error, and `forward` is never invoked — no
+/// partial bundle reaches the transport.
+#[tokio::test]
+async fn default_body_truncated_stream_is_cancelled() {
+    let (cla, events_rx, bundle, data, addr) = direct_call_fixture();
+    let rx = feed(vec![Segment::Next(data.slice(..4))]).await;
+
+    let Err(err) = cla
+        .forward_streamed(None, &addr, &bundle.id, &rx, data.len() as u64)
+        .await
+    else {
+        panic!("Expected a truncated stream to fail");
+    };
+    assert!(matches!(err, cla::Error::StreamCancelled));
+    assert!(events_rx.is_empty());
+}
+
+/// A stream exceeding the declared `total_len` is rejected before delegation.
+#[tokio::test]
+async fn default_body_rejects_stream_exceeding_total_len() {
+    let (cla, events_rx, bundle, data, addr) = direct_call_fixture();
+    let rx = feed(vec![Segment::Final(data.clone())]).await;
+
+    let Err(err) = cla.forward_streamed(None, &addr, &bundle.id, &rx, 4).await else {
+        panic!("Expected an oversize stream to fail");
+    };
+    assert!(matches!(
+        err,
+        cla::Error::PayloadTooLarge { size, max: 4 } if size > 4
+    ));
+    assert!(events_rx.is_empty());
+}

--- a/bpa/tests/forward_streamed.rs
+++ b/bpa/tests/forward_streamed.rs
@@ -483,6 +483,28 @@ async fn default_body_truncated_stream_is_cancelled() {
     assert!(events_rx.is_empty());
 }
 
+/// A stream completing with fewer bytes than the declared `total_len` is
+/// rejected before delegation — no short transfer reaches the transport.
+#[tokio::test]
+async fn default_body_rejects_under_delivering_stream() {
+    let (cla, events_rx, bundle, data, addr) = direct_call_fixture();
+    let short = data.slice(..data.len() - 1);
+    let rx = feed(vec![Segment::Final(short.clone())]).await;
+
+    let Err(err) = cla
+        .forward_streamed(None, &addr, &bundle.id, &rx, data.len() as u64)
+        .await
+    else {
+        panic!("Expected an under-delivering stream to fail");
+    };
+    assert!(matches!(
+        err,
+        cla::Error::PayloadUnderrun { size, expected }
+            if size == short.len() && expected == data.len()
+    ));
+    assert!(events_rx.is_empty());
+}
+
 /// A stream exceeding the declared `total_len` is rejected before delegation.
 #[tokio::test]
 async fn default_body_rejects_stream_exceeding_total_len() {


### PR DESCRIPTION
Adds the streamed egress primitive to the Cla trait — seam 6 of the six streaming seams (refactor_plan: "the pull-shaped Receiver/Segment stream is the target for all six seams"), and the first out-path seam to land. This is streaming_pipeline_design.md §6.2's Cla::write, landed as forward_streamed for consistency with dispatch_streamed/send_streamed, and keeping forward's bundle_id correlation parameter, which the sketch predates.

````rust
async fn forward_streamed(
    &self,
    queue: Option<u32>,
    cla_addr: &ClaAddress,
    bundle_id: &Id,
    stream: &dyn crate::stream::Receiver<Segment>,
    total_len: u64,
) -> Result<ForwardBundleResult>
````

Non-breaking: the method has a provided default body — the §6.2 buffered adapter — so all existing Cla implementors compile and behave identically. It collects via concat_stream capped at total_len, maps truncation → StreamCancelled and overrun → PayloadTooLarge, and delegates to forward(). Single-Final streams take concat_stream's zero-copy fast path, so buffered CLAs receive the identical Bytes.

32-bit safe: total_len is u64 with a usize::try_from pre-flight before any buffering — no as usize on a wire-scale length.
The BPA now always forwards through the streamed door (§6.2: "Internally, the BPA always uses write()"): the dispatcher wraps the loaded bundle as a single Final segment with total_len = data.len(), the exact mirror of Sink::dispatch's default body on the ingress side. All four ForwardBundleResult arms and the requeue fall-through are unchanged; a streamed-door Err takes the existing restore-to-Waiting path.

total_len contract: the exact byte count the stream will deliver — the framing hint length-prefixed transports need (e.g. TCPCLv4 XFER_SEGMENT), and the same number the v1 wire's Forwarding.bundle_size carries, so the internal seam and the future cla.v1 Forward bridge line up parameter-for-parameter.
Also: records the landed shape in a §6.2 "Landed state" note in streaming_pipeline_design.md (same convention as the §5 ingress note), and fixes a broken EgressPolicy intra-doc link in the trait docs (now zero rustdoc warnings in hardy-bpa).

# Why now
The public Cla trait is the extension surface — settling the streamed shape before more CLAs exist avoids a second breaking round. The default-body adapter means the streaming lands behind the API later (streamed storage load, egress executor) with no further trait churn.

# Tests
New bpa/tests/forward_streamed.rs (nothing added to pipeline.rs):

Full-path: a streaming CLA receives exactly one Final segment with exact total_len, bytes parse to the originated bundle; a forward-only CLA round-trips through the default adapter.

Full-path: a failed streamed attempt requeues via the existing restore/Waiting path and retries.

Direct-call: multi-segment reassembly; zero-copy single-Final (pointer-equality asserted); truncation → StreamCancelled with forward never invoked; overrun of total_len → PayloadTooLarge.

Gates: fmt --check, clippy --locked --all-targets --all-features -D warnings, test --locked --all-features --workspace all green (the two tcpclv4 socket-bind tests fail only in the sandbox used for development — AddrNotAvailable — and fail identically on clean main there).

# Merge notes (refactor train)
Deliberately shaped to stay out of the train's way: bpa/src/cla/mod.rs and stream.rs are untouched by refactor/parse/cbor-perf/metadata, tests live in a new file, and file-cla/tcpclv4/bibe/proto are untouched. Expected conflicts when the train lands: the single call-site hunk in dispatcher/forward.rs and the one doc blockquote — both mechanical.

# Follow-ups
Streaming overrides in tcpclv4 (XFER_SEGMENT framing from total_len) and file-cla, once the train lands.
BundleStorage::load_stream (the storage-side enabler; save_stream remains the in-path prerequisite).

The Deliver seam (announce/collect), re-ported from refactor/grpc-api-v1 onto the metadata model.
Eventually retire whole-buffer forward() per §5.1's "transitional convenience" note.