### PR TITLE
feat(bpa): add Service::on_receive_streamed, the streamed delivery door

### DIFF
--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -220,8 +220,16 @@ impl Dispatcher {
 
         let delivery_result = match &service.service {
             services::registry::ServiceImpl::LowLevel(svc) => {
-                // Pass raw bundle bytes to low-level services
-                svc.on_receive(data, bundle.expiry()).await
+                // Pass raw bundle bytes to low-level services, always
+                // through the streamed door: the whole bundle is in hand,
+                // so it travels as a single Final segment.
+                let total_len = data.len() as u64;
+                let (tx, rx) = hardy_async::channel::bounded(1);
+                crate::stream::Sender::send(&tx, crate::stream::Segment::Final(data))
+                    .await
+                    .trace_expect("bounded(1) send with live receiver cannot fail");
+                svc.on_receive_streamed(&rx, bundle.expiry(), total_len)
+                    .await
             }
             services::registry::ServiceImpl::Application(app) => {
                 // Extract and decrypt payload for Application

--- a/bpa/src/services/mod.rs
+++ b/bpa/src/services/mod.rs
@@ -256,6 +256,60 @@ pub trait Service: Send + Sync {
     /// subsequent registration on the same EID re-delivers it.
     async fn on_receive(&self, data: Bytes, expiry: time::OffsetDateTime) -> Result<()>;
 
+    /// Called when a bundle arrives, delivered as a stream of segments.
+    ///
+    /// The streaming counterpart of [`on_receive`](Self::on_receive): the
+    /// implementation pulls [`Segment::Next`](crate::stream::Segment::Next)
+    /// items from `stream` until
+    /// [`Segment::Final`](crate::stream::Segment::Final) (which may carry
+    /// empty bytes) completes the delivery.
+    ///
+    /// A pull returning `Err(`[`RecvError`](crate::stream::RecvError)`)`
+    /// before `Final` means the producer aborted the delivery: the
+    /// implementation must not act on the partial bundle and must not
+    /// return `Ok` — returning `Err` leaves the bundle parked as
+    /// `WaitingForService` for re-delivery, exactly as for
+    /// [`on_receive`](Self::on_receive).
+    ///
+    /// `total_len` is the exact number of bundle bytes the stream will
+    /// deliver — the sum of all segment payload lengths — carried as `u64`
+    /// so it remains valid on 32-bit targets. An implementation may size
+    /// buffers from it before pulling the first segment.
+    ///
+    /// The provided implementation buffers the stream — capped at
+    /// `total_len` — and delegates to [`on_receive`](Self::on_receive). An
+    /// implementation of `on_receive` must therefore not delegate here
+    /// unless it also overrides this method, or the pair would recurse. A
+    /// truncated stream yields [`Error::StreamCancelled`]; a stream
+    /// exceeding `total_len`, or a `total_len` that cannot fit in
+    /// addressable memory, yields [`Error::PayloadTooLarge`].
+    async fn on_receive_streamed(
+        &self,
+        stream: &dyn crate::stream::Receiver<crate::stream::Segment>,
+        expiry: time::OffsetDateTime,
+        total_len: u64,
+    ) -> Result<()> {
+        // The buffered adapter's limit is a contiguous in-memory buffer: a
+        // total_len that is not indexable as usize (32-bit targets) cannot
+        // be assembled, and is rejected before pulling a segment. Both
+        // fields saturate to the representable maximum.
+        let Ok(max_size) = usize::try_from(total_len) else {
+            return Err(Error::PayloadTooLarge {
+                size: usize::MAX,
+                max: usize::MAX,
+            });
+        };
+        let data = crate::stream::concat_stream(stream, max_size)
+            .await
+            .map_err(|e| match e {
+                crate::stream::ConcatError::Cancelled => Error::StreamCancelled,
+                crate::stream::ConcatError::TooLarge { size, max } => {
+                    Error::PayloadTooLarge { size, max }
+                }
+            })?;
+        self.on_receive(data, expiry).await
+    }
+
     /// Called when status report received for a sent bundle
     async fn on_status_notify(
         &self,

--- a/bpa/src/services/mod.rs
+++ b/bpa/src/services/mod.rs
@@ -37,6 +37,13 @@ pub enum Error {
     #[error("Payload too large: {size} bytes exceeds the maximum of {max} bytes")]
     PayloadTooLarge { size: usize, max: usize },
 
+    /// A bundle stream completed with fewer bytes than its declared
+    /// `total_len`. An implementation may size buffers — or frame a
+    /// transfer — from the declared length before pulling the first
+    /// segment, so an under-delivering producer is rejected at the seam.
+    #[error("Bundle stream delivered {size} bytes of the {expected} declared")]
+    PayloadUnderrun { size: usize, expected: usize },
+
     /// The node ID configuration doesn't support the requested service scheme.
     #[error(transparent)]
     NodeId(#[from] crate::node_ids::Error),
@@ -282,7 +289,9 @@ pub trait Service: Send + Sync {
     /// unless it also overrides this method, or the pair would recurse. A
     /// truncated stream yields [`Error::StreamCancelled`]; a stream
     /// exceeding `total_len`, or a `total_len` that cannot fit in
-    /// addressable memory, yields [`Error::PayloadTooLarge`].
+    /// addressable memory, yields [`Error::PayloadTooLarge`]; a stream
+    /// completing with fewer bytes than `total_len` yields
+    /// [`Error::PayloadUnderrun`].
     async fn on_receive_streamed(
         &self,
         stream: &dyn crate::stream::Receiver<crate::stream::Segment>,
@@ -307,6 +316,15 @@ pub trait Service: Send + Sync {
                     Error::PayloadTooLarge { size, max }
                 }
             })?;
+        // Producers must deliver exactly total_len bytes: an implementation
+        // may have sized buffers or framed a transfer from it, so an
+        // under-delivering producer fails here at the seam.
+        if data.len() != max_size {
+            return Err(Error::PayloadUnderrun {
+                size: data.len(),
+                expected: max_size,
+            });
+        }
         self.on_receive(data, expiry).await
     }
 

--- a/bpa/tests/on_receive_streamed.rs
+++ b/bpa/tests/on_receive_streamed.rs
@@ -442,6 +442,32 @@ async fn default_body_truncated_stream_is_cancelled() {
     assert!(events_rx.is_empty());
 }
 
+/// A stream completing with fewer bytes than the declared `total_len` is
+/// rejected before delegation — no short bundle reaches the service.
+#[tokio::test]
+async fn default_body_rejects_under_delivering_stream() {
+    let (svc, events_rx) = BufferedService::new();
+    let data = build_bundle(
+        &"ipn:0.1.1".parse().unwrap(),
+        &"ipn:0.2.99".parse().unwrap(),
+        b"payload",
+    );
+    let short = data.slice(..data.len() - 1);
+    let rx = feed(vec![Segment::Final(short.clone())]).await;
+
+    let Err(err) =
+        services::Service::on_receive_streamed(&*svc, &rx, expiry(), data.len() as u64).await
+    else {
+        panic!("Expected an under-delivering stream to fail");
+    };
+    assert!(matches!(
+        err,
+        services::Error::PayloadUnderrun { size, expected }
+            if size == short.len() && expected == data.len()
+    ));
+    assert!(events_rx.is_empty());
+}
+
 /// A stream exceeding the declared `total_len` is rejected before
 /// delegation.
 #[tokio::test]

--- a/bpa/tests/on_receive_streamed.rs
+++ b/bpa/tests/on_receive_streamed.rs
@@ -1,0 +1,465 @@
+//! Integration tests for `Service::on_receive_streamed` — the streamed
+//! delivery door and its buffered default adapter.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use hardy_bpa::{
+    Bytes, async_trait,
+    bpa::{Bpa, BpaRegistration},
+    cla, services,
+    stream::{Receiver, Segment},
+};
+use hardy_bpv7::eid::{Eid, IpnNodeId, NodeId};
+
+// ---------------------------------------------------------------------------
+// Events observed by the mock services
+// ---------------------------------------------------------------------------
+
+enum Event {
+    /// `on_receive` was invoked with the whole bundle.
+    Received(Bytes),
+    /// `on_receive_streamed` was invoked and pulled the stream to completion.
+    Streamed {
+        segments: Vec<Segment>,
+        total_len: u64,
+    },
+    /// `on_receive_streamed` failed the delivery.
+    Failed,
+}
+
+// ---------------------------------------------------------------------------
+// Mock services
+// ---------------------------------------------------------------------------
+
+/// Overrides `on_receive_streamed`, recording every segment it pulls.
+struct StreamingService {
+    sink: hardy_async::sync::spin::Once<Box<dyn services::ServiceSink>>,
+    events_tx: flume::Sender<Event>,
+    /// When set, every `on_receive_streamed` call fails without pulling.
+    failing: AtomicBool,
+}
+
+impl StreamingService {
+    fn new(failing: bool) -> (Arc<Self>, flume::Receiver<Event>) {
+        let (tx, rx) = flume::bounded(16);
+        (
+            Arc::new(Self {
+                sink: hardy_async::sync::spin::Once::new(),
+                events_tx: tx,
+                failing: AtomicBool::new(failing),
+            }),
+            rx,
+        )
+    }
+}
+
+#[async_trait]
+impl services::Service for StreamingService {
+    async fn on_register(&self, _endpoint: &Eid, sink: Box<dyn services::ServiceSink>) {
+        self.sink.call_once(|| sink);
+    }
+
+    async fn on_unregister(&self) {}
+
+    async fn on_receive(&self, data: Bytes, _expiry: time::OffsetDateTime) -> services::Result<()> {
+        // A call here means the streamed door was bypassed — observable,
+        // so the test fails on the assertion rather than inside a BPA task.
+        let _ = self.events_tx.send(Event::Received(data));
+        Ok(())
+    }
+
+    async fn on_receive_streamed(
+        &self,
+        stream: &dyn Receiver<Segment>,
+        _expiry: time::OffsetDateTime,
+        total_len: u64,
+    ) -> services::Result<()> {
+        if self.failing.load(Ordering::SeqCst) {
+            let _ = self.events_tx.send(Event::Failed);
+            return Err(services::Error::StreamCancelled);
+        }
+        let mut segments = Vec::new();
+        loop {
+            match stream.recv().await {
+                Ok(segment @ Segment::Next(_)) => segments.push(segment),
+                Ok(segment @ Segment::Final(_)) => {
+                    segments.push(segment);
+                    break;
+                }
+                Err(_) => {
+                    let _ = self.events_tx.send(Event::Failed);
+                    return Err(services::Error::StreamCancelled);
+                }
+            }
+        }
+        let _ = self.events_tx.send(Event::Streamed {
+            segments,
+            total_len,
+        });
+        Ok(())
+    }
+
+    async fn on_status_notify(
+        &self,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        _from: &Eid,
+        _kind: services::StatusNotify,
+        _reason: hardy_bpv7::status_report::ReasonCode,
+        _timestamp: Option<time::OffsetDateTime>,
+    ) {
+    }
+}
+
+/// Relies on the provided `on_receive_streamed` — the buffered default
+/// adapter.
+struct BufferedService {
+    sink: hardy_async::sync::spin::Once<Box<dyn services::ServiceSink>>,
+    events_tx: flume::Sender<Event>,
+}
+
+impl BufferedService {
+    fn new() -> (Arc<Self>, flume::Receiver<Event>) {
+        let (tx, rx) = flume::bounded(16);
+        (
+            Arc::new(Self {
+                sink: hardy_async::sync::spin::Once::new(),
+                events_tx: tx,
+            }),
+            rx,
+        )
+    }
+}
+
+#[async_trait]
+impl services::Service for BufferedService {
+    async fn on_register(&self, _endpoint: &Eid, sink: Box<dyn services::ServiceSink>) {
+        self.sink.call_once(|| sink);
+    }
+
+    async fn on_unregister(&self) {}
+
+    async fn on_receive(&self, data: Bytes, _expiry: time::OffsetDateTime) -> services::Result<()> {
+        let _ = self.events_tx.send(Event::Received(data));
+        Ok(())
+    }
+
+    async fn on_status_notify(
+        &self,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        _from: &Eid,
+        _kind: services::StatusNotify,
+        _reason: hardy_bpv7::status_report::ReasonCode,
+        _timestamp: Option<time::OffsetDateTime>,
+    ) {
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal CLA to inject inbound bundles
+// ---------------------------------------------------------------------------
+
+struct IngressCla {
+    sink: hardy_async::sync::spin::Once<Box<dyn cla::Sink>>,
+}
+
+impl IngressCla {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            sink: hardy_async::sync::spin::Once::new(),
+        })
+    }
+}
+
+#[async_trait]
+impl cla::Cla for IngressCla {
+    async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
+        self.sink.call_once(|| sink);
+    }
+
+    async fn on_unregister(&self) {}
+
+    async fn forward(
+        &self,
+        _queue: Option<u32>,
+        _cla_addr: &cla::ClaAddress,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        _bundle: Bytes,
+    ) -> cla::Result<cla::ForwardBundleResult> {
+        Ok(cla::ForwardBundleResult::Sent)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_bundle(source: &Eid, destination: &Eid, payload: &[u8]) -> Bytes {
+    let (_, data) = hardy_bpv7::builder::Builder::new(source.clone(), destination.clone())
+        .with_payload(std::borrow::Cow::Borrowed(payload))
+        .build(hardy_bpv7::creation_timestamp::CreationTimestamp::now())
+        .expect("Failed to build bundle");
+    Bytes::from(data)
+}
+
+/// A pre-filled segment stream. The sender is dropped on return, so a
+/// sequence not ending in `Final` reads as a truncated stream.
+async fn feed(segments: Vec<Segment>) -> hardy_async::channel::Receiver<Segment> {
+    let (tx, rx) = hardy_async::channel::bounded(segments.len().max(1));
+    for segment in segments {
+        hardy_async::channel::Sender::send(&tx, segment)
+            .await
+            .unwrap();
+    }
+    rx
+}
+
+async fn recv_event(rx: &flume::Receiver<Event>, secs: u64) -> Event {
+    tokio::time::timeout(tokio::time::Duration::from_secs(secs), rx.recv_async())
+        .await
+        .expect("Timed out waiting for service event")
+        .expect("Service event channel closed")
+}
+
+/// Builds a BPA as node ipn:0.1 with an ingress CLA, and dispatches an
+/// inbound bundle from ipn:0.2.1 addressed to the local service ipn:0.1.7.
+async fn bpa_with_inbound(payload: &[u8]) -> (Bpa, Bytes) {
+    let node_ids = hardy_bpa::node_ids::NodeIds::try_from(
+        [NodeId::Ipn(IpnNodeId {
+            allocator_id: 0,
+            node_number: 1,
+        })]
+        .as_slice(),
+    )
+    .unwrap();
+    let bpa = Bpa::builder().node_ids(node_ids).build().await.unwrap();
+    bpa.start(false);
+
+    let inbound = build_bundle(
+        &"ipn:0.2.1".parse().unwrap(),
+        &"ipn:0.1.7".parse().unwrap(),
+        payload,
+    );
+
+    let cla = IngressCla::new();
+    bpa.register_cla("ingress".to_string(), cla.clone(), None)
+        .await
+        .unwrap();
+    cla.sink
+        .get()
+        .unwrap()
+        .dispatch(inbound.clone(), None, None)
+        .await
+        .unwrap();
+
+    (bpa, inbound)
+}
+
+// ---------------------------------------------------------------------------
+// Full-path tests: deliver_bundle -> on_receive_streamed
+// ---------------------------------------------------------------------------
+
+/// A streaming service receives the whole bundle as a single `Final`
+/// segment with an exact `total_len`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_service_receives_single_final_segment() {
+    let node_ids = hardy_bpa::node_ids::NodeIds::try_from(
+        [NodeId::Ipn(IpnNodeId {
+            allocator_id: 0,
+            node_number: 1,
+        })]
+        .as_slice(),
+    )
+    .unwrap();
+    let bpa = Bpa::builder().node_ids(node_ids).build().await.unwrap();
+    bpa.start(false);
+
+    let (svc, events_rx) = StreamingService::new(false);
+    bpa.register_service(hardy_bpv7::eid::Service::Ipn(7), svc.clone())
+        .await
+        .unwrap();
+
+    let cla = IngressCla::new();
+    bpa.register_cla("ingress".to_string(), cla.clone(), None)
+        .await
+        .unwrap();
+    cla.sink
+        .get()
+        .unwrap()
+        .dispatch(
+            build_bundle(
+                &"ipn:0.2.1".parse().unwrap(),
+                &"ipn:0.1.7".parse().unwrap(),
+                b"ping",
+            ),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let Event::Streamed {
+        segments,
+        total_len,
+    } = recv_event(&events_rx, 5).await
+    else {
+        panic!("Expected the streamed door, got another event");
+    };
+    assert_eq!(segments.len(), 1);
+    let Segment::Final(data) = &segments[0] else {
+        panic!("Expected a single Final segment");
+    };
+    assert_eq!(total_len, data.len() as u64);
+
+    let parsed = hardy_bpv7::bundle::ParsedBundle::parse(data, hardy_bpv7::bpsec::no_keys)
+        .expect("Failed to parse delivered bundle");
+    assert_eq!(parsed.bundle.id.source, "ipn:0.2.1".parse().unwrap());
+    assert_eq!(parsed.bundle.destination, "ipn:0.1.7".parse().unwrap());
+
+    assert!(events_rx.is_empty());
+    bpa.shutdown().await;
+}
+
+/// A service that only implements `on_receive` still receives the whole
+/// bundle, through the buffered default adapter.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn buffered_service_receives_whole_bundle_via_default_adapter() {
+    let (bpa, _inbound) = bpa_with_inbound(b"pong").await;
+
+    let (svc, events_rx) = BufferedService::new();
+    bpa.register_service(hardy_bpv7::eid::Service::Ipn(7), svc.clone())
+        .await
+        .unwrap();
+
+    let Event::Received(data) = recv_event(&events_rx, 5).await else {
+        panic!("Expected the buffered adapter to call on_receive");
+    };
+    let parsed = hardy_bpv7::bundle::ParsedBundle::parse(&data, hardy_bpv7::bpsec::no_keys)
+        .expect("Failed to parse delivered bundle");
+    assert_eq!(parsed.bundle.destination, "ipn:0.1.7".parse().unwrap());
+
+    bpa.shutdown().await;
+}
+
+/// A failed streamed delivery parks the bundle as WaitingForService, and a
+/// subsequent registration on the same EID re-delivers it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_streamed_delivery_parks_and_redelivers() {
+    let (bpa, _inbound) = bpa_with_inbound(b"park me").await;
+
+    let (failing_svc, failing_rx) = StreamingService::new(true);
+    bpa.register_service(hardy_bpv7::eid::Service::Ipn(7), failing_svc.clone())
+        .await
+        .unwrap();
+    assert!(matches!(recv_event(&failing_rx, 5).await, Event::Failed));
+
+    failing_svc.sink.get().unwrap().unregister().await;
+
+    let (svc, events_rx) = StreamingService::new(false);
+    bpa.register_service(hardy_bpv7::eid::Service::Ipn(7), svc.clone())
+        .await
+        .unwrap();
+
+    let Event::Streamed { segments, .. } = recv_event(&events_rx, 10).await else {
+        panic!("Expected re-delivery through the streamed door");
+    };
+    assert!(matches!(segments.last(), Some(Segment::Final(_))));
+
+    bpa.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// Direct-call tests: the default adapter body
+// ---------------------------------------------------------------------------
+
+fn expiry() -> time::OffsetDateTime {
+    time::OffsetDateTime::now_utc() + time::Duration::hours(1)
+}
+
+/// The default body reassembles a multi-segment stream before delegating.
+#[tokio::test]
+async fn default_body_concats_multi_segment_stream() {
+    let (svc, events_rx) = BufferedService::new();
+    let data = build_bundle(
+        &"ipn:0.1.1".parse().unwrap(),
+        &"ipn:0.2.99".parse().unwrap(),
+        b"payload",
+    );
+    let (head, tail) = (data.slice(..10), data.slice(10..));
+    let rx = feed(vec![Segment::Next(head), Segment::Final(tail)]).await;
+
+    services::Service::on_receive_streamed(&*svc, &rx, expiry(), data.len() as u64)
+        .await
+        .unwrap();
+
+    let Ok(Event::Received(received)) = events_rx.try_recv() else {
+        panic!("Expected on_receive to get the reassembled bundle");
+    };
+    assert_eq!(received, data);
+}
+
+/// A single-`Final` stream passes through the default body zero-copy.
+#[tokio::test]
+async fn default_body_is_zero_copy_for_single_final() {
+    let (svc, events_rx) = BufferedService::new();
+    let data = build_bundle(
+        &"ipn:0.1.1".parse().unwrap(),
+        &"ipn:0.2.99".parse().unwrap(),
+        b"payload",
+    );
+    let rx = feed(vec![Segment::Final(data.clone())]).await;
+
+    services::Service::on_receive_streamed(&*svc, &rx, expiry(), data.len() as u64)
+        .await
+        .unwrap();
+
+    let Ok(Event::Received(received)) = events_rx.try_recv() else {
+        panic!("Expected on_receive to get the bundle");
+    };
+    assert_eq!(received.as_ptr(), data.as_ptr());
+}
+
+/// A truncated stream is an error, and `on_receive` is never invoked — no
+/// partial bundle reaches the service.
+#[tokio::test]
+async fn default_body_truncated_stream_is_cancelled() {
+    let (svc, events_rx) = BufferedService::new();
+    let data = build_bundle(
+        &"ipn:0.1.1".parse().unwrap(),
+        &"ipn:0.2.99".parse().unwrap(),
+        b"payload",
+    );
+    let rx = feed(vec![Segment::Next(data.slice(..4))]).await;
+
+    let Err(err) =
+        services::Service::on_receive_streamed(&*svc, &rx, expiry(), data.len() as u64).await
+    else {
+        panic!("Expected a truncated stream to fail");
+    };
+    assert!(matches!(err, services::Error::StreamCancelled));
+    assert!(events_rx.is_empty());
+}
+
+/// A stream exceeding the declared `total_len` is rejected before
+/// delegation.
+#[tokio::test]
+async fn default_body_rejects_stream_exceeding_total_len() {
+    let (svc, events_rx) = BufferedService::new();
+    let data = build_bundle(
+        &"ipn:0.1.1".parse().unwrap(),
+        &"ipn:0.2.99".parse().unwrap(),
+        b"payload",
+    );
+    let rx = feed(vec![Segment::Final(data.clone())]).await;
+
+    let Err(err) = services::Service::on_receive_streamed(&*svc, &rx, expiry(), 4).await else {
+        panic!("Expected an oversize stream to fail");
+    };
+    assert!(matches!(
+        err,
+        services::Error::PayloadTooLarge { size, max: 4 } if size > 4
+    ));
+    assert!(events_rx.is_empty());
+}


### PR DESCRIPTION
Adds the streamed delivery primitive to the Service trait — the low-level half of the delivery seams (seams 4/5 in refactor_plan), companion to #<CLA-PR> which landed seam 6 (Cla::forward_streamed). Same recipe: a default-bodied _streamed method so the change is non-breaking, and the BPA switched to always use the streamed door.

````rust
async fn on_receive_streamed(
    &self,
    stream: &dyn crate::stream::Receiver<Segment>,
    expiry: time::OffsetDateTime,
    total_len: u64,
) -> Result<()>
````

Non-breaking: the provided default body buffers via concat_stream capped at total_len (with a usize pre-flight for 32-bit targets) and delegates to on_receive(); single-Final streams take the zero-copy fast path, so existing services receive the identical Bytes.

Delivery semantics preserved: Err — including on a truncated stream — parks the bundle as WaitingForService, and re-registration on the same EID re-delivers, exactly as on_receive documents. A truncated delivery must never surface as Ok.
Dispatcher: the ServiceImpl::LowLevel arm of deliver_bundle wraps the loaded bundle as a single Final segment (total_len = data.len()), mirroring the ingress Sink::dispatch idiom.

Application delivery (Application::on_receive) is deliberately untouched — the payload door involves BPSec decode and is bound up with the announce/collect design, tracked separately.

# Tests
New bpa/tests/on_receive_streamed.rs: full-path single-Final delivery with exact total_len; buffered-service round-trip through the default adapter; failed streamed delivery parks and re-registration re-delivers; direct-call adapter tests (multi-segment reassembly, zero-copy pointer equality, truncation → StreamCancelled with on_receive never invoked, total_len overrun → PayloadTooLarge).

Gates green: fmt --check, clippy --locked --all-targets --all-features -D warnings, test --locked --all-features --workspace (the two tcpclv4 socket-bind tests fail only in the development sandbox, identically on clean main).

# Merge notes (refactor train)
Unlike the CLA branch, both source files here are touched by the train: the services/mod.rs trait hunk is a self-contained insertion (trivial resolution), but the local.rs call-site hunk sits inside deliver_bundle, which the metadata leg rewrites — expect to re-apply the one-arm change there when the train lands.

# Follow-ups
Streamed Application delivery, as part of the announce/collect Deliver design (from refactor/grpc-api-v1).
BundleStorage::load_stream so delivery can stream from storage instead of wrapping a loaded buffer.

Design-doc note for the delivery seams once the announce/collect direction is settled (§6-style "Landed state" note deliberately deferred — this is one half of seams 4/5).