### PR TITLE
fix(bpa): claim terminal bundle resolutions with a conditional tombstone

### DIFF
--- a/bpa/src/dispatcher/forward.rs
+++ b/bpa/src/dispatcher/forward.rs
@@ -46,10 +46,16 @@ impl Dispatcher {
         let (pre_rewrite, data) = match self.update_extension_blocks(&bundle, data) {
             Err(e) => {
                 warn!("Failed to update extension blocks: {e}");
-                self.store
-                    .update_status(&mut bundle, &bundle::BundleStatus::Waiting)
-                    .await;
-                return self.store.watch_bundle(bundle).await;
+                // Conditional: the reaper can resolve the claimed bundle at
+                // any await, and the park must not resurrect a tombstone.
+                if self
+                    .store
+                    .swap_status(&mut bundle, &bundle::BundleStatus::Waiting)
+                    .await
+                {
+                    self.store.watch_bundle(bundle).await;
+                }
+                return;
             }
             Ok((new_bundle, data)) => (core::mem::replace(&mut bundle.bundle, new_bundle), data),
         };
@@ -106,6 +112,18 @@ impl Dispatcher {
             .await
         {
             Ok(cla::ForwardBundleResult::Sent) => {
+                // The terminal claim is a conditional tombstone: the reaper
+                // races a bundle that expires during a synchronous transmit,
+                // and losing the claim means its deletion report has gone
+                // out. The forwarded report is suppressed with the rest:
+                // a lost resolution never happened.
+                if !self.store.tombstone_if(&bundle).await {
+                    debug!(
+                        "Forward completion for {} lost the resolution race, ignored",
+                        bundle.bundle.id
+                    );
+                    return;
+                }
                 metrics::counter!("bpa.bundle.forwarded").increment(1);
                 self.report_bundle_forwarded(&bundle).await;
 
@@ -137,10 +155,15 @@ impl Dispatcher {
         // original) and return it to Waiting for a fresh routing decision
         // along with the rest of the peer's queue.
         bundle.bundle = pre_rewrite;
-        self.store
-            .update_status(&mut bundle, &bundle::BundleStatus::Waiting)
-            .await;
-        self.store.watch_bundle(bundle).await;
+        // Conditional for the same reason: losing the swap means the reaper
+        // or a sweep resolved the bundle while the CLA held the call.
+        if self
+            .store
+            .swap_status(&mut bundle, &bundle::BundleStatus::Waiting)
+            .await
+        {
+            self.store.watch_bundle(bundle).await;
+        }
         self.store.reset_peer_queue(peer).await;
     }
 

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -278,8 +278,8 @@ impl Dispatcher {
                 service: service_eid,
             };
             // Conditional: the reaper expires bundles regardless of status,
-            // so it may have resolved this one mid-delivery — the park must
-            // not resurrect a tombstoned bundle.
+            // so it may have resolved this one mid-delivery, and the park
+            // must not resurrect a tombstoned bundle.
             if self.store.swap_status(&mut bundle, &desired).await {
                 self.store.watch_bundle(bundle).await;
             }
@@ -288,7 +288,7 @@ impl Dispatcher {
 
         // The terminal claim is a conditional tombstone: the reaper races
         // in-flight deliveries, and losing the claim means it resolved the
-        // bundle first — its "Lifetime expired" deletion report has gone
+        // bundle first. Its "Lifetime expired" deletion report has gone
         // out, so this delivery must stay silent rather than contradict it.
         if !self.store.tombstone_if(&bundle).await {
             debug!(

--- a/bpa/src/dispatcher/local.rs
+++ b/bpa/src/dispatcher/local.rs
@@ -277,8 +277,25 @@ impl Dispatcher {
             let desired = bundle::BundleStatus::WaitingForService {
                 service: service_eid,
             };
-            self.store.update_status(&mut bundle, &desired).await;
-            return self.store.watch_bundle(bundle).await;
+            // Conditional: the reaper expires bundles regardless of status,
+            // so it may have resolved this one mid-delivery — the park must
+            // not resurrect a tombstoned bundle.
+            if self.store.swap_status(&mut bundle, &desired).await {
+                self.store.watch_bundle(bundle).await;
+            }
+            return;
+        }
+
+        // The terminal claim is a conditional tombstone: the reaper races
+        // in-flight deliveries, and losing the claim means it resolved the
+        // bundle first — its "Lifetime expired" deletion report has gone
+        // out, so this delivery must stay silent rather than contradict it.
+        if !self.store.tombstone_if(&bundle).await {
+            debug!(
+                "Delivery completion for {} lost the resolution race, ignored",
+                bundle.bundle.id
+            );
+            return;
         }
 
         metrics::counter!("bpa.bundle.delivered").increment(1);

--- a/bpa/src/dispatcher/mod.rs
+++ b/bpa/src/dispatcher/mod.rs
@@ -151,8 +151,22 @@ impl Dispatcher {
         }
     }
 
+    // Every drop is a terminal resolution, claimed with a conditional
+    // tombstone. Callers own their bundle through the pipeline's claim
+    // discipline, but the reaper expires bundles regardless of owner, so
+    // any drop can race it — and it races them. Losing the claim means
+    // another resolver's deletion report has gone out; this one stays
+    // silent rather than contradict it. Callers therefore pass a bundle
+    // whose metadata is already stored, with a current status snapshot.
     #[cfg_attr(feature = "instrument", instrument(skip(self, bundle)))]
     pub async fn drop_bundle(&self, bundle: bundle::Bundle, reason: ReasonCode) {
+        if !self.store.tombstone_if(&bundle).await {
+            debug!(
+                "Drop of bundle {} lost the resolution race, ignored",
+                bundle.bundle.id
+            );
+            return;
+        }
         metrics::counter!("bpa.bundle.dropped", "reason" => crate::otel_metrics::reason_label(&reason)).increment(1);
         self.report_bundle_deletion(&bundle, reason).await;
         self.delete_bundle(bundle).await

--- a/bpa/src/dispatcher/mod.rs
+++ b/bpa/src/dispatcher/mod.rs
@@ -154,7 +154,7 @@ impl Dispatcher {
     // Every drop is a terminal resolution, claimed with a conditional
     // tombstone. Callers own their bundle through the pipeline's claim
     // discipline, but the reaper expires bundles regardless of owner, so
-    // any drop can race it — and it races them. Losing the claim means
+    // any drop can race it, and it races them. Losing the claim means
     // another resolver's deletion report has gone out; this one stays
     // silent rather than contradict it. Callers therefore pass a bundle
     // whose metadata is already stored, with a current status snapshot.

--- a/bpa/tests/on_deliver.rs
+++ b/bpa/tests/on_deliver.rs
@@ -164,7 +164,7 @@ impl services::Service for BufferedService {
 }
 
 /// Holds every delivery open until released, then drains the stream and
-/// completes `Ok` — a delivery deliberately still in flight when something
+/// completes `Ok`: a delivery deliberately still in flight when something
 /// else (the expiry reaper) resolves the bundle.
 struct HoldingService {
     sink: hardy_async::sync::spin::Once<Box<dyn services::ServiceSink>>,
@@ -536,17 +536,43 @@ async fn expiry_mid_delivery_resolves_once() {
 
     // ...when the bundle expires: the reaper resolves it, and the deletion
     // report (the only report this bundle requests) reaches report_to.
-    assert!(matches!(
-        recv_event(&reports_rx, 10).await,
-        Event::Streamed { .. }
-    ));
+    let Event::Streamed { segments, .. } = recv_event(&reports_rx, 10).await else {
+        panic!("Expected the deletion report at report_to");
+    };
+
+    // Pin the winner's identity: the report is the *reaper's* deletion
+    // report, citing LifetimeExpired. If the claim logic ever inverted,
+    // a delivered/deleted pair from the completion would fail here.
+    let Some(hardy_bpa::stream::Segment::Final(report)) = segments.last() else {
+        panic!("Expected a whole report bundle");
+    };
+    let parsed = hardy_bpv7::bundle::ParsedBundle::parse(report, hardy_bpv7::bpsec::no_keys)
+        .expect("Failed to parse report bundle");
+    let payload = report.slice(parsed.bundle.blocks.get(&1).unwrap().payload_range());
+    let hardy_bpv7::status_report::AdministrativeRecord::BundleStatusReport(status) =
+        hardy_cbor::decode::parse(payload.as_ref()).expect("Failed to parse admin record");
+    assert!(status.deleted.is_some(), "expected a deletion assertion");
+    assert!(status.received.is_none() && status.delivered.is_none());
+    assert_eq!(
+        status.reason,
+        hardy_bpv7::status_report::ReasonCode::LifetimeExpired
+    );
 
     // Release the held delivery: its completion must lose the terminal
-    // claim silently — no delivered/deleted reporting after the reaper's.
+    // claim silently, with no delivered/deleted reporting after the
+    // reaper's. A bounded negative wait: any wrongly-emitted report pair
+    // would arrive through the live pipeline well within it. (Shutdown is
+    // not usable as the barrier here: it closes the dispatch channel
+    // before joining the pool, so a late report would be dropped unsent
+    // and the assertion would pass vacuously.)
     release_tx.send(()).expect("Holding service gone");
-    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
     assert!(
-        reports_rx.is_empty(),
+        tokio::time::timeout(
+            tokio::time::Duration::from_millis(1000),
+            reports_rx.recv_async()
+        )
+        .await
+        .is_err(),
         "the completed delivery re-resolved the expired bundle"
     );
 

--- a/bpa/tests/on_deliver.rs
+++ b/bpa/tests/on_deliver.rs
@@ -163,6 +163,71 @@ impl services::Service for BufferedService {
     }
 }
 
+/// Holds every delivery open until released, then drains the stream and
+/// completes `Ok` — a delivery deliberately still in flight when something
+/// else (the expiry reaper) resolves the bundle.
+struct HoldingService {
+    sink: hardy_async::sync::spin::Once<Box<dyn services::ServiceSink>>,
+    started_tx: flume::Sender<()>,
+    release_rx: flume::Receiver<()>,
+}
+
+impl HoldingService {
+    fn new() -> (Arc<Self>, flume::Receiver<()>, flume::Sender<()>) {
+        let (started_tx, started_rx) = flume::bounded(1);
+        let (release_tx, release_rx) = flume::bounded(1);
+        (
+            Arc::new(Self {
+                sink: hardy_async::sync::spin::Once::new(),
+                started_tx,
+                release_rx,
+            }),
+            started_rx,
+            release_tx,
+        )
+    }
+}
+
+#[async_trait]
+impl services::Service for HoldingService {
+    async fn on_register(&self, _endpoint: &Eid, sink: Box<dyn services::ServiceSink>) {
+        self.sink.call_once(|| sink);
+    }
+
+    async fn on_unregister(&self) {}
+
+    async fn on_deliver(
+        &self,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        _expiry: time::OffsetDateTime,
+        _total_len: u64,
+        stream: &mut dyn Receiver<Segment>,
+    ) -> services::Result<()> {
+        let _ = self.started_tx.send(());
+        let _ = self.release_rx.recv_async().await;
+        // The race under test is the completion claim, not the stream: the
+        // delivery's buffer was loaded before the reaper ran, so it still
+        // drains to Final.
+        loop {
+            match stream.recv().await {
+                Ok(Segment::Final(_)) | Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_status_notify(
+        &self,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        _from: &Eid,
+        _kind: services::StatusNotify,
+        _reason: hardy_bpv7::status_report::ReasonCode,
+        _timestamp: Option<time::OffsetDateTime>,
+    ) {
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Minimal CLA to inject inbound bundles
 // ---------------------------------------------------------------------------
@@ -389,6 +454,101 @@ async fn failed_streamed_delivery_parks_and_redelivers() {
         panic!("Expected re-delivery through the streamed door");
     };
     assert!(matches!(segments.last(), Some(Segment::Final(_))));
+
+    bpa.shutdown().await;
+}
+
+/// A bundle that expires while its delivery is in flight is resolved
+/// exactly once. The reaper wins the conditional terminal claim and sends
+/// the only deletion report; the delivery's completion loses the claim and
+/// stays silent instead of contradicting it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expiry_mid_delivery_resolves_once() {
+    let node_ids = hardy_bpa::node_ids::NodeIds::try_from(
+        [NodeId::Ipn(IpnNodeId {
+            allocator_id: 0,
+            node_number: 1,
+        })]
+        .as_slice(),
+    )
+    .unwrap();
+    let bpa = Bpa::builder()
+        .node_ids(node_ids)
+        .status_reports(true)
+        .build()
+        .await
+        .unwrap();
+    bpa.start(false);
+
+    // Deletion reports are addressed to ipn:0.1.9: a local capture service.
+    let (reports, reports_rx) = StreamingService::new(false);
+    bpa.register_service(hardy_bpv7::eid::Service::Ipn(9), reports.clone())
+        .await
+        .unwrap();
+
+    // A first delivery attempt fails, parking the bundle as
+    // WaitingForService — which is also what places it on the reaper's
+    // expiry watch list.
+    let (failing_svc, failing_rx) = StreamingService::new(true);
+    bpa.register_service(hardy_bpv7::eid::Service::Ipn(7), failing_svc.clone())
+        .await
+        .unwrap();
+
+    let (_, data) = hardy_bpv7::builder::Builder::new(
+        "ipn:0.2.1".parse().unwrap(),
+        "ipn:0.1.7".parse().unwrap(),
+    )
+    .with_report_to("ipn:0.1.9".parse().unwrap())
+    .with_flags(hardy_bpv7::bundle::Flags {
+        delete_report_requested: true,
+        ..Default::default()
+    })
+    .with_lifetime(core::time::Duration::from_millis(2000))
+    .with_payload(std::borrow::Cow::Borrowed(b"expire me".as_slice()))
+    .build(hardy_bpv7::creation_timestamp::CreationTimestamp::now())
+    .expect("Failed to build bundle");
+
+    let cla = IngressCla::new();
+    bpa.register_cla("ingress".to_string(), cla.clone(), None)
+        .await
+        .unwrap();
+    cla.sink
+        .get()
+        .unwrap()
+        .dispatch(None, None, &mut Bytes::from(data))
+        .await
+        .unwrap();
+    assert!(matches!(recv_event(&failing_rx, 5).await, Event::Failed));
+
+    // Re-register with a service that holds the redelivery open across
+    // the bundle's expiry.
+    failing_svc.sink.get().unwrap().unregister().await;
+    let (svc, started_rx, release_tx) = HoldingService::new();
+    bpa.register_service(hardy_bpv7::eid::Service::Ipn(7), svc.clone())
+        .await
+        .unwrap();
+
+    // The redelivery is in flight...
+    tokio::time::timeout(tokio::time::Duration::from_secs(5), started_rx.recv_async())
+        .await
+        .expect("Timed out waiting for the delivery to start")
+        .expect("Holding service gone");
+
+    // ...when the bundle expires: the reaper resolves it, and the deletion
+    // report (the only report this bundle requests) reaches report_to.
+    assert!(matches!(
+        recv_event(&reports_rx, 10).await,
+        Event::Streamed { .. }
+    ));
+
+    // Release the held delivery: its completion must lose the terminal
+    // claim silently — no delivered/deleted reporting after the reaper's.
+    release_tx.send(()).expect("Holding service gone");
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+    assert!(
+        reports_rx.is_empty(),
+        "the completed delivery re-resolved the expired bundle"
+    );
 
     bpa.shutdown().await;
 }

--- a/bpa/tests/on_deliver.rs
+++ b/bpa/tests/on_deliver.rs
@@ -7,13 +7,18 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
+use hardy_bpa::storage::{MetadataMemStorage, MetadataStorage};
 use hardy_bpa::{
     Bytes, async_trait,
     bpa::{Bpa, BpaRegistration},
     cla, services,
     stream::{Receiver, Segment},
 };
-use hardy_bpv7::eid::{Eid, IpnNodeId, NodeId};
+use hardy_bpv7::{
+    bundle::ParsedBundle,
+    eid::{Eid, IpnNodeId, NodeId},
+    status_report::{AdministrativeRecord, ReasonCode},
+};
 
 // ---------------------------------------------------------------------------
 // Events observed by the mock services
@@ -472,9 +477,11 @@ async fn expiry_mid_delivery_resolves_once() {
         .as_slice(),
     )
     .unwrap();
+    let metadata_store = Arc::new(MetadataMemStorage::new(None));
     let bpa = Bpa::builder()
         .node_ids(node_ids)
         .status_reports(true)
+        .metadata_storage(metadata_store.clone())
         .build()
         .await
         .unwrap();
@@ -528,7 +535,7 @@ async fn expiry_mid_delivery_resolves_once() {
         .await
         .unwrap();
 
-    // The redelivery is in flight...
+    // The redelivery is in flight (the timeout only bounds a regression)...
     tokio::time::timeout(tokio::time::Duration::from_secs(5), started_rx.recv_async())
         .await
         .expect("Timed out waiting for the delivery to start")
@@ -546,37 +553,38 @@ async fn expiry_mid_delivery_resolves_once() {
     let Some(hardy_bpa::stream::Segment::Final(report)) = segments.last() else {
         panic!("Expected a whole report bundle");
     };
-    let parsed = hardy_bpv7::bundle::ParsedBundle::parse(report, hardy_bpv7::bpsec::no_keys)
+    let parsed = ParsedBundle::parse(report, hardy_bpv7::bpsec::no_keys)
         .expect("Failed to parse report bundle");
     let payload = report.slice(parsed.bundle.blocks.get(&1).unwrap().payload_range());
-    let hardy_bpv7::status_report::AdministrativeRecord::BundleStatusReport(status) =
+    let AdministrativeRecord::BundleStatusReport(status) =
         hardy_cbor::decode::parse(payload.as_ref()).expect("Failed to parse admin record");
     assert!(status.deleted.is_some(), "expected a deletion assertion");
     assert!(status.received.is_none() && status.delivered.is_none());
-    assert_eq!(
-        status.reason,
-        hardy_bpv7::status_report::ReasonCode::LifetimeExpired
-    );
+    assert_eq!(status.reason, ReasonCode::LifetimeExpired);
 
     // Release the held delivery: its completion must lose the terminal
     // claim silently, with no delivered/deleted reporting after the
-    // reaper's. A bounded negative wait: any wrongly-emitted report pair
-    // would arrive through the live pipeline well within it. (Shutdown is
-    // not usable as the barrier here: it closes the dispatch channel
-    // before joining the pool, so a late report would be dropped unsent
-    // and the assertion would pass vacuously.)
+    // reaper's. shutdown() is the barrier: it joins the pools, so by the
+    // time it returns a wrongly-emitted second report has either been
+    // delivered (visible on reports_rx) or persisted-then-stranded when
+    // the dispatch channel closed (visible as live metadata below).
+    // Both are asserted empty; no quiet window is involved.
     release_tx.send(()).expect("Holding service gone");
+    bpa.shutdown().await;
     assert!(
-        tokio::time::timeout(
-            tokio::time::Duration::from_millis(1000),
-            reports_rx.recv_async()
-        )
-        .await
-        .is_err(),
+        reports_rx.is_empty(),
         "the completed delivery re-resolved the expired bundle"
     );
-
-    bpa.shutdown().await;
+    let (live_tx, live_rx) = hardy_async::channel::bounded(16);
+    metadata_store
+        .poll_expiry(&live_tx, 16)
+        .await
+        .expect("Failed to poll metadata store");
+    drop(live_tx);
+    assert!(
+        live_rx.recv().await.is_err(),
+        "a resolved bundle left live metadata behind"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The expiry reaper resolves bundles regardless of which task currently owns them, and both it and the owners resolved unconditionally: a bundle expiring while its delivery (or any drop) was in flight could be resolved twice, emitting contradictory deletion reports to report_to ("Lifetime expired" from the reaper, then delivered + "No additional information" from the completing delivery) and double-decrementing the status gauge.

Every terminal resolution is now a compare-and-swap claim, with the losing side staying silent:

- drop_bundle claims via Store::tombstone_if before reporting, covering every drop site (reaper expiry, filter drops, admin, depleted storage).
- deliver_bundle's completion claims the same way, kept apart from drop_bundle so a delivery never counts as a dropped bundle.
- deliver_bundle's Err park swaps conditionally out of Dispatching, so a deferred delivery cannot resurrect a bundle the reaper has tombstoned.

This mirrors the conditional-tombstone shape the CLA transfer-outcome path already uses, independently arrived at by refactor/grpc-api-v1's complete_delivery. The race matters most once deliveries can be held open: an announce-then-pull bridge holds toward expiry, where the two resolvers practically synchronise.

The regression test parks a bundle (arming the reaper's watch list), redelivers into a service that holds the stream across expiry, and asserts report_to sees exactly one deletion report.

Signed-off-by: Rick Taylor <rtaylor@aalyria.com>