### PR TITLE
ci: parallelize the jobs and cache protoc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,9 +19,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  PROTOC_VERSION: "29.3"
 
 jobs:
-  build:
+  checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -32,10 +33,28 @@ jobs:
       - name: Use cached dependencies and artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          shared-key: checks
 
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      # The release-asset URL is a plain CDN download, not the GitHub API,
+      # so it is not subject to API rate limits; with the cache it only
+      # runs at all when PROTOC_VERSION changes.
+      - name: Cache protoc
+        id: protoc-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/protoc
+          key: protoc-${{ env.PROTOC_VERSION }}-linux-x86_64
+
+      - name: Install protoc (cache miss)
+        if: steps.protoc-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+          mkdir -p "$HOME/.local/protoc"
+          unzip -q /tmp/protoc.zip -d "$HOME/.local/protoc"
+
+      - name: Add protoc to PATH
+        run: echo "$HOME/.local/protoc/bin" >> "$GITHUB_PATH"
 
       - name: Check formatting
         run: cargo fmt --check
@@ -43,8 +62,85 @@ jobs:
       - name: Check linting
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
-      - name: Build all tests
-        run: cargo test --no-run --locked --all-features --workspace
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Use cached dependencies and artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: tests
+
+      - name: Cache protoc
+        id: protoc-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/protoc
+          key: protoc-${{ env.PROTOC_VERSION }}-linux-x86_64
+
+      - name: Install protoc (cache miss)
+        if: steps.protoc-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+          mkdir -p "$HOME/.local/protoc"
+          unzip -q /tmp/protoc.zip -d "$HOME/.local/protoc"
+
+      - name: Add protoc to PATH
+        run: echo "$HOME/.local/protoc/bin" >> "$GITHUB_PATH"
+
+      - name: Start postgres and minio
+        run: docker compose up -d --wait postgres minio
+
+      - name: Create S3 test bucket
+        run: |
+          docker compose exec minio \
+            mc alias set local http://localhost:9000 minioadmin minioadmin
+          docker compose exec minio \
+            mc mb --ignore-existing local/hardy-test
+
+      - name: Run tests
+        env:
+          TEST_POSTGRES_URL: postgresql://hardy:hardy@localhost:5432
+          TEST_S3_ENDPOINT: http://localhost:9000
+          AWS_ACCESS_KEY_ID: minioadmin
+          AWS_SECRET_ACCESS_KEY: minioadmin
+        run: cargo test --locked --all-features --workspace
+
+      - name: Stop postgres and minio
+        if: always()
+        run: docker compose down -v
+
+      - name: Build ping test binaries
+        run: cargo build --locked --all-features -p hardy-bpa-server -p hardy-tools
+
+      - name: Run ping tests
+        env:
+          BP_BIN: ./target/debug/bp
+          HARDY_BPA_SERVER_CONFIG_FILE: ${{ runner.temp }}/hardy-ping.yaml
+        run: |
+          cat > "$HARDY_BPA_SERVER_CONFIG_FILE" <<'EOF'
+          log-level: info
+          node-ids: ["ipn:1.0"]
+          status-reports: true
+          built-in-services:
+            echo: [7]
+          storage:
+            metadata:
+              type: memory
+            bundle:
+              type: memory
+          clas:
+            - name: cl0
+              type: tcpclv4
+              listeners: ["[::]:4556"]
+          EOF
+          ./target/debug/hardy-bpa-server &
+          bash ./tests/interop/hardy/run_hardy_ping_test.sh --peer 127.0.0.1:4556 --count 5
 
   no-std:
     runs-on: ubuntu-latest
@@ -89,113 +185,6 @@ jobs:
           -p hardy-eid-patterns
           --target thumbv7em-none-eabihf
 
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-          save-if: false
-
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Run tests
-        run: cargo test --locked --all-features --verbose --workspace --exclude storage-tests
-
-  storage-tests:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-          save-if: false
-
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Start postgres and minio
-        run: |
-          docker compose up -d --wait postgres minio
-
-      - name: Create S3 test bucket
-        run: |
-          docker compose exec minio \
-            mc alias set local http://localhost:9000 minioadmin minioadmin
-          docker compose exec minio \
-            mc mb --ignore-existing local/hardy-test
-
-      - name: Run storage tests
-        env:
-          TEST_POSTGRES_URL: postgresql://hardy:hardy@localhost:5432
-          TEST_S3_ENDPOINT: http://localhost:9000
-          AWS_ACCESS_KEY_ID: minioadmin
-          AWS_SECRET_ACCESS_KEY: minioadmin
-        run: cargo test -p storage-tests --locked --features postgres,s3 --verbose
-
-      - name: Cleanup
-        if: always()
-        run: docker compose down -v
-
-  ping-tests:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-          save-if: false
-
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Build binaries
-        run: cargo build --locked --all-features -p hardy-bpa-server -p hardy-tools
-
-      - name: Run ping tests
-        env:
-          BP_BIN: ./target/debug/bp
-          HARDY_BPA_SERVER_CONFIG_FILE: ${{ runner.temp }}/hardy-ping.yaml
-        run: |
-          cat > "$HARDY_BPA_SERVER_CONFIG_FILE" <<'EOF'
-          log-level: info
-          node-ids: ["ipn:1.0"]
-          status-reports: true
-          built-in-services:
-            echo: [7]
-          storage:
-            metadata:
-              type: memory
-            bundle:
-              type: memory
-          clas:
-            - name: cl0
-              type: tcpclv4
-              listeners: ["[::]:4556"]
-          EOF
-          ./target/debug/hardy-bpa-server &
-          bash ./tests/interop/hardy/run_hardy_ping_test.sh --peer 127.0.0.1:4556 --count 5
-
   msrv:
     runs-on: ubuntu-latest
     steps:
@@ -215,8 +204,23 @@ jobs:
         with:
           shared-key: msrv
 
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Cache protoc
+        id: protoc-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/protoc
+          key: protoc-${{ env.PROTOC_VERSION }}-linux-x86_64
+
+      - name: Install protoc (cache miss)
+        if: steps.protoc-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+          mkdir -p "$HOME/.local/protoc"
+          unzip -q /tmp/protoc.zip -d "$HOME/.local/protoc"
+
+      - name: Add protoc to PATH
+        run: echo "$HOME/.local/protoc/bin" >> "$GITHUB_PATH"
 
       - name: Check on MSRV
         run: cargo check --locked --all-features --workspace


### PR DESCRIPTION
# Restructure the CI into parallel jobs with a cached protoc

## Background

The Rust workflow ran six jobs: `build` (format, lint, compile the tests), then `test`, `storage-tests`, and `ping-tests` fanned out behind it via `needs`, with `no-std` and `msrv` on the side. The fan-out shape meant every downstream job paid the full runner preamble (checkout, toolchain, ~1 minute of `rust-cache` restore, and an apt protoc install) to run a few seconds of already-compiled tests, and nothing test-related could start until `build` finished. Five of the six jobs installed protoc with `apt-get update && apt-get install`, where the `update` alone costs 20 to 40 seconds per job.

## What this changes and why

The six jobs become four fully independent ones, with no `needs` chains: wall time is the slowest job, not a build-then-fan-out sum.

| Job | Runs | Cache key | Protoc |
|---|---|---|---|
| `checks` | `cargo fmt --check`, `cargo clippy -D warnings` | `checks` | yes |
| `tests` | the whole workspace test run (storage suites included), then the ping e2e | `tests` | yes |
| `no-std` | 32-bit bare-metal compile checks | `no-std` | no |
| `msrv` | `cargo check` on the MSRV toolchain | `msrv` | yes |

Two decisions carry the design:

- **Lint and test split into parallel jobs because they share no build artifacts anyway.** Clippy produces check-profile metadata; `cargo test` produces debug objects. Running them on two runners duplicates almost no compilation, unlike the old fan-out, which restored the same debug artifacts onto three runners. Each job saves its own `rust-cache` key, so neither clobbers the other's cache.
- **Everything that shares the debug target dir stays in one job.** The workspace tests, the service-backed storage suites, and the ping e2e all consume the same build, so they are sequential steps of `tests` rather than jobs: splitting them is what made the old layout pay three runner preambles for seconds of work. `--all-features` activates `storage-tests`' `postgres,s3` features, so one `cargo test --workspace` invocation now covers what used to be two jobs, with postgres and minio brought up beside it.

## The protoc install

The apt install is replaced by one `actions/cache` entry keyed on a `PROTOC_VERSION` workflow variable and shared by every job that needs protoc. On a cache hit, which is every run except the one after a version bump, the binary materializes with no network access at all. On a miss, the fill is a direct download of the GitHub release asset: that URL is plain CDN, not the GitHub API, so it is not subject to the API rate limits that actions like `arduino/setup-protoc` hit when they list releases. Bumping `PROTOC_VERSION` is the whole upgrade procedure.

## The cost and wall-time impact

- Three runner preambles per PR run are gone (checkout, toolchain, cache restore, protoc, times the three old fan-out jobs), and with them four `apt-get update` runs.
- Nothing waits on a `build` job anymore: `checks` and `tests` start together, and a formatting failure still surfaces in the first minute because it is the first step of `checks`.
- One cache save per key instead of one save plus three restores of the same key.

## Deliberate choices and named follow-ups

- **Branch protection must be updated with the merge:** the required checks are now `checks` and `tests`; the old `build`, `test`, and `storage-tests` check names no longer exist.
- **`no-std` and `msrv` stay separate** because they use a different target and a different toolchain respectively: merging either into the main jobs would poison the shared caches.
- **`cargo-nextest` is the next wall-time lever, not taken here.** It would parallelize the workspace's many test binaries inside `tests` (with `cargo test --doc` kept alongside for doctests), but it changes the test runner's execution model, so it deserves its own change.
- The docker services start with `up -d --wait` immediately before the test step; if image pulls ever dominate, the pull can overlap the earlier steps, a readability trade that is not worth it today.
