### PR TITLE
fix(bibe)!: encode the encapsulated bundle as a byte string

### DIFF
--- a/bibe/docs/design.md
+++ b/bibe/docs/design.md
@@ -786,6 +786,8 @@ BIBE-PDU = [
 
 For complete (non-segmented) bundles, `transmission-id`, `total-length`, and `segmented-offset` are all set to zero. This adds 3 bytes overhead but simplifies processing since BIBE-PDU is always a 4-element array, and enables future segmentation support.
 
+A PDU with any non-zero field is a segment of a larger bundle. Until segmentation is implemented, the decapsulation service rejects such PDUs rather than dispatch a partial bundle as if it were complete.
+
 **Example (complete bundle):**
 
 ```cbor

--- a/bibe/src/cla.rs
+++ b/bibe/src/cla.rs
@@ -61,7 +61,7 @@ impl BibeCla {
     }
 
     /// Encapsulate an inner bundle into an outer bundle.
-    fn encapsulate(&self, inner: Bytes, outer_dest: Eid) -> Result<Bytes, Error> {
+    pub fn encapsulate(&self, inner: Bytes, outer_dest: Eid) -> Result<Bytes, Error> {
         // Parse inner bundle to get lifetime for outer bundle
         let parsed = ParsedBundle::parse(&inner, bpsec::no_keys)?;
         let lifetime = parsed.bundle.lifetime;
@@ -73,7 +73,11 @@ impl BibeCla {
             a.emit(&0u64); // transmission-id
             a.emit(&0u64); // total-length
             a.emit(&0u64); // segmented-offset
-            a.emit(inner.as_ref()); // encapsulated-bundle-segment
+
+            // encapsulated-bundle-segment, as a definite-length byte string
+            // (a bare `&[u8]` would encode as a CBOR array of integers, which
+            // decapsulation rejects)
+            a.emit(&hardy_cbor::encode::Bytes(inner.as_ref()));
         });
 
         let (_bundle, data) =

--- a/bibe/src/cla.rs
+++ b/bibe/src/cla.rs
@@ -1,23 +1,21 @@
-use alloc::borrow::Cow;
+use alloc::boxed::Box;
 use core::num::NonZeroU32;
 
 use hardy_async::sync::spin::Once;
 use hardy_bpa::{
     Bytes, async_trait,
-    cla::{Cla, ClaAddress, ForwardBundleResult, Sink},
+    cla::{Cla, ClaAddress, ForwardBundleResult, Result as ClaResult, Segment, Sink},
     stream::{Receiver, buffer_stream},
 };
 use hardy_bpv7::{
-    builder::Builder,
     bundle::Id,
-    creation_timestamp::CreationTimestamp,
     eid::{Eid, NodeId},
-    parse::Parsed,
 };
-use hardy_cbor::encode::{emit, emit_array};
+use hardy_cbor::{decode, encode};
 use tracing::{debug, warn};
 
-use crate::Error;
+use crate::{Error, pdu};
+
 /// BIBE CLA for encapsulation.
 ///
 /// Implements `forward()` to encapsulate bundles and re-inject them into the BPA.
@@ -50,7 +48,7 @@ impl BibeCla {
     /// will be encapsulated with `decap_endpoint` as the outer destination.
     pub async fn add_tunnel(&self, tunnel_id: NodeId, decap_endpoint: Eid) -> Result<(), Error> {
         // Encode the decap endpoint as CBOR
-        let cbor_bytes = emit(&decap_endpoint).0;
+        let cbor_bytes = encode::emit(&decap_endpoint).0;
         let cla_addr = ClaAddress::Private(cbor_bytes.into());
 
         // Register as a peer - this creates the local route entry
@@ -68,45 +66,13 @@ impl BibeCla {
     // a complete bundle in memory, so it enters the BPA as a one-segment
     // stream (`Bytes` is a `stream::Receiver`). This is a deliberate stepping stone toward
     // the full streaming pipeline; see bpa/docs/streaming_pipeline_design.md.
-    pub(crate) async fn dispatch(&self, mut bundle: Bytes) -> Result<(), Error> {
+    pub async fn dispatch(&self, mut bundle: Bytes) -> Result<(), Error> {
         self.sink
             .get()
             .ok_or(Error::NotRegistered)?
             .dispatch(None, None, &mut bundle)
             .await?;
         Ok(())
-    }
-
-    /// Encapsulate an inner bundle into an outer bundle.
-    pub fn encapsulate(&self, inner: Bytes, outer_dest: Eid) -> Result<Bytes, Error> {
-        // Parse inner bundle structurally to read its lifetime.
-        let Parsed {
-            data: inner,
-            bundle: parsed_bundle,
-            ..
-        } = hardy_bpv7::parse::parse(inner)?;
-        let lifetime = parsed_bundle.primary.lifetime;
-
-        // Build outer bundle with BIBE-PDU payload:
-        // [transmission-id, total-length, segmented-offset, encapsulated-bundle-segment]
-        // For complete bundles: [0, 0, 0, bundle-bytes]
-        let payload = emit_array(Some(4), |a| {
-            a.emit(&0u64); // transmission-id
-            a.emit(&0u64); // total-length
-            a.emit(&0u64); // segmented-offset
-
-            // encapsulated-bundle-segment, as a definite-length byte string
-            // (a bare `&[u8]` would encode as a CBOR array of integers, which
-            // decapsulation rejects)
-            a.emit(&hardy_cbor::encode::Bytes(inner.as_ref()));
-        });
-
-        let (_bundle, data) = Builder::new(self.tunnel_source.clone(), outer_dest)
-            .with_lifetime(lifetime)
-            .with_payload(Cow::Owned(payload))
-            .build(CreationTimestamp::now())?;
-
-        Ok(data.into())
     }
 }
 
@@ -136,8 +102,8 @@ impl Cla for BibeCla {
         cla_addr: &ClaAddress,
         _bundle_id: &Id,
         total_len: u64,
-        stream: &mut dyn Receiver<hardy_bpa::cla::Segment>,
-    ) -> hardy_bpa::cla::Result<ForwardBundleResult> {
+        stream: &mut dyn Receiver<Segment>,
+    ) -> ClaResult<ForwardBundleResult> {
         let bundle = buffer_stream(stream, total_len).await?;
 
         // Decode destination EID from CBOR in ClaAddress
@@ -146,7 +112,7 @@ impl Cla for BibeCla {
             return Ok(ForwardBundleResult::NoNeighbour);
         };
 
-        let outer_dest: Eid = match hardy_cbor::decode::parse(dest_bytes) {
+        let outer_dest: Eid = match decode::parse(dest_bytes) {
             Ok(eid) => eid,
             Err(e) => {
                 warn!("Failed to decode destination EID from ClaAddress: {e}");
@@ -157,7 +123,7 @@ impl Cla for BibeCla {
         debug!("BIBE encapsulating bundle to {outer_dest}");
 
         // Encapsulate the bundle
-        let outer = match self.encapsulate(bundle, outer_dest) {
+        let outer = match pdu::encapsulate(&self.tunnel_source, bundle, outer_dest) {
             Ok(outer) => outer,
             Err(e) => {
                 warn!("BIBE encapsulation failed: {e}");

--- a/bibe/src/cla.rs
+++ b/bibe/src/cla.rs
@@ -78,7 +78,7 @@ impl BibeCla {
     }
 
     /// Encapsulate an inner bundle into an outer bundle.
-    fn encapsulate(&self, inner: Bytes, outer_dest: Eid) -> Result<Bytes, Error> {
+    pub fn encapsulate(&self, inner: Bytes, outer_dest: Eid) -> Result<Bytes, Error> {
         // Parse inner bundle structurally to read its lifetime.
         let Parsed {
             data: inner,
@@ -94,7 +94,11 @@ impl BibeCla {
             a.emit(&0u64); // transmission-id
             a.emit(&0u64); // total-length
             a.emit(&0u64); // segmented-offset
-            a.emit(inner.as_ref()); // encapsulated-bundle-segment
+
+            // encapsulated-bundle-segment, as a definite-length byte string
+            // (a bare `&[u8]` would encode as a CBOR array of integers, which
+            // decapsulation rejects)
+            a.emit(&hardy_cbor::encode::Bytes(inner.as_ref()));
         });
 
         let (_bundle, data) = Builder::new(self.tunnel_source.clone(), outer_dest)

--- a/bibe/src/config.rs
+++ b/bibe/src/config.rs
@@ -1,8 +1,12 @@
-use super::*;
+use alloc::vec::Vec;
+
+use hardy_bpv7::eid::{Eid, NodeId, Service};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Configuration for BIBE tunnel endpoints.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Config {
     /// Source EID for outer bundles created by encapsulation.
     pub tunnel_source: Eid,
@@ -29,7 +33,7 @@ pub struct Config {
 /// The `decap_endpoint` is the actual service endpoint (e.g., `ipn:100.12`)
 /// that receives the outer bundle for decapsulation.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Tunnel {
     /// The tunnel NodeId that becomes routable (used in `via` routes).
     pub tunnel: NodeId,

--- a/bibe/src/lib.rs
+++ b/bibe/src/lib.rs
@@ -145,6 +145,9 @@ pub enum Error {
     /// Invalid CLA address format.
     #[error("Invalid CLA address format")]
     InvalidAddress,
+    /// The BIBE-PDU is a segment of a larger bundle; segmentation is not supported.
+    #[error("Segmented BIBE-PDUs are not supported")]
+    SegmentedPdu,
     /// Failed to parse bundle.
     #[error(transparent)]
     BundleParse(#[from] hardy_bpv7::Error),

--- a/bibe/src/lib.rs
+++ b/bibe/src/lib.rs
@@ -141,6 +141,9 @@ pub enum Error {
     /// Invalid CLA address format.
     #[error("Invalid CLA address format")]
     InvalidAddress,
+    /// The BIBE-PDU is a segment of a larger bundle; segmentation is not supported.
+    #[error("Segmented BIBE-PDUs are not supported")]
+    SegmentedPdu,
     /// Failed to parse bundle.
     #[error(transparent)]
     BundleParse(#[from] hardy_bpv7::Error),

--- a/bibe/src/lib.rs
+++ b/bibe/src/lib.rs
@@ -15,19 +15,21 @@ as virtual peers, making them routable via standard BPA forwarding.
 
 extern crate alloc;
 
+use alloc::{sync::Arc, vec::Vec};
+
+use hardy_bpa::bpa::BpaRegistration;
+use hardy_bpv7::eid::{Eid, NodeId, Service};
+use thiserror::Error as ThisError;
+use tracing::debug;
+
+use crate::{cla::BibeCla, service::DecapService};
+
 mod cla;
 mod config;
+mod pdu;
 mod service;
 
 pub use config::{Config, Tunnel};
-
-// Common imports for submodules (accessed via `use super::*;`)
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
-
-use hardy_async::sync::spin::Once;
-use hardy_bpa::{Bytes, async_trait, bpa::BpaRegistration};
-use hardy_bpv7::eid::{Eid, NodeId, Service};
-use tracing::{debug, warn};
 
 /// BIBE tunnel endpoint manager.
 ///
@@ -41,8 +43,8 @@ pub struct Bibe {
     tunnels: Vec<Tunnel>,
 
     // Internal components
-    cla: Arc<cla::BibeCla>,
-    decap_service: Arc<service::DecapService>,
+    cla: Arc<BibeCla>,
+    decap_service: Arc<DecapService>,
 }
 
 impl Bibe {
@@ -52,8 +54,8 @@ impl Bibe {
     ///
     /// * `config` - The configuration for this BIBE instance.
     pub fn new(config: &Config) -> Self {
-        let cla = Arc::new(cla::BibeCla::new(config.tunnel_source.clone()));
-        let decap_service = Arc::new(service::DecapService::new(cla.clone()));
+        let cla = Arc::new(BibeCla::new(config.tunnel_source.clone()));
+        let decap_service = Arc::new(DecapService::new(cla.clone()));
 
         Self {
             decap_service_id: config.decap_service_id.clone(),
@@ -133,7 +135,11 @@ impl Bibe {
 }
 
 /// Errors from BIBE operations.
-#[derive(Debug, thiserror::Error)]
+///
+/// The wrapped source types are named by path: every one of them is called
+/// `Error`, so importing them would collide with each other and with this
+/// enum.
+#[derive(Debug, ThisError)]
 pub enum Error {
     /// CLA not registered with BPA yet.
     #[error("CLA not registered with BPA")]

--- a/bibe/src/pdu.rs
+++ b/bibe/src/pdu.rs
@@ -1,0 +1,247 @@
+use alloc::borrow::Cow;
+
+use hardy_bpa::Bytes;
+use hardy_bpv7::{
+    Error as Bpv7Error,
+    builder::Builder,
+    creation_timestamp::CreationTimestamp,
+    eid::Eid,
+    parse::{Parsed, parse},
+};
+use hardy_cbor::{
+    decode::{Error as CborError, Value, parse_array},
+    encode::{Bytes as CborBytes, emit_array},
+};
+
+use crate::Error;
+
+/// Wrap a complete inner bundle in an outer bundle carrying a BIBE-PDU payload.
+///
+/// The outer bundle is sourced at `tunnel_source`, addressed to `outer_dest`,
+/// and inherits the inner bundle's lifetime.
+pub fn encapsulate(tunnel_source: &Eid, inner: Bytes, outer_dest: Eid) -> Result<Bytes, Error> {
+    // Parse inner bundle structurally to read its lifetime.
+    let Parsed {
+        data: inner,
+        bundle: parsed_bundle,
+        ..
+    } = parse(inner)?;
+    let lifetime = parsed_bundle.primary.lifetime;
+
+    // Build outer bundle with BIBE-PDU payload:
+    // [transmission-id, total-length, segmented-offset, encapsulated-bundle-segment]
+    // For complete bundles: [0, 0, 0, bundle-bytes]
+    let payload = emit_array(Some(4), |a| {
+        a.emit(&0u64); // transmission-id
+        a.emit(&0u64); // total-length
+        a.emit(&0u64); // segmented-offset
+
+        // encapsulated-bundle-segment, as a definite-length byte string
+        // (a bare `&[u8]` would encode as a CBOR array of integers, which
+        // decapsulation rejects)
+        a.emit(&CborBytes(inner.as_ref()));
+    });
+
+    let (_bundle, data) = Builder::new(tunnel_source.clone(), outer_dest)
+        .with_lifetime(lifetime)
+        .with_payload(Cow::Owned(payload))
+        .build(CreationTimestamp::now())?;
+
+    Ok(data.into())
+}
+
+/// Extract the inner bundle from an outer bundle's BIBE-PDU payload.
+pub fn decapsulate(outer_bytes: Bytes) -> Result<Bytes, Error> {
+    // Structural parse — we only need the payload block range; no BPSec
+    // validation is required to decapsulate.
+    let Parsed {
+        data: outer_bytes,
+        bundle: parsed_bundle,
+        ..
+    } = parse(outer_bytes)?;
+
+    // Get payload block (block number 1) and its range within outer_bytes
+    let payload_block = parsed_bundle
+        .blocks
+        .get(&1)
+        .ok_or(Bpv7Error::MissingBlock(1))?;
+
+    // Payload is BIBE-PDU: [transmission-id, total-length, segmented-offset, bundle-segment]
+    // For complete bundles: all three ints are 0. `payload` bounds-checks the
+    // wire-derived range (returns None on a 32-bit-unrepresentable or
+    // over-claiming extent) instead of slicing with a truncating `as usize`.
+    let payload = payload_block
+        .payload(&outer_bytes)
+        .map(|p| outer_bytes.slice_ref(p))
+        .ok_or(Bpv7Error::MissingBlock(1))?;
+    let (inner_range, len) = parse_array(&payload, |a, _shortest, _tags| -> Result<_, Error> {
+        let transmission_id: u64 = a.parse()?;
+        let total_length: u64 = a.parse()?;
+        let segmented_offset: u64 = a.parse()?;
+
+        // A complete bundle carries all three fields as zero; anything
+        // else marks a segment of a larger bundle, and this
+        // implementation does not reassemble segments, so dispatching
+        // the segment as a complete bundle would inject garbage.
+        if transmission_id != 0 || total_length != 0 || segmented_offset != 0 {
+            return Err(Error::SegmentedPdu);
+        }
+
+        // Parse the byte string and get its range within payload. The
+        // range reported by `parse_value` is relative to the start of
+        // the item, so rebase it onto the item's offset within the
+        // payload before slicing.
+        let segment_start = a.offset();
+        a.parse_value(|value, _shortest, tags| match value {
+            Value::Bytes(range) => Ok(segment_start + range.start..segment_start + range.end),
+            _ => Err(CborError::IncorrectType(
+                "Byte String",
+                value.item_type(tags),
+            )),
+        })
+        .map_err(Into::into)
+    })?;
+
+    // Check for smuggled data after the CBOR array
+    if len != payload.len() {
+        return Err(CborError::AdditionalItems.into());
+    }
+
+    // Return zero-copy slice of the inner bundle
+    Ok(payload.slice(inner_range))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{vec, vec::Vec};
+
+    use super::*;
+
+    const INNER_LIFETIME: core::time::Duration = core::time::Duration::from_secs(60);
+
+    const TUNNEL_SOURCE: &str = "ipn:10.1";
+    const DECAP_ENDPOINT: &str = "ipn:20.5";
+
+    // Build a complete inner bundle with a payload of the given length.
+    fn make_inner(payload_len: usize) -> Bytes {
+        let (_, data) = Builder::new("ipn:1.1".parse().unwrap(), "ipn:2.1".parse().unwrap())
+            .with_lifetime(INNER_LIFETIME)
+            .with_payload(Cow::Owned(vec![0x5A; payload_len]))
+            .build(CreationTimestamp::now())
+            .unwrap();
+        Bytes::from(data)
+    }
+
+    // Build an outer bundle carrying an arbitrary byte sequence as its payload,
+    // standing in for a (possibly malformed) BIBE-PDU.
+    fn make_outer(payload: Vec<u8>) -> Bytes {
+        let (_, data) = Builder::new(
+            TUNNEL_SOURCE.parse().unwrap(),
+            DECAP_ENDPOINT.parse().unwrap(),
+        )
+        .with_lifetime(INNER_LIFETIME)
+        .with_payload(Cow::Owned(payload))
+        .build(CreationTimestamp::now())
+        .unwrap();
+        Bytes::from(data)
+    }
+
+    // The full BIBE-PDU wire format: encapsulate then decapsulate must return
+    // the inner bundle byte-identically. Inner sizes straddle the CBOR
+    // byte-string length-field boundaries (23/24, 255/256, 65535/65536 payload
+    // bytes) to catch length-encoding splice and range off-by-one errors.
+    #[test]
+    fn test_encap_decap_round_trip() {
+        let tunnel_source: Eid = TUNNEL_SOURCE.parse().unwrap();
+        let decap_endpoint: Eid = DECAP_ENDPOINT.parse().unwrap();
+
+        for payload_len in [0usize, 1, 23, 24, 255, 256, 65535, 65536] {
+            let inner = make_inner(payload_len);
+            let outer = encapsulate(&tunnel_source, inner.clone(), decap_endpoint.clone()).unwrap();
+
+            let parsed = parse(outer.clone()).unwrap();
+            assert_eq!(parsed.bundle.primary.destination, decap_endpoint);
+            assert_eq!(parsed.bundle.primary.id.source, tunnel_source);
+            assert_eq!(parsed.bundle.primary.lifetime, INNER_LIFETIME);
+
+            let recovered = decapsulate(outer).unwrap();
+            assert_eq!(
+                recovered.as_ref(),
+                inner.as_ref(),
+                "inner bundle must round-trip byte-identically (payload_len {payload_len})"
+            );
+            parse(recovered).unwrap();
+        }
+    }
+
+    // A BIBE-PDU with any non-zero transmission-id/total-length/segmented-offset
+    // is a segment of a larger bundle; decapsulation must reject it rather than
+    // dispatch the segment as a complete bundle.
+    #[test]
+    fn test_decap_rejects_segment() {
+        for (transmission_id, total_length, segmented_offset) in
+            [(1u64, 0u64, 0u64), (0, 100, 0), (0, 0, 50)]
+        {
+            let pdu = emit_array(Some(4), |a| {
+                a.emit(&transmission_id);
+                a.emit(&total_length);
+                a.emit(&segmented_offset);
+                a.emit(&CborBytes(b"partial-bundle-bytes".as_slice()));
+            });
+
+            let err = decapsulate(make_outer(pdu)).unwrap_err();
+            assert!(
+                matches!(err, Error::SegmentedPdu),
+                "expected SegmentedPdu for ({transmission_id}, {total_length}, {segmented_offset}), got {err:?}"
+            );
+        }
+    }
+
+    // Bytes smuggled after the BIBE-PDU array must be rejected.
+    #[test]
+    fn test_decap_trailing_garbage() {
+        let inner = make_inner(4);
+        let mut pdu = emit_array(Some(4), |a| {
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&CborBytes(inner.as_ref()));
+        });
+        pdu.extend_from_slice(b"garbage");
+
+        let err = decapsulate(make_outer(pdu)).unwrap_err();
+        assert!(
+            matches!(err, Error::Cbor(CborError::AdditionalItems)),
+            "expected AdditionalItems, got {err:?}"
+        );
+    }
+
+    // The encapsulated-bundle-segment element must be a byte string.
+    #[test]
+    fn test_decap_wrong_segment_type() {
+        let pdu = emit_array(Some(4), |a| {
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit("not a byte string");
+        });
+
+        let err = decapsulate(make_outer(pdu)).unwrap_err();
+        assert!(
+            matches!(err, Error::Cbor(CborError::IncorrectType(_, _))),
+            "expected IncorrectType, got {err:?}"
+        );
+    }
+
+    // A PDU array with fewer than four elements is malformed.
+    #[test]
+    fn test_decap_short_array() {
+        let pdu = emit_array(Some(3), |a| {
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&0u64);
+        });
+
+        assert!(decapsulate(make_outer(pdu)).is_err());
+    }
+}

--- a/bibe/src/service.rs
+++ b/bibe/src/service.rs
@@ -27,7 +27,7 @@ impl DecapService {
     }
 
     /// Extract inner bundle from outer bundle payload.
-    fn decapsulate(&self, outer_bytes: Bytes) -> Result<Bytes, Error> {
+    pub fn decapsulate(&self, outer_bytes: Bytes) -> Result<Bytes, Error> {
         // Parse the outer bundle
         let parsed = ParsedBundle::parse(&outer_bytes, bpsec::no_keys)?;
 
@@ -42,22 +42,36 @@ impl DecapService {
         // Payload is BIBE-PDU: [transmission-id, total-length, segmented-offset, bundle-segment]
         // For complete bundles: all three ints are 0
         let payload = outer_bytes.slice(payload_range);
-        let (inner_range, len) = hardy_cbor::decode::parse_array(
-            &payload,
-            |a, _shortest, _tags| -> Result<_, hardy_cbor::decode::Error> {
-                let _transmission_id: u64 = a.parse()?;
-                let _total_length: u64 = a.parse()?;
-                let _segmented_offset: u64 = a.parse()?;
-                // Parse byte string and get the range within payload
+        let (inner_range, len) =
+            hardy_cbor::decode::parse_array(&payload, |a, _shortest, _tags| -> Result<_, Error> {
+                let transmission_id: u64 = a.parse()?;
+                let total_length: u64 = a.parse()?;
+                let segmented_offset: u64 = a.parse()?;
+
+                // A complete bundle carries all three fields as zero; anything
+                // else marks a segment of a larger bundle, and this
+                // implementation does not reassemble segments, so dispatching
+                // the segment as a complete bundle would inject garbage.
+                if transmission_id != 0 || total_length != 0 || segmented_offset != 0 {
+                    return Err(Error::SegmentedPdu);
+                }
+
+                // Parse the byte string and get its range within payload. The
+                // range reported by `parse_value` is relative to the start of
+                // the item, so rebase it onto the item's offset within the
+                // payload before slicing.
+                let segment_start = a.offset();
                 a.parse_value(|value, _shortest, _tags| match value {
-                    hardy_cbor::decode::Value::Bytes(range) => Ok(range),
+                    hardy_cbor::decode::Value::Bytes(range) => {
+                        Ok(segment_start + range.start..segment_start + range.end)
+                    }
                     _ => Err(hardy_cbor::decode::Error::IncorrectType(
                         "Byte String".into(),
                         value.type_name(false),
                     )),
                 })
-            },
-        )?;
+                .map_err(Into::into)
+            })?;
 
         // Check for smuggled data after the CBOR array
         if len != payload.len() {
@@ -123,5 +137,149 @@ impl Service for DecapService {
         _timestamp: Option<time::OffsetDateTime>,
     ) {
         // DecapService doesn't send bundles, so no status reports expected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hardy_bpv7::builder::Builder;
+
+    use super::*;
+
+    const INNER_LIFETIME: core::time::Duration = core::time::Duration::from_secs(60);
+
+    // Build a complete inner bundle with a payload of the given length.
+    fn make_inner(payload_len: usize) -> Bytes {
+        let (_, data) = Builder::new("ipn:1.1".parse().unwrap(), "ipn:2.1".parse().unwrap())
+            .with_lifetime(INNER_LIFETIME)
+            .with_payload(Cow::Owned(alloc::vec![0x5A; payload_len]))
+            .build(CreationTimestamp::now())
+            .unwrap();
+        Bytes::from(data)
+    }
+
+    // Build an outer bundle carrying an arbitrary byte sequence as its payload,
+    // standing in for a (possibly malformed) BIBE-PDU.
+    fn make_outer(payload: Vec<u8>) -> Bytes {
+        let (_, data) = Builder::new("ipn:10.1".parse().unwrap(), "ipn:20.5".parse().unwrap())
+            .with_lifetime(INNER_LIFETIME)
+            .with_payload(Cow::Owned(payload))
+            .build(CreationTimestamp::now())
+            .unwrap();
+        Bytes::from(data)
+    }
+
+    fn make_decap() -> DecapService {
+        DecapService::new(Arc::new(cla::BibeCla::new("ipn:10.1".parse().unwrap())))
+    }
+
+    // The full BIBE-PDU wire format: encapsulate then decapsulate must return
+    // the inner bundle byte-identically. Inner sizes straddle the CBOR
+    // byte-string length-field boundaries (23/24, 255/256, 65535/65536 payload
+    // bytes) to catch length-encoding splice and range off-by-one errors.
+    #[test]
+    fn test_encap_decap_round_trip() {
+        let tunnel_source: Eid = "ipn:10.1".parse().unwrap();
+        let decap_endpoint: Eid = "ipn:20.5".parse().unwrap();
+        let bibe_cla = cla::BibeCla::new(tunnel_source.clone());
+        let decap = make_decap();
+
+        for payload_len in [0usize, 1, 23, 24, 255, 256, 65535, 65536] {
+            let inner = make_inner(payload_len);
+            let outer = bibe_cla
+                .encapsulate(inner.clone(), decap_endpoint.clone())
+                .unwrap();
+
+            let parsed = ParsedBundle::parse(&outer, bpsec::no_keys).unwrap();
+            assert_eq!(parsed.bundle.destination, decap_endpoint);
+            assert_eq!(parsed.bundle.id.source, tunnel_source);
+            assert_eq!(parsed.bundle.lifetime, INNER_LIFETIME);
+
+            let recovered = decap.decapsulate(outer).unwrap();
+            assert_eq!(
+                recovered.as_ref(),
+                inner.as_ref(),
+                "inner bundle must round-trip byte-identically (payload_len {payload_len})"
+            );
+            ParsedBundle::parse(&recovered, bpsec::no_keys).unwrap();
+        }
+    }
+
+    // A BIBE-PDU with any non-zero transmission-id/total-length/segmented-offset
+    // is a segment of a larger bundle; decapsulation must reject it rather than
+    // dispatch the segment as a complete bundle.
+    #[test]
+    fn test_decap_rejects_segment() {
+        let decap = make_decap();
+
+        for (transmission_id, total_length, segmented_offset) in
+            [(1u64, 0u64, 0u64), (0, 100, 0), (0, 0, 50)]
+        {
+            let pdu = hardy_cbor::encode::emit_array(Some(4), |a| {
+                a.emit(&transmission_id);
+                a.emit(&total_length);
+                a.emit(&segmented_offset);
+                a.emit(&hardy_cbor::encode::Bytes(
+                    b"partial-bundle-bytes".as_slice(),
+                ));
+            });
+
+            let err = decap.decapsulate(make_outer(pdu)).unwrap_err();
+            assert!(
+                matches!(err, Error::SegmentedPdu),
+                "expected SegmentedPdu for ({transmission_id}, {total_length}, {segmented_offset}), got {err:?}"
+            );
+        }
+    }
+
+    // Bytes smuggled after the BIBE-PDU array must be rejected.
+    #[test]
+    fn test_decap_trailing_garbage() {
+        let inner = make_inner(4);
+        let mut pdu = hardy_cbor::encode::emit_array(Some(4), |a| {
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&hardy_cbor::encode::Bytes(inner.as_ref()));
+        });
+        pdu.extend_from_slice(b"garbage");
+
+        let err = make_decap().decapsulate(make_outer(pdu)).unwrap_err();
+        assert!(
+            matches!(err, Error::Cbor(hardy_cbor::decode::Error::AdditionalItems)),
+            "expected AdditionalItems, got {err:?}"
+        );
+    }
+
+    // The encapsulated-bundle-segment element must be a byte string.
+    #[test]
+    fn test_decap_wrong_segment_type() {
+        let pdu = hardy_cbor::encode::emit_array(Some(4), |a| {
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit("not a byte string");
+        });
+
+        let err = make_decap().decapsulate(make_outer(pdu)).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::Cbor(hardy_cbor::decode::Error::IncorrectType(_, _))
+            ),
+            "expected IncorrectType, got {err:?}"
+        );
+    }
+
+    // A PDU array with fewer than four elements is malformed.
+    #[test]
+    fn test_decap_short_array() {
+        let pdu = hardy_cbor::encode::emit_array(Some(3), |a| {
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&0u64);
+        });
+
+        assert!(make_decap().decapsulate(make_outer(pdu)).is_err());
     }
 }

--- a/bibe/src/service.rs
+++ b/bibe/src/service.rs
@@ -1,18 +1,31 @@
-use super::*;
-use hardy_bpa::services::{Service, ServiceSink, StatusNotify};
+use alloc::{boxed::Box, sync::Arc};
+
+use hardy_async::sync::spin::Once;
+use hardy_bpa::{
+    async_trait,
+    services::{
+        Error as ServiceError, Result as ServiceResult, Service, ServiceSink, StatusNotify,
+    },
+    stream::{Receiver, Segment, buffer_stream},
+};
+use hardy_bpv7::{bundle::Id, eid::Eid, status_report::ReasonCode};
+use time::OffsetDateTime;
+use tracing::{debug, warn};
+
+use crate::{cla::BibeCla, pdu};
 
 /// BIBE Decapsulation Service.
 ///
 /// Receives outer bundles, extracts the inner bundle from the payload,
 /// and re-injects it into the BPA via the CLA's dispatch method.
 pub struct DecapService {
-    cla: Arc<cla::BibeCla>,
+    cla: Arc<BibeCla>,
     sink: Once<Box<dyn ServiceSink>>,
 }
 
 impl DecapService {
     /// Create a new DecapService using the given CLA for dispatch.
-    pub fn new(cla: Arc<cla::BibeCla>) -> Self {
+    pub fn new(cla: Arc<BibeCla>) -> Self {
         Self {
             cla,
             sink: Once::new(),
@@ -24,69 +37,6 @@ impl DecapService {
         if let Some(sink) = self.sink.get() {
             sink.unregister().await;
         }
-    }
-
-    /// Extract inner bundle from outer bundle payload.
-    pub fn decapsulate(&self, outer_bytes: Bytes) -> Result<Bytes, Error> {
-        // Structural parse — we only need the payload block range; no
-        // BPSec validation is required to decapsulate.
-        let hardy_bpv7::parse::Parsed {
-            data: outer_bytes,
-            bundle: parsed_bundle,
-            ..
-        } = hardy_bpv7::parse::parse(outer_bytes)?;
-
-        // Get payload block (block number 1) and its range within outer_bytes
-        let payload_block = parsed_bundle
-            .blocks
-            .get(&1)
-            .ok_or(hardy_bpv7::Error::MissingBlock(1))?;
-        // Payload is BIBE-PDU: [transmission-id, total-length, segmented-offset, bundle-segment]
-        // For complete bundles: all three ints are 0. `payload` bounds-checks the
-        // wire-derived range (returns None on a 32-bit-unrepresentable or
-        // over-claiming extent) instead of slicing with a truncating `as usize`.
-        let payload = payload_block
-            .payload(&outer_bytes)
-            .map(|p| outer_bytes.slice_ref(p))
-            .ok_or(hardy_bpv7::Error::MissingBlock(1))?;
-        let (inner_range, len) =
-            hardy_cbor::decode::parse_array(&payload, |a, _shortest, _tags| -> Result<_, Error> {
-                let transmission_id: u64 = a.parse()?;
-                let total_length: u64 = a.parse()?;
-                let segmented_offset: u64 = a.parse()?;
-
-                // A complete bundle carries all three fields as zero; anything
-                // else marks a segment of a larger bundle, and this
-                // implementation does not reassemble segments, so dispatching
-                // the segment as a complete bundle would inject garbage.
-                if transmission_id != 0 || total_length != 0 || segmented_offset != 0 {
-                    return Err(Error::SegmentedPdu);
-                }
-
-                // Parse the byte string and get its range within payload. The
-                // range reported by `parse_value` is relative to the start of
-                // the item, so rebase it onto the item's offset within the
-                // payload before slicing.
-                let segment_start = a.offset();
-                a.parse_value(|value, _shortest, tags| match value {
-                    hardy_cbor::decode::Value::Bytes(range) => {
-                        Ok(segment_start + range.start..segment_start + range.end)
-                    }
-                    _ => Err(hardy_cbor::decode::Error::IncorrectType(
-                        "Byte String",
-                        value.item_type(tags),
-                    )),
-                })
-                .map_err(Into::into)
-            })?;
-
-        // Check for smuggled data after the CBOR array
-        if len != payload.len() {
-            return Err(hardy_cbor::decode::Error::AdditionalItems.into());
-        }
-
-        // Return zero-copy slice of the inner bundle
-        Ok(payload.slice(inner_range))
     }
 }
 
@@ -108,16 +58,16 @@ impl Service for DecapService {
     // bpa/docs/streaming_pipeline_design.md.
     async fn on_deliver(
         &self,
-        _bundle_id: &hardy_bpv7::bundle::Id,
-        _expiry: time::OffsetDateTime,
+        _bundle_id: &Id,
+        _expiry: OffsetDateTime,
         total_len: u64,
-        stream: &mut dyn hardy_bpa::stream::Receiver<hardy_bpa::stream::Segment>,
-    ) -> hardy_bpa::services::Result<()> {
-        let data = hardy_bpa::stream::buffer_stream(stream, total_len).await?;
+        stream: &mut dyn Receiver<Segment>,
+    ) -> ServiceResult<()> {
+        let data = buffer_stream(stream, total_len).await?;
 
         // A malformed outer bundle is a permanent failure: log and accept it,
         // so it is not parked for a retry that could never succeed.
-        let inner = match self.decapsulate(data) {
+        let inner = match pdu::decapsulate(data) {
             Ok(inner) => inner,
             Err(e) => {
                 warn!("BIBE decapsulation failed: {e}");
@@ -132,163 +82,17 @@ impl Service for DecapService {
             .dispatch(inner)
             .await
             .inspect_err(|e| warn!("Failed to dispatch decapsulated bundle: {e}"))
-            .map_err(|e| hardy_bpa::services::Error::Internal(e.into()))
+            .map_err(|e| ServiceError::Internal(e.into()))
     }
 
     async fn on_status_notify(
         &self,
-        _bundle_id: &hardy_bpv7::bundle::Id,
+        _bundle_id: &Id,
         _from: &Eid,
         _kind: StatusNotify,
-        _reason: hardy_bpv7::status_report::ReasonCode,
-        _timestamp: Option<time::OffsetDateTime>,
+        _reason: ReasonCode,
+        _timestamp: Option<OffsetDateTime>,
     ) {
         // DecapService doesn't send bundles, so no status reports expected
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use alloc::borrow::Cow;
-
-    use hardy_bpv7::{builder::Builder, creation_timestamp::CreationTimestamp};
-
-    use super::*;
-
-    const INNER_LIFETIME: core::time::Duration = core::time::Duration::from_secs(60);
-
-    // Build a complete inner bundle with a payload of the given length.
-    fn make_inner(payload_len: usize) -> Bytes {
-        let (_, data) = Builder::new("ipn:1.1".parse().unwrap(), "ipn:2.1".parse().unwrap())
-            .with_lifetime(INNER_LIFETIME)
-            .with_payload(Cow::Owned(alloc::vec![0x5A; payload_len]))
-            .build(CreationTimestamp::now())
-            .unwrap();
-        Bytes::from(data)
-    }
-
-    // Build an outer bundle carrying an arbitrary byte sequence as its payload,
-    // standing in for a (possibly malformed) BIBE-PDU.
-    fn make_outer(payload: Vec<u8>) -> Bytes {
-        let (_, data) = Builder::new("ipn:10.1".parse().unwrap(), "ipn:20.5".parse().unwrap())
-            .with_lifetime(INNER_LIFETIME)
-            .with_payload(Cow::Owned(payload))
-            .build(CreationTimestamp::now())
-            .unwrap();
-        Bytes::from(data)
-    }
-
-    fn make_decap() -> DecapService {
-        DecapService::new(Arc::new(cla::BibeCla::new("ipn:10.1".parse().unwrap())))
-    }
-
-    // The full BIBE-PDU wire format: encapsulate then decapsulate must return
-    // the inner bundle byte-identically. Inner sizes straddle the CBOR
-    // byte-string length-field boundaries (23/24, 255/256, 65535/65536 payload
-    // bytes) to catch length-encoding splice and range off-by-one errors.
-    #[test]
-    fn test_encap_decap_round_trip() {
-        let tunnel_source: Eid = "ipn:10.1".parse().unwrap();
-        let decap_endpoint: Eid = "ipn:20.5".parse().unwrap();
-        let bibe_cla = cla::BibeCla::new(tunnel_source.clone());
-        let decap = make_decap();
-
-        for payload_len in [0usize, 1, 23, 24, 255, 256, 65535, 65536] {
-            let inner = make_inner(payload_len);
-            let outer = bibe_cla
-                .encapsulate(inner.clone(), decap_endpoint.clone())
-                .unwrap();
-
-            let parsed = hardy_bpv7::parse::parse(outer.clone()).unwrap();
-            assert_eq!(parsed.bundle.primary.destination, decap_endpoint);
-            assert_eq!(parsed.bundle.primary.id.source, tunnel_source);
-            assert_eq!(parsed.bundle.primary.lifetime, INNER_LIFETIME);
-
-            let recovered = decap.decapsulate(outer).unwrap();
-            assert_eq!(
-                recovered.as_ref(),
-                inner.as_ref(),
-                "inner bundle must round-trip byte-identically (payload_len {payload_len})"
-            );
-            hardy_bpv7::parse::parse(recovered).unwrap();
-        }
-    }
-
-    // A BIBE-PDU with any non-zero transmission-id/total-length/segmented-offset
-    // is a segment of a larger bundle; decapsulation must reject it rather than
-    // dispatch the segment as a complete bundle.
-    #[test]
-    fn test_decap_rejects_segment() {
-        let decap = make_decap();
-
-        for (transmission_id, total_length, segmented_offset) in
-            [(1u64, 0u64, 0u64), (0, 100, 0), (0, 0, 50)]
-        {
-            let pdu = hardy_cbor::encode::emit_array(Some(4), |a| {
-                a.emit(&transmission_id);
-                a.emit(&total_length);
-                a.emit(&segmented_offset);
-                a.emit(&hardy_cbor::encode::Bytes(
-                    b"partial-bundle-bytes".as_slice(),
-                ));
-            });
-
-            let err = decap.decapsulate(make_outer(pdu)).unwrap_err();
-            assert!(
-                matches!(err, Error::SegmentedPdu),
-                "expected SegmentedPdu for ({transmission_id}, {total_length}, {segmented_offset}), got {err:?}"
-            );
-        }
-    }
-
-    // Bytes smuggled after the BIBE-PDU array must be rejected.
-    #[test]
-    fn test_decap_trailing_garbage() {
-        let inner = make_inner(4);
-        let mut pdu = hardy_cbor::encode::emit_array(Some(4), |a| {
-            a.emit(&0u64);
-            a.emit(&0u64);
-            a.emit(&0u64);
-            a.emit(&hardy_cbor::encode::Bytes(inner.as_ref()));
-        });
-        pdu.extend_from_slice(b"garbage");
-
-        let err = make_decap().decapsulate(make_outer(pdu)).unwrap_err();
-        assert!(
-            matches!(err, Error::Cbor(hardy_cbor::decode::Error::AdditionalItems)),
-            "expected AdditionalItems, got {err:?}"
-        );
-    }
-
-    // The encapsulated-bundle-segment element must be a byte string.
-    #[test]
-    fn test_decap_wrong_segment_type() {
-        let pdu = hardy_cbor::encode::emit_array(Some(4), |a| {
-            a.emit(&0u64);
-            a.emit(&0u64);
-            a.emit(&0u64);
-            a.emit("not a byte string");
-        });
-
-        let err = make_decap().decapsulate(make_outer(pdu)).unwrap_err();
-        assert!(
-            matches!(
-                err,
-                Error::Cbor(hardy_cbor::decode::Error::IncorrectType(_, _))
-            ),
-            "expected IncorrectType, got {err:?}"
-        );
-    }
-
-    // A PDU array with fewer than four elements is malformed.
-    #[test]
-    fn test_decap_short_array() {
-        let pdu = hardy_cbor::encode::emit_array(Some(3), |a| {
-            a.emit(&0u64);
-            a.emit(&0u64);
-            a.emit(&0u64);
-        });
-
-        assert!(make_decap().decapsulate(make_outer(pdu)).is_err());
     }
 }

--- a/bibe/src/service.rs
+++ b/bibe/src/service.rs
@@ -27,7 +27,7 @@ impl DecapService {
     }
 
     /// Extract inner bundle from outer bundle payload.
-    fn decapsulate(&self, outer_bytes: Bytes) -> Result<Bytes, Error> {
+    pub fn decapsulate(&self, outer_bytes: Bytes) -> Result<Bytes, Error> {
         // Structural parse — we only need the payload block range; no
         // BPSec validation is required to decapsulate.
         let hardy_bpv7::parse::Parsed {
@@ -49,22 +49,36 @@ impl DecapService {
             .payload(&outer_bytes)
             .map(|p| outer_bytes.slice_ref(p))
             .ok_or(hardy_bpv7::Error::MissingBlock(1))?;
-        let (inner_range, len) = hardy_cbor::decode::parse_array(
-            &payload,
-            |a, _shortest, _tags| -> Result<_, hardy_cbor::decode::Error> {
-                let _transmission_id: u64 = a.parse()?;
-                let _total_length: u64 = a.parse()?;
-                let _segmented_offset: u64 = a.parse()?;
-                // Parse byte string and get the range within payload
+        let (inner_range, len) =
+            hardy_cbor::decode::parse_array(&payload, |a, _shortest, _tags| -> Result<_, Error> {
+                let transmission_id: u64 = a.parse()?;
+                let total_length: u64 = a.parse()?;
+                let segmented_offset: u64 = a.parse()?;
+
+                // A complete bundle carries all three fields as zero; anything
+                // else marks a segment of a larger bundle, and this
+                // implementation does not reassemble segments, so dispatching
+                // the segment as a complete bundle would inject garbage.
+                if transmission_id != 0 || total_length != 0 || segmented_offset != 0 {
+                    return Err(Error::SegmentedPdu);
+                }
+
+                // Parse the byte string and get its range within payload. The
+                // range reported by `parse_value` is relative to the start of
+                // the item, so rebase it onto the item's offset within the
+                // payload before slicing.
+                let segment_start = a.offset();
                 a.parse_value(|value, _shortest, tags| match value {
-                    hardy_cbor::decode::Value::Bytes(range) => Ok(range),
+                    hardy_cbor::decode::Value::Bytes(range) => {
+                        Ok(segment_start + range.start..segment_start + range.end)
+                    }
                     _ => Err(hardy_cbor::decode::Error::IncorrectType(
                         "Byte String",
                         value.item_type(tags),
                     )),
                 })
-            },
-        )?;
+                .map_err(Into::into)
+            })?;
 
         // Check for smuggled data after the CBOR array
         if len != payload.len() {
@@ -130,5 +144,151 @@ impl Service for DecapService {
         _timestamp: Option<time::OffsetDateTime>,
     ) {
         // DecapService doesn't send bundles, so no status reports expected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::borrow::Cow;
+
+    use hardy_bpv7::{builder::Builder, creation_timestamp::CreationTimestamp};
+
+    use super::*;
+
+    const INNER_LIFETIME: core::time::Duration = core::time::Duration::from_secs(60);
+
+    // Build a complete inner bundle with a payload of the given length.
+    fn make_inner(payload_len: usize) -> Bytes {
+        let (_, data) = Builder::new("ipn:1.1".parse().unwrap(), "ipn:2.1".parse().unwrap())
+            .with_lifetime(INNER_LIFETIME)
+            .with_payload(Cow::Owned(alloc::vec![0x5A; payload_len]))
+            .build(CreationTimestamp::now())
+            .unwrap();
+        Bytes::from(data)
+    }
+
+    // Build an outer bundle carrying an arbitrary byte sequence as its payload,
+    // standing in for a (possibly malformed) BIBE-PDU.
+    fn make_outer(payload: Vec<u8>) -> Bytes {
+        let (_, data) = Builder::new("ipn:10.1".parse().unwrap(), "ipn:20.5".parse().unwrap())
+            .with_lifetime(INNER_LIFETIME)
+            .with_payload(Cow::Owned(payload))
+            .build(CreationTimestamp::now())
+            .unwrap();
+        Bytes::from(data)
+    }
+
+    fn make_decap() -> DecapService {
+        DecapService::new(Arc::new(cla::BibeCla::new("ipn:10.1".parse().unwrap())))
+    }
+
+    // The full BIBE-PDU wire format: encapsulate then decapsulate must return
+    // the inner bundle byte-identically. Inner sizes straddle the CBOR
+    // byte-string length-field boundaries (23/24, 255/256, 65535/65536 payload
+    // bytes) to catch length-encoding splice and range off-by-one errors.
+    #[test]
+    fn test_encap_decap_round_trip() {
+        let tunnel_source: Eid = "ipn:10.1".parse().unwrap();
+        let decap_endpoint: Eid = "ipn:20.5".parse().unwrap();
+        let bibe_cla = cla::BibeCla::new(tunnel_source.clone());
+        let decap = make_decap();
+
+        for payload_len in [0usize, 1, 23, 24, 255, 256, 65535, 65536] {
+            let inner = make_inner(payload_len);
+            let outer = bibe_cla
+                .encapsulate(inner.clone(), decap_endpoint.clone())
+                .unwrap();
+
+            let parsed = hardy_bpv7::parse::parse(outer.clone()).unwrap();
+            assert_eq!(parsed.bundle.primary.destination, decap_endpoint);
+            assert_eq!(parsed.bundle.primary.id.source, tunnel_source);
+            assert_eq!(parsed.bundle.primary.lifetime, INNER_LIFETIME);
+
+            let recovered = decap.decapsulate(outer).unwrap();
+            assert_eq!(
+                recovered.as_ref(),
+                inner.as_ref(),
+                "inner bundle must round-trip byte-identically (payload_len {payload_len})"
+            );
+            hardy_bpv7::parse::parse(recovered).unwrap();
+        }
+    }
+
+    // A BIBE-PDU with any non-zero transmission-id/total-length/segmented-offset
+    // is a segment of a larger bundle; decapsulation must reject it rather than
+    // dispatch the segment as a complete bundle.
+    #[test]
+    fn test_decap_rejects_segment() {
+        let decap = make_decap();
+
+        for (transmission_id, total_length, segmented_offset) in
+            [(1u64, 0u64, 0u64), (0, 100, 0), (0, 0, 50)]
+        {
+            let pdu = hardy_cbor::encode::emit_array(Some(4), |a| {
+                a.emit(&transmission_id);
+                a.emit(&total_length);
+                a.emit(&segmented_offset);
+                a.emit(&hardy_cbor::encode::Bytes(
+                    b"partial-bundle-bytes".as_slice(),
+                ));
+            });
+
+            let err = decap.decapsulate(make_outer(pdu)).unwrap_err();
+            assert!(
+                matches!(err, Error::SegmentedPdu),
+                "expected SegmentedPdu for ({transmission_id}, {total_length}, {segmented_offset}), got {err:?}"
+            );
+        }
+    }
+
+    // Bytes smuggled after the BIBE-PDU array must be rejected.
+    #[test]
+    fn test_decap_trailing_garbage() {
+        let inner = make_inner(4);
+        let mut pdu = hardy_cbor::encode::emit_array(Some(4), |a| {
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&hardy_cbor::encode::Bytes(inner.as_ref()));
+        });
+        pdu.extend_from_slice(b"garbage");
+
+        let err = make_decap().decapsulate(make_outer(pdu)).unwrap_err();
+        assert!(
+            matches!(err, Error::Cbor(hardy_cbor::decode::Error::AdditionalItems)),
+            "expected AdditionalItems, got {err:?}"
+        );
+    }
+
+    // The encapsulated-bundle-segment element must be a byte string.
+    #[test]
+    fn test_decap_wrong_segment_type() {
+        let pdu = hardy_cbor::encode::emit_array(Some(4), |a| {
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit("not a byte string");
+        });
+
+        let err = make_decap().decapsulate(make_outer(pdu)).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::Cbor(hardy_cbor::decode::Error::IncorrectType(_, _))
+            ),
+            "expected IncorrectType, got {err:?}"
+        );
+    }
+
+    // A PDU array with fewer than four elements is malformed.
+    #[test]
+    fn test_decap_short_array() {
+        let pdu = hardy_cbor::encode::emit_array(Some(3), |a| {
+            a.emit(&0u64);
+            a.emit(&0u64);
+            a.emit(&0u64);
+        });
+
+        assert!(make_decap().decapsulate(make_outer(pdu)).is_err());
     }
 }


### PR DESCRIPTION
# Fix the BIBE PDU wire encoding: byte-string payloads and honest offsets

## Background

BIBE (Bundle-in-Bundle Encapsulation) tunnels a whole bundle as the payload of another bundle: `encapsulate` wraps an outgoing bundle into a BIBE PDU, and the decapsulation service unwraps arriving PDUs and re-dispatches the inner bundle. The PDU is a CBOR array of a transmission id, a total length, a segmented offset, and the encapsulated bundle bytes.

## What this changes and why

Writing the first encapsulate/decapsulate round-trip test exposed that the wire format never worked end to end:

- **The inner bundle was encoded as a CBOR array of integers, one uint per byte, not as a byte string.** `a.emit(inner.as_ref())` picks hardy-cbor's slice-of-integers encoding; the byte-string encoding needs the `encode::Bytes` wrapper. Decapsulation rejects arrays, so every tunneled bundle died at the far end.
- **Decapsulation applied the byte-string range to the whole payload instead of the item.** The range returned by `parse_value` is relative to the item start, so the recovered "bundle" was shifted by the PDU header length: it included header bytes at the front and lost the tail.

Two hardy nodes could exchange BIBE bundles only because both were equally wrong; a spec-correct peer could not interoperate with hardy at all. **The fix is breaking against the previous hardy-bibe wire format**, which is unavoidable: the old format was the bug.

Additionally, `decapsulate` treated every PDU as complete, silently accepting fragments: a non-zero transmission id, total length, or segmented offset now fails with the new `Error::SegmentedPdu`, because segmentation is declared future work in the design doc and treating a fragment as a whole bundle corrupts the payload. The existing permanent-failure path in `on_deliver` handles the rejection.

## Tests

Byte-identity round-trips across inner payload sizes chosen to cross every CBOR length-field boundary (0, 1, 23, 24, 255, 256, 65535, 65536), outer bundle field assertions, and malformed-PDU cases: each non-zero header field, trailing garbage, a non-byte-string segment, and a wrong-arity array. `cargo test -p hardy-bibe`, clippy with `-D warnings`, and fmt are clean; the design doc is updated to state the complete-PDU-only contract.
