### PR TITLE
fix(bpa-server): construct storage config defaults per field

### DIFF
--- a/bpa-server/docs/TODO.md
+++ b/bpa-server/docs/TODO.md
@@ -1,0 +1,20 @@
+# bpa-server TODO
+
+## Missing storage default: report as a `Config::load` error instead of panicking
+
+### Background
+
+`MetadataStorageConfig::default()` and `BundleStorageConfig::default()` (`src/config/storage.rs`) panic in builds compiled without the feature that provides their default backend (`sqlite-storage` for metadata, `localdisk-storage` for bundle data). The stance is deliberate: an unconfigured node must never silently degrade to a non-persistent memory backend, and the panic is pinned by `empty_config_has_defaults` in `src/config/mod.rs`, which flips to `should_panic(expected = "built without the")` under those feature combinations.
+
+`StorageConfig` now carries per-field `#[serde(default)]` rather than a container-level one, so a selector default is only constructed for a selector genuinely absent from the config. A feature-reduced build that configures both backends explicitly no longer panics at startup; the panic is confined to the case it is actually about.
+
+### What is still wrong
+
+A panic is the wrong report for a user error in a config file. The operator gets a backtrace instead of a diagnostic, and the failure is indistinguishable from a bug. It also keeps most of the config tests from running under `--no-default-features`: any test that loads a config without an explicit `storage.metadata`/`storage.bundle` aborts the process rather than returning an error the test can assert on.
+
+### What is needed
+
+- A typed error variant on the `Config::load` error surface for "no default backend in this build", carrying which selector (`storage.metadata` or `storage.bundle`) and which feature would have provided it, so the message stays as actionable as today's panic text.
+- The selector `Default` impls can then stop panicking; the missing-default decision moves to the point where the config is validated, which means threading fallibility through the serde path (a custom deserializer for the two fields, or a post-load validation pass over an `Option`-shaped intermediate).
+- Every `Config::load` caller updated for the widened error taxonomy: this is a load-API contract change, which is why it was deferred from the per-field-defaults fix by review ruling (2026-09-11) rather than folded into it.
+- `empty_config_has_defaults` converts from `should_panic` to asserting the typed error variant, and the config tests become runnable under `--no-default-features`.

--- a/bpa-server/src/config/storage.rs
+++ b/bpa-server/src/config/storage.rs
@@ -215,14 +215,22 @@ impl Default for BundleStorageConfig {
 // Combined storage configuration. The cache knobs are optional: absent
 // keys leave the cache's own defaults in force, so no default value is
 // restated here.
+//
+// Defaults are per-field, not container-level: a container-level
+// `#[serde(default)]` constructs the whole `Default` up front, and the
+// backend selector defaults panic in builds without the default-backend
+// features, even when every backend is explicitly configured. Per-field
+// defaults fire only for the keys that are actually absent.
 #[derive(Default, Serialize, Deserialize, Debug)]
-#[serde(deny_unknown_fields, default, rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct StorageConfig {
     // LRU bundle cache capacity, in entries; must be greater than zero.
+    #[serde(default)]
     pub lru_capacity: Option<NonZeroUsize>,
 
     // Largest bundle size eligible for caching, in bytes; must be greater
     // than zero.
+    #[serde(default)]
     pub max_cached_bundle_size: Option<NonZeroUsize>,
 
     #[serde(default)]

--- a/bpa-server/tests/test_bundle_processing.sh
+++ b/bpa-server/tests/test_bundle_processing.sh
@@ -2,14 +2,19 @@
 # Test script to process a bundle through the full BPA server
 #
 # Usage:
-#   ./bpa-server/tests/test_bundle_processing.sh [-o output_dir] [-n node_id] [bundle_file]
+#   ./bpa-server/tests/test_bundle_processing.sh [-o output_dir] [-n node_id] [-i] [bundle_file]
 #
 # Options:
 #   -o output_dir   Save output bundles (e.g., status reports) to this directory
 #   -n node_id      Set the BPA node ID (default: ipn:1.0)
+#   -i              Interactive mode: start the server and wait for manual input
 #
-# If no bundle file is specified, starts the server and waits for manual input.
-# The server watches an outbox directory - copy bundles there to process them.
+# By default a test bundle destined for the file-cla peer ipn:2.0 is
+# generated with the `bundle` tool and the script asserts it traverses the
+# BPA (consumed from the outbox, written to the peer inbox), exiting
+# nonzero on failure. Pass a bundle_file to process that bundle instead.
+# In interactive mode the server watches the outbox directory - copy
+# bundles there to process them.
 
 set -e
 
@@ -19,13 +24,17 @@ WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # Parse options
 OUTPUT_DIR=""
 NODE_ID="ipn:1.0"
-while getopts "o:n:" opt; do
+INTERACTIVE=false
+while getopts "o:n:i" opt; do
     case $opt in
         o)
             OUTPUT_DIR="$OPTARG"
             ;;
         n)
             NODE_ID="$OPTARG"
+            ;;
+        i)
+            INTERACTIVE=true
             ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
@@ -67,13 +76,51 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Poll until a file contains at least N occurrences of a pattern, with a
+# deadline in seconds. Fails fast when the given process dies first.
+wait_for_log() {
+    local file=$1 pattern=$2 count=$3 deadline=$4 pid=${5:-}
+    local waited=0 seen
+    while :; do
+        seen=$(grep -c "$pattern" "$file" 2>/dev/null) || true
+        if [ "${seen:-0}" -ge "$count" ]; then
+            return 0
+        fi
+        if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+            echo "ERROR: process $pid exited while waiting for '$pattern'"
+            return 1
+        fi
+        if [ "$waited" -ge $((deadline * 10)) ]; then
+            echo "ERROR: timed out waiting for ${count}x '$pattern' in $file"
+            return 1
+        fi
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+}
+
+# Poll until a shell condition holds, with a deadline in seconds.
+wait_for() {
+    local deadline=$1
+    shift
+    local waited=0
+    while ! "$@"; do
+        if [ "$waited" -ge $((deadline * 10)) ]; then
+            return 1
+        fi
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    return 0
+}
+
 # Create directories
 mkdir -p "$TEST_DIR/outbox"
 mkdir -p "$TEST_DIR/inbox"
 mkdir -p "$TEST_DIR/bundles"
 mkdir -p "$TEST_DIR/metadata"
 
-# Create static routes file - forward everything via file-cla or reflect
+# Create static routes file - reflect anything that has no peer route
 cat > "$TEST_DIR/static_routes" << 'EOF'
 # Forward all bundles - reflect back to sender for testing
 *:** reflect
@@ -89,7 +136,7 @@ node-ids = "$NODE_ID"
 
 [static-routes]
 routes-file = "$TEST_DIR/static_routes"
-watch = false
+watch = "none"
 
 [storage.metadata]
 type = "memory"
@@ -100,9 +147,8 @@ type = "memory"
 [[clas]]
 name = "file-test"
 type = "file-cla"
-[clas.config]
 outbox = "$TEST_DIR/outbox"
-[clas.config.peers]
+[clas.peers]
 "ipn:2.0" = "$TEST_DIR/inbox"
 EOF
 
@@ -113,39 +159,61 @@ echo "=== Static Routes ==="
 cat "$TEST_DIR/static_routes"
 echo ""
 
-# Build bpa-server with file-cla feature
-echo "=== Building bpa-server with file-cla ==="
-cd "$WORKSPACE_DIR"
-cargo build --release -p hardy-bpa-server --no-default-features --features file-cla
+# Build bpa-server with file-cla feature (and the bundle tool if we need
+# to generate the test bundle). Set BUILD_PROFILE=debug for a faster
+# local build.
+BUILD_PROFILE="${BUILD_PROFILE:-release}"
+if [ "$BUILD_PROFILE" = "release" ]; then
+    CARGO_PROFILE_FLAG="--release"
+else
+    CARGO_PROFILE_FLAG=""
+fi
 
-BPA_BIN="$WORKSPACE_DIR/target/release/hardy-bpa-server"
+echo "=== Building bpa-server with file-cla ($BUILD_PROFILE) ==="
+cd "$WORKSPACE_DIR"
+# A minimal build: the config below selects the memory backends
+# explicitly, so no storage feature is needed.
+cargo build $CARGO_PROFILE_FLAG -p hardy-bpa-server --no-default-features --features file-cla
+
+BPA_BIN="$WORKSPACE_DIR/target/$BUILD_PROFILE/hardy-bpa-server"
 
 if [ ! -x "$BPA_BIN" ]; then
     echo "ERROR: Failed to build hardy-bpa-server"
     exit 1
 fi
 
+# Determine bundle file to use
+BUNDLE_FILE="${1:-}"
+if [ -z "$BUNDLE_FILE" ] && [ "$INTERACTIVE" = false ]; then
+    echo ""
+    echo "=== Generating test bundle ==="
+    cargo build $CARGO_PROFILE_FLAG -p hardy-bpv7-tools
+    BUNDLE_BIN="$WORKSPACE_DIR/target/$BUILD_PROFILE/bundle"
+    BUNDLE_FILE="$TEST_DIR/test.bundle"
+    "$BUNDLE_BIN" create --source "ipn:3.1" --destination "ipn:2.0" \
+        --payload "Hello, bundle processing test" --output "$BUNDLE_FILE"
+fi
+
+BPA_LOG="$TEST_DIR/bpa.log"
+
 echo ""
 echo "=== Starting BPA Server ==="
-"$BPA_BIN" -c "$TEST_DIR/config.toml" &
+echo "Server log: $BPA_LOG"
+"$BPA_BIN" -c "$TEST_DIR/config.toml" > "$BPA_LOG" 2>&1 &
 BPA_PID=$!
 
-# Wait for server to start
-sleep 2
-
-if ! kill -0 "$BPA_PID" 2>/dev/null; then
+# Wait for the server to report readiness
+if ! wait_for_log "$BPA_LOG" "Started successfully" 1 20 "$BPA_PID"; then
     echo "ERROR: BPA server failed to start"
-    wait "$BPA_PID" || true
+    cat "$BPA_LOG"
     exit 1
 fi
 
 echo "BPA server started with PID $BPA_PID"
 
-# Determine bundle file to use
-BUNDLE_FILE="${1:-}"
-if [ -z "$BUNDLE_FILE" ]; then
+if [ "$INTERACTIVE" = true ]; then
     echo ""
-    echo "No bundle file specified."
+    echo "Interactive mode."
     echo "To test, copy a bundle file to: $TEST_DIR/outbox/"
     echo ""
     echo "Example:"
@@ -170,20 +238,23 @@ echo "=== Submitting bundle to BPA ==="
 echo "Bundle: $BUNDLE_FILE"
 cp "$BUNDLE_FILE" "$TEST_DIR/outbox/test_bundle.bin"
 
-# Wait for processing
-echo "Waiting for bundle to be processed..."
-sleep 3
+FAILED=0
 
-# Check if the bundle was processed (file should be removed from outbox)
-if [ -f "$TEST_DIR/outbox/test_bundle.bin" ]; then
-    echo "WARNING: Bundle file still in outbox - may not have been processed"
-else
+# The bundle must be consumed from the outbox
+echo "Waiting for bundle to be processed..."
+if wait_for 20 test ! -f "$TEST_DIR/outbox/test_bundle.bin"; then
     echo "Bundle file was consumed from outbox"
+else
+    echo "ERROR: Bundle file still in outbox - not processed"
+    FAILED=1
 fi
 
-# Check for any output in inbox
-OUTPUT_COUNT=$(find "$TEST_DIR/inbox" -type f 2>/dev/null | wc -l)
-if [ "$OUTPUT_COUNT" -gt 0 ]; then
+# ... and an output bundle must appear in the peer inbox
+inbox_has_output() {
+    [ "$(find "$TEST_DIR/inbox" -type f 2>/dev/null | wc -l)" -gt 0 ]
+}
+if wait_for 20 inbox_has_output; then
+    OUTPUT_COUNT=$(find "$TEST_DIR/inbox" -type f 2>/dev/null | wc -l)
     echo ""
     echo "=== Output Bundles ($OUTPUT_COUNT) ==="
     ls -la "$TEST_DIR/inbox"
@@ -193,11 +264,18 @@ if [ "$OUTPUT_COUNT" -gt 0 ]; then
         echo "Output bundles will be saved to: $OUTPUT_DIR"
     fi
 else
-    echo "No output bundles generated"
+    echo "ERROR: no output bundle appeared in the peer inbox"
+    FAILED=1
 fi
 
 echo ""
+if [ "$FAILED" -ne 0 ]; then
+    echo "=== Test FAILED ==="
+    echo "Last 50 lines of the server log:"
+    tail -n 50 "$BPA_LOG"
+    exit 1
+fi
+
 echo "=== Test Complete ==="
-echo "Check the log output above for any parsing errors."
 echo ""
 echo "Stopping BPA server..."

--- a/bpa-server/tests/test_static_routes.sh
+++ b/bpa-server/tests/test_static_routes.sh
@@ -20,7 +20,6 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-NODE_PORT=4570
 PING_COUNT=3
 
 RED='\033[0;31m'
@@ -33,6 +32,64 @@ log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
 log_step() { echo -e "${BLUE}[STEP]${NC} $*"; }
+
+# Probe a TCP port with bash's /dev/tcp; success means something is listening.
+port_open() {
+    (exec 3<>"/dev/tcp/$1/$2") 2>/dev/null
+}
+
+# Pick a TCP port nothing is listening on.
+find_free_port() {
+    local port
+    while :; do
+        port=$(( (RANDOM % 20000) + 20000 ))
+        if ! port_open 127.0.0.1 "$port" && ! port_open ::1 "$port"; then
+            echo "$port"
+            return 0
+        fi
+    done
+}
+
+# Poll until a TCP port accepts connections, with a deadline in seconds.
+# Fails fast when the given process dies first.
+wait_for_port() {
+    local host=$1 port=$2 deadline=$3 label=$4 pid=$5
+    local waited=0
+    while ! port_open "$host" "$port"; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            log_error "$label exited before listening on $host:$port"
+            return 1
+        fi
+        if [ "$waited" -ge $((deadline * 10)) ]; then
+            log_error "Timed out waiting for $label on $host:$port"
+            return 1
+        fi
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    return 0
+}
+
+# Poll until a file contains at least N occurrences of a pattern, with a
+# deadline in seconds.
+wait_for_log() {
+    local file=$1 pattern=$2 count=$3 deadline=$4
+    local waited=0 seen
+    while :; do
+        seen=$(grep -c "$pattern" "$file" 2>/dev/null) || true
+        if [ "${seen:-0}" -ge "$count" ]; then
+            return 0
+        fi
+        if [ "$waited" -ge $((deadline * 10)) ]; then
+            log_error "Timed out waiting for ${count}x '$pattern' in $file"
+            return 1
+        fi
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+}
+
+NODE_PORT=$(find_free_port)
 
 SKIP_BUILD=false
 while [[ $# -gt 0 ]]; do
@@ -76,14 +133,20 @@ trap cleanup EXIT INT TERM
 TEST_DIR=$(mktemp -d)
 log_info "Test directory: $TEST_DIR"
 
+# Set BUILD_PROFILE=debug for a faster local build.
+BUILD_PROFILE="${BUILD_PROFILE:-release}"
 if [ "$SKIP_BUILD" = false ]; then
-    log_step "Building..."
+    log_step "Building ($BUILD_PROFILE)..."
     cd "$WORKSPACE_DIR"
-    cargo build --release -p hardy-tools -p hardy-bpa-server
+    if [ "$BUILD_PROFILE" = "release" ]; then
+        cargo build --release -p hardy-tools -p hardy-bpa-server
+    else
+        cargo build -p hardy-tools -p hardy-bpa-server
+    fi
 fi
 
-BP_BIN="$WORKSPACE_DIR/target/release/bp"
-BPA_BIN="$WORKSPACE_DIR/target/release/hardy-bpa-server"
+BP_BIN="$WORKSPACE_DIR/target/$BUILD_PROFILE/bp"
+BPA_BIN="$WORKSPACE_DIR/target/$BUILD_PROFILE/hardy-bpa-server"
 
 for bin in "$BP_BIN" "$BPA_BIN"; do
     [ -x "$bin" ] || { log_error "Not found: $bin"; exit 1; }
@@ -97,15 +160,17 @@ cat > "$ROUTES_FILE" <<EOF
 ipn:*.*.* drop
 EOF
 
-# Start BPA with echo + static routes + watch
+# Start BPA with echo + static routes + watch. debug logging so route
+# installs/withdrawals ("Adding route"/"Removed route" from the RIB) are
+# observable in the log.
 cat > "$TEST_DIR/bpa.yaml" <<EOF
 node-ids: "ipn:1.0"
-log-level: warn
+log-level: debug
 built-in-services:
   echo: [7]
 static-routes:
   routes-file: "$ROUTES_FILE"
-  watch: true
+  watch: native
 storage:
   metadata:
     type: memory
@@ -114,41 +179,64 @@ storage:
 clas:
   - name: tcp0
     type: tcpclv4
-    address: "[::]:$NODE_PORT"
+    listeners: ["[::]:$NODE_PORT"]
 EOF
 
+BPA_LOG="$TEST_DIR/bpa.log"
+
 log_step "Starting BPA server..."
-"$BPA_BIN" --config "$TEST_DIR/bpa" &
+"$BPA_BIN" --config "$TEST_DIR/bpa" > "$BPA_LOG" 2>&1 &
 BPA_PID=$!
-sleep 1
-kill -0 "$BPA_PID" 2>/dev/null || { log_error "BPA failed to start"; exit 1; }
+wait_for_port 127.0.0.1 "$NODE_PORT" 20 "BPA TCPCLv4" "$BPA_PID" \
+    || { log_error "BPA failed to start"; cat "$BPA_LOG"; exit 1; }
 
-# TEST 1: Startup
+# TEST 1: Startup, and the initial route actually lands in the RIB
 log_step "TEST 1: Startup with routes file"
-log_info "TEST 1: PASSED"
+if wait_for_log "$BPA_LOG" "Adding route .*source 'static_routes'" 1 15; then
+    log_info "TEST 1: PASSED"
+else
+    log_error "TEST 1: FAILED (initial static route not installed)"
+    FAILURES=$((FAILURES + 1))
+fi
 
-# TEST 2: Hot-reload
+# TEST 2: Hot-reload installs the new route
 log_step "TEST 2: Hot-reload — modify routes file"
 cat > "$ROUTES_FILE" <<EOF
 ipn:*.*.* drop
 ipn:99.*.* drop 3
 EOF
-sleep 2
-kill -0 "$BPA_PID" 2>/dev/null && log_info "TEST 2: PASSED" || { log_error "TEST 2: FAILED"; FAILURES=$((FAILURES + 1)); }
+if wait_for_log "$BPA_LOG" "Reloading static routes" 1 15 \
+    && wait_for_log "$BPA_LOG" "Adding route ipn:99.*source 'static_routes'" 1 15 \
+    && kill -0 "$BPA_PID" 2>/dev/null; then
+    log_info "TEST 2: PASSED"
+else
+    log_error "TEST 2: FAILED (reload did not install the new route)"
+    FAILURES=$((FAILURES + 1))
+fi
 
-# TEST 3: File removal
+# TEST 3: File removal withdraws both routes
 log_step "TEST 3: File removal"
 rm -f "$ROUTES_FILE"
-sleep 2
-kill -0 "$BPA_PID" 2>/dev/null && log_info "TEST 3: PASSED" || { log_error "TEST 3: FAILED"; FAILURES=$((FAILURES + 1)); }
+if wait_for_log "$BPA_LOG" "Removed route .*source 'static_routes'" 2 15 \
+    && kill -0 "$BPA_PID" 2>/dev/null; then
+    log_info "TEST 3: PASSED"
+else
+    log_error "TEST 3: FAILED (routes not withdrawn after file removal)"
+    FAILURES=$((FAILURES + 1))
+fi
 
-# TEST 4: File restore
+# TEST 4: File restore re-installs the route (second add of ipn:*.*.*)
 log_step "TEST 4: File restore"
 cat > "$ROUTES_FILE" <<EOF
 ipn:*.*.* drop
 EOF
-sleep 2
-kill -0 "$BPA_PID" 2>/dev/null && log_info "TEST 4: PASSED" || { log_error "TEST 4: FAILED"; FAILURES=$((FAILURES + 1)); }
+if wait_for_log "$BPA_LOG" "Adding route .*source 'static_routes'" 3 15 \
+    && kill -0 "$BPA_PID" 2>/dev/null; then
+    log_info "TEST 4: PASSED"
+else
+    log_error "TEST 4: FAILED (route not re-installed after restore)"
+    FAILURES=$((FAILURES + 1))
+fi
 
 # TEST 5: Ping echo — BPA still functional
 log_step "TEST 5: Ping echo service"

--- a/bpa-server/tests/test_static_routes.sh
+++ b/bpa-server/tests/test_static_routes.sh
@@ -33,52 +33,20 @@ log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
 log_step() { echo -e "${BLUE}[STEP]${NC} $*"; }
 
-# Probe a TCP port with bash's /dev/tcp; success means something is listening.
-port_open() {
-    (exec 3<>"/dev/tcp/$1/$2") 2>/dev/null
-}
-
-# Pick a TCP port nothing is listening on.
-find_free_port() {
-    local port
-    while :; do
-        port=$(( (RANDOM % 20000) + 20000 ))
-        if ! port_open 127.0.0.1 "$port" && ! port_open ::1 "$port"; then
-            echo "$port"
-            return 0
-        fi
-    done
-}
-
-# Poll until a TCP port accepts connections, with a deadline in seconds.
-# Fails fast when the given process dies first.
-wait_for_port() {
-    local host=$1 port=$2 deadline=$3 label=$4 pid=$5
-    local waited=0
-    while ! port_open "$host" "$port"; do
-        if ! kill -0 "$pid" 2>/dev/null; then
-            log_error "$label exited before listening on $host:$port"
-            return 1
-        fi
-        if [ "$waited" -ge $((deadline * 10)) ]; then
-            log_error "Timed out waiting for $label on $host:$port"
-            return 1
-        fi
-        sleep 0.1
-        waited=$((waited + 1))
-    done
-    return 0
-}
-
 # Poll until a file contains at least N occurrences of a pattern, with a
-# deadline in seconds.
+# deadline in seconds. Fails fast when the given process dies first, so a
+# dead server does not burn every remaining deadline in turn.
 wait_for_log() {
-    local file=$1 pattern=$2 count=$3 deadline=$4
+    local file=$1 pattern=$2 count=$3 deadline=$4 pid=${5:-}
     local waited=0 seen
     while :; do
         seen=$(grep -c "$pattern" "$file" 2>/dev/null) || true
         if [ "${seen:-0}" -ge "$count" ]; then
             return 0
+        fi
+        if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+            log_error "Process $pid exited while waiting for '$pattern'"
+            return 1
         fi
         if [ "$waited" -ge $((deadline * 10)) ]; then
             log_error "Timed out waiting for ${count}x '$pattern' in $file"
@@ -88,8 +56,6 @@ wait_for_log() {
         waited=$((waited + 1))
     done
 }
-
-NODE_PORT=$(find_free_port)
 
 SKIP_BUILD=false
 while [[ $# -gt 0 ]]; do
@@ -179,7 +145,7 @@ storage:
 clas:
   - name: tcp0
     type: tcpclv4
-    listeners: ["[::]:$NODE_PORT"]
+    listeners: ["[::]:0"]
 EOF
 
 BPA_LOG="$TEST_DIR/bpa.log"
@@ -187,12 +153,20 @@ BPA_LOG="$TEST_DIR/bpa.log"
 log_step "Starting BPA server..."
 "$BPA_BIN" --config "$TEST_DIR/bpa" > "$BPA_LOG" 2>&1 &
 BPA_PID=$!
-wait_for_port 127.0.0.1 "$NODE_PORT" 20 "BPA TCPCLv4" "$BPA_PID" \
+
+# The CLA is configured with port 0, so the kernel picks the port and the
+# listener reports what it bound. Reading it back is race-free: the socket
+# is bound and accepting by the time the line is logged, so there is no
+# window in which anything else can take the port.
+wait_for_log "$BPA_LOG" "TCP server listening on " 1 20 "$BPA_PID" \
     || { log_error "BPA failed to start"; cat "$BPA_LOG"; exit 1; }
+NODE_PORT=$(grep -o "TCP server listening on .*:[0-9]\+" "$BPA_LOG" | head -1 | sed 's/.*://')
+[ -n "$NODE_PORT" ] || { log_error "Could not read the bound port"; cat "$BPA_LOG"; exit 1; }
+log_info "BPA TCPCLv4 listening on port $NODE_PORT"
 
 # TEST 1: Startup, and the initial route actually lands in the RIB
 log_step "TEST 1: Startup with routes file"
-if wait_for_log "$BPA_LOG" "Adding route .*source 'static_routes'" 1 15; then
+if wait_for_log "$BPA_LOG" "Adding route .*source 'static_routes'" 1 15 "$BPA_PID"; then
     log_info "TEST 1: PASSED"
 else
     log_error "TEST 1: FAILED (initial static route not installed)"
@@ -205,8 +179,8 @@ cat > "$ROUTES_FILE" <<EOF
 ipn:*.*.* drop
 ipn:99.*.* drop 3
 EOF
-if wait_for_log "$BPA_LOG" "Reloading static routes" 1 15 \
-    && wait_for_log "$BPA_LOG" "Adding route ipn:99.*source 'static_routes'" 1 15 \
+if wait_for_log "$BPA_LOG" "Reloading static routes" 1 15 "$BPA_PID" \
+    && wait_for_log "$BPA_LOG" "Adding route ipn:99.*source 'static_routes'" 1 15 "$BPA_PID" \
     && kill -0 "$BPA_PID" 2>/dev/null; then
     log_info "TEST 2: PASSED"
 else
@@ -217,7 +191,7 @@ fi
 # TEST 3: File removal withdraws both routes
 log_step "TEST 3: File removal"
 rm -f "$ROUTES_FILE"
-if wait_for_log "$BPA_LOG" "Removed route .*source 'static_routes'" 2 15 \
+if wait_for_log "$BPA_LOG" "Removed route .*source 'static_routes'" 2 15 "$BPA_PID" \
     && kill -0 "$BPA_PID" 2>/dev/null; then
     log_info "TEST 3: PASSED"
 else
@@ -230,7 +204,7 @@ log_step "TEST 4: File restore"
 cat > "$ROUTES_FILE" <<EOF
 ipn:*.*.* drop
 EOF
-if wait_for_log "$BPA_LOG" "Adding route .*source 'static_routes'" 3 15 \
+if wait_for_log "$BPA_LOG" "Adding route .*source 'static_routes'" 3 15 "$BPA_PID" \
     && kill -0 "$BPA_PID" 2>/dev/null; then
     log_info "TEST 4: PASSED"
 else


### PR DESCRIPTION
# Fix feature-reduced storage config and make the bpa-server e2e scripts assert real outcomes

## Background

bpa-server's e2e shell scripts existed but proved nothing: `test_bundle_processing.sh` nested its file-cla settings under a key the CLA never reads and exited 0 unconditionally, and `test_static_routes.sh` asserted only that the process was still alive after each reload. Reviving the first script uncovered a production config bug.

## The production fix

`StorageConfig` used a container-level `#[serde(default)]`, which constructs the complete `Default` up front, and the backend selector defaults deliberately panic in builds without the default-backend features. The result: a build without `sqlite-storage` panicked at startup even when the config explicitly selected `storage.metadata: memory`, contradicting the comment at the panic site. Defaults are now per-field, so they fire only for keys actually absent: explicitly configured backends load in any build, and the unconfigured default still refuses to silently degrade to the memory backend, which the existing `should_panic`-gated test continues to pin.

## The scripts

- `test_bundle_processing.sh` builds with `--no-default-features --features file-cla` (its original intent, viable again with the fix), nests the file-cla keys where `hardy_file_cla::Config` reads them, polls outbox consumption and peer-inbox delivery with deadlines, and exits nonzero on failure. Verified end to end: the bundle traverses.
- `test_static_routes.sh` asserts observable RIB effects per test (route-add counts by source, reload notices, route removals) with deadline polls instead of `kill -0`, on a dynamic port.

## Named follow-up

Configs that omit `storage:` entirely still panic by design in feature-reduced builds, which also keeps most config tests from running under `--no-default-features`. Surfacing the missing-default as a `Config::load` error instead of a panic would be the deeper fix; it changes the load API's contract, so it is left as its own decision.
