### PR TITLE
fix(tools): treat a failed capability probe as unprivileged

### DIFF
--- a/tools/lib/privilege.rs
+++ b/tools/lib/privilege.rs
@@ -21,13 +21,10 @@ pub fn has_required_privileges() -> bool {
         return true;
     }
 
-    // As a fallback, check if the user is running as root (EUID 0).
-    // A root user implicitly has all capabilities.
-    // Note: The `caps` crate can also check this, but a direct libc call is also common.
-    // We'll stick to the `caps` API for consistency here.
-    if caps::has_cap(None, CapSet::Effective, Capability::CAP_SETFCAP).is_ok() {
-        // A reasonable proxy for checking if the user is root, as only root can set file capabilities.
-        // A more direct check would be `nix::unistd::geteuid().is_root()`.
+    // As a fallback, check whether the process is effectively root: only
+    // root holds CAP_SETFCAP by default, so an effective CAP_SETFCAP is a
+    // reasonable proxy for EUID 0.
+    if caps::has_cap(None, CapSet::Effective, Capability::CAP_SETFCAP).unwrap_or(false) {
         return true;
     }
 
@@ -45,29 +42,30 @@ pub fn has_required_privileges() -> bool {
     unsafe { libc::geteuid() == 0 }
 }
 
+// The function must agree with the platform's ground truth for the
+// privileges it claims to check, whatever privileges the test runner
+// happens to have: the test passes for both privileged and unprivileged
+// runners, but fails if the function's answer diverges from the platform
+// query it is contracted to reflect.
 #[test]
-fn test() -> anyhow::Result<()> {
-    println!("Checking for required privileges...");
+fn agrees_with_platform_ground_truth() {
+    let actual = has_required_privileges();
 
-    if !has_required_privileges() {
-        eprintln!("\nError: This application requires elevated privileges to run.");
+    #[cfg(target_os = "linux")]
+    let expected = {
+        use caps::{CapSet, Capability};
+        caps::has_cap(None, CapSet::Effective, Capability::CAP_NET_ADMIN).unwrap_or(false)
+            || caps::has_cap(None, CapSet::Effective, Capability::CAP_SETFCAP).unwrap_or(false)
+    };
 
-        // Provide platform-specific instructions for the user.
-        cfg_select! {
-            target_os = "windows" => eprintln!("Please right-click the executable and select 'Run as Administrator'."),
-            target_os = "linux" => eprintln!(
-                "Please re-run as root or grant the application the 'CAP_NET_ADMIN' capability using 'setcap'."
-            ),
-            _ => eprintln!("Please re-run as root."),
-        }
+    #[cfg(target_os = "windows")]
+    let expected = check_elevation::is_elevated().unwrap_or(false);
 
-        // Exit with a non-zero status code to indicate an error.
-        return Err(anyhow::anyhow!("Missing required privileges."));
-    }
+    #[cfg(all(unix, not(target_os = "linux")))]
+    let expected = unsafe { libc::geteuid() == 0 };
 
-    println!("Success! Running with sufficient privileges.");
-    // --- Your main application logic would go here ---
-    // For example: opening a raw socket, configuring a network interface, etc.
-
-    Ok(())
+    assert_eq!(
+        actual, expected,
+        "has_required_privileges() disagrees with the platform privilege query"
+    );
 }

--- a/tools/src/ping/payload.rs
+++ b/tools/src/ping/payload.rs
@@ -186,3 +186,88 @@ pub fn build_payload(args: &Command, seq_no: u32) -> anyhow::Result<BuiltPing> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    fn base_command() -> Command {
+        Command::try_parse_from(["bp-ping", "-S", "ipn:1.1", "ipn:2.7"]).unwrap()
+    }
+
+    // The wire format is a CBOR sequence number followed by raw 0xAA padding.
+    #[test]
+    fn test_payload_round_trip() {
+        for padding in [0usize, 1, 1000] {
+            let bytes = Payload::new(u32::MAX).with_padding(padding).to_bytes();
+
+            // u32::MAX encodes as a 5-byte CBOR unsigned integer.
+            assert_eq!(bytes.len(), 5 + padding);
+            assert!(bytes[5..].iter().all(|b| *b == PADDING_BYTE));
+
+            let parsed = Payload::parse(&bytes).unwrap();
+            assert_eq!(parsed.seqno, u32::MAX);
+            assert_eq!(parsed.padding_len, padding);
+        }
+
+        assert!(Payload::parse(&[]).is_err());
+    }
+
+    // Sweep every target size across a window that includes the CBOR
+    // byte-string length-field boundaries (payload 23->24 and 255->256 bytes):
+    // each target must yield either a bundle of exactly that size or a clean
+    // error for the sizes the length-field jumps make unreachable — never a
+    // wrong-sized Ok.
+    fn run_size_sweep() {
+        let mut args = base_command();
+
+        let base_len = build_payload(&args, 0).unwrap().0.len();
+
+        // Below the minimum: a clean error.
+        args.size = Some(base_len - 1);
+        assert!(build_payload(&args, 0).is_err());
+
+        let mut unreachable_targets = 0;
+        for target in base_len..base_len + 300 {
+            args.size = Some(target);
+            match build_payload(&args, 0) {
+                Ok((bundle, payload)) => {
+                    assert_eq!(
+                        bundle.len(),
+                        target,
+                        "build_payload returned a wrong-sized bundle for target {target}"
+                    );
+                    // The reflected-payload comparison depends on the returned
+                    // payload bytes matching what was actually built in.
+                    let parsed = Payload::parse(&payload).unwrap();
+                    assert_eq!(parsed.seqno, 0);
+                }
+                Err(_) => unreachable_targets += 1,
+            }
+        }
+
+        // The payload byte-string length field widens twice in this window,
+        // each jump skipping exactly one target size.
+        assert!(
+            (1..=4).contains(&unreachable_targets),
+            "unexpected number of unreachable target sizes: {unreachable_targets}"
+        );
+    }
+
+    #[test]
+    fn test_build_payload_exact_sizes() {
+        // Watchdog, not synchronization: the sweep is pure computation and
+        // finishes in well under a second. The generous bound only converts a
+        // non-terminating binary-search regression into a test failure instead
+        // of a hung test run.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            run_size_sweep();
+            tx.send(()).ok();
+        });
+        rx.recv_timeout(std::time::Duration::from_secs(120))
+            .expect("build_payload size sweep did not terminate");
+    }
+}

--- a/tools/src/ping/service.rs
+++ b/tools/src/ping/service.rs
@@ -719,3 +719,125 @@ impl hardy_bpa::services::Service for Service {
         // Status reports arrive via on_deliver when report_to = service EID
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use hardy_bpv7::eid::IpnNodeId;
+
+    use super::*;
+
+    // min/max/avg/stddev over a known sample set, recorded out of order to
+    // catch a swapped min/max fold.
+    #[test]
+    fn test_statistics_math() {
+        let mut stats = Statistics::default();
+        stats.record_rtt(Duration::from_millis(4));
+        stats.record_rtt(Duration::from_millis(2));
+        stats.record_rtt(Duration::from_millis(6));
+
+        assert_eq!(stats.received, 3);
+        assert_eq!(stats.min_rtt, Some(Duration::from_millis(2)));
+        assert_eq!(stats.max_rtt, Some(Duration::from_millis(6)));
+        assert_eq!(stats.avg_rtt(), Some(Duration::from_millis(4)));
+        // Population stddev of {2ms, 4ms, 6ms} is 1632.99us; the integer
+        // arithmetic truncates to 1632us.
+        assert_eq!(stats.stddev_rtt(), Some(Duration::from_micros(1632)));
+    }
+
+    // Identical samples have zero spread.
+    #[test]
+    fn test_statistics_identical_samples() {
+        let mut stats = Statistics::default();
+        for _ in 0..3 {
+            stats.record_rtt(Duration::from_millis(5));
+        }
+
+        assert_eq!(stats.min_rtt, Some(Duration::from_millis(5)));
+        assert_eq!(stats.max_rtt, Some(Duration::from_millis(5)));
+        assert_eq!(stats.avg_rtt(), Some(Duration::from_millis(5)));
+        assert_eq!(stats.stddev_rtt(), Some(Duration::ZERO));
+    }
+
+    // A single sample has an average but no defined deviation.
+    #[test]
+    fn test_statistics_single_sample() {
+        let mut stats = Statistics::default();
+        stats.record_rtt(Duration::from_millis(2));
+
+        assert_eq!(stats.avg_rtt(), Some(Duration::from_millis(2)));
+        assert_eq!(stats.stddev_rtt(), None);
+    }
+
+    // No samples: no averages, and 0% loss when nothing was sent.
+    #[test]
+    fn test_statistics_empty() {
+        let stats = Statistics::default();
+
+        assert_eq!(stats.avg_rtt(), None);
+        assert_eq!(stats.stddev_rtt(), None);
+        assert_eq!(stats.min_rtt, None);
+        assert_eq!(stats.max_rtt, None);
+        assert_eq!(stats.loss_percent(), 0.0);
+    }
+
+    #[test]
+    fn test_loss_percent() {
+        let mut stats = Statistics {
+            sent: 4,
+            ..Default::default()
+        };
+        for _ in 0..3 {
+            stats.record_rtt(Duration::from_millis(1));
+        }
+        assert_eq!(stats.loss_percent(), 25.0);
+
+        stats.record_rtt(Duration::from_millis(1));
+        assert_eq!(stats.loss_percent(), 0.0);
+    }
+
+    // Text always parses to the 3-element `Eid::Ipn` form; the legacy
+    // 2-element form only arises from CBOR decoding, so it is constructed
+    // directly here.
+    fn legacy_ipn(node_number: u32, service_number: u32) -> Eid {
+        Eid::LegacyIpn {
+            fqnn: IpnNodeId {
+                allocator_id: 0,
+                node_number,
+            },
+            service_number,
+        }
+    }
+
+    fn eid(s: &str) -> Eid {
+        s.parse().unwrap()
+    }
+
+    // RFC 9758: the legacy 2-element and 3-element encodings of the same ipn
+    // endpoint are distinct Eid variants but the same endpoint; anything else
+    // that differs is a different endpoint.
+    #[test]
+    fn test_same_endpoint() {
+        // 2-element vs 3-element encodings of ipn:0.1.2 collapse, both ways.
+        assert!(same_endpoint(&legacy_ipn(1, 2), &eid("ipn:0.1.2")));
+        assert!(same_endpoint(&eid("ipn:0.1.2"), &legacy_ipn(1, 2)));
+
+        // Structural equality still matches.
+        assert!(same_endpoint(&eid("ipn:1.2"), &eid("ipn:0.1.2")));
+        assert!(same_endpoint(&Eid::Null, &Eid::Null));
+
+        // Different service or node numbers do not match.
+        assert!(!same_endpoint(&legacy_ipn(1, 2), &eid("ipn:1.3")));
+        assert!(!same_endpoint(&legacy_ipn(1, 2), &eid("ipn:2.2")));
+
+        // dtn endpoints differing only in demux do not match.
+        assert!(!same_endpoint(&eid("dtn://node/a"), &eid("dtn://node/b")));
+
+        // Different schemes do not match.
+        assert!(!same_endpoint(&eid("dtn://node/a"), &eid("ipn:1.2")));
+
+        // The null endpoint has no node-id (the to_node_id Err arm).
+        assert!(!same_endpoint(&Eid::Null, &eid("ipn:1.2")));
+    }
+}


### PR DESCRIPTION
# Fix the privilege probe and test the ping arithmetic

## Background

`tools/lib/privilege.rs` decides whether the CLI runs with elevated privileges. Its test asserted the CI runner's privileges rather than any code behavior: it failed on any unprivileged macOS or BSD machine, and passed on Linux only because of a bug in the function under test.

## What this changes and why

- **The bug:** the Linux capability probe used `caps::has_cap(...).is_ok()`, so a *failed probe* counted as privileged. It now treats a failed probe as unprivileged (`unwrap_or(false)`). The replacement test compares the function against platform ground truth, so it passes on privileged and unprivileged runners alike and fails exactly if the `is_ok()` regression returns.
- **Ping math, previously untested pure functions:** `build_payload`'s exact-target-size search is exercised across a 300-size sweep spanning the CBOR length-field boundaries, under a watchdog that turns a non-terminating binary-search mutant into a failure rather than a hang; `Statistics` (min/max under out-of-order recording, average, an exact stddev case, loss percentage, and the empty/single-sample edges) and `same_endpoint`'s RFC 9758 two-and-three-element ipn collapsing (with directly constructed legacy EIDs, since text never parses to the legacy form) are pinned.

## Verification

`cargo test -p hardy-tools`, clippy `-D warnings`, and fmt are clean; the privilege test passes as an unprivileged user here and is written to pass for root as well.
