### PR TITLE
Fix: dispatch outbox files that predate the watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,6 +2101,7 @@ dependencies = [
  "notify",
  "notify-debouncer-full",
  "serde",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/file-cla/CHANGELOG.md
+++ b/file-cla/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 - Adapted to the `hardy-bpa` deferred transfer-outcome CLA contract (new `Cla::forward` signature). Behaviour is unchanged: forwards remain terminal.
 
+### Fixed
+- Files already sitting in the outbox when the CLA starts are dispatched instead of ignored until something touches them again. Filesystem notifications only cover files created after the watch is installed, so a bundle queued while the CLA was down (removable media, a restart) stayed there indefinitely. The watcher now scans the outbox once, after installing the watch so nothing arriving mid-scan is missed, and resolves symlinks so the scan and the notification path agree about the same directory entry.
+
 ## [0.2.0]
 
 ### Changed

--- a/file-cla/Cargo.toml
+++ b/file-cla/Cargo.toml
@@ -33,3 +33,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 notify-debouncer-full = "0.7"
 notify = { version = "8", default-features = false, features = ["macos_kqueue"] }
 flume = "0.12"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread", "time"] }

--- a/file-cla/docs/design.md
+++ b/file-cla/docs/design.md
@@ -58,6 +58,10 @@ The CLA uses the `notify` crate with `notify-debouncer-full` for filesystem moni
 
 Only `Create(File)` events trigger bundle dispatch. This avoids reacting to modifications or deletions.
 
+On startup the watcher first scans the outbox and dispatches any files already present: bundles are routinely queued while the CLA is not running (removable media, restarts), and filesystem notifications only cover files created after the watch is installed.
+
+The scan resolves symlinks, so a linked file is dispatched exactly as a regular one is: the notification path reports a symlink's creation as an ordinary file creation, and the two paths must agree about the same directory entry.
+
 ### Bundle ID-Based File Naming
 
 When writing bundles for egress, files are named using the bundle's source EID and creation timestamp:

--- a/file-cla/src/lib.rs
+++ b/file-cla/src/lib.rs
@@ -153,3 +153,64 @@ impl Cla {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A relative path is joined onto the supplied cwd and the directory chain
+    // is created.
+    #[test]
+    fn test_canonicalize_relative_path_joins_cwd() {
+        let cwd = tempfile::tempdir().unwrap();
+
+        let result = canonicalize_path(cwd.path(), &PathBuf::from("nested/dir")).unwrap();
+
+        let expected = cwd.path().join("nested/dir");
+        assert!(expected.is_dir(), "directory chain should be created");
+        assert_eq!(PathBuf::from(result), expected.canonicalize().unwrap());
+    }
+
+    // An absolute path ignores the cwd entirely (Path::join semantics); nothing
+    // is created under the cwd.
+    #[test]
+    fn test_canonicalize_absolute_path_ignores_cwd() {
+        let cwd = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let target = other.path().join("inbox");
+
+        let result = canonicalize_path(cwd.path(), &target).unwrap();
+
+        assert!(target.is_dir());
+        assert_eq!(PathBuf::from(result), target.canonicalize().unwrap());
+        assert_eq!(
+            std::fs::read_dir(cwd.path()).unwrap().count(),
+            0,
+            "an absolute path must not be prefixed with the cwd"
+        );
+    }
+
+    // A regular file already occupying the target path surfaces as CreateDir,
+    // not Canonicalize.
+    #[test]
+    fn test_canonicalize_existing_file_is_create_dir_error() {
+        let cwd = tempfile::tempdir().unwrap();
+        std::fs::write(cwd.path().join("occupied"), b"not a directory").unwrap();
+
+        let err = canonicalize_path(cwd.path(), &PathBuf::from("occupied")).unwrap_err();
+        assert!(matches!(err, Error::CreateDir { .. }), "got {err:?}");
+    }
+
+    // A non-UTF-8 path component is rejected up front as InvalidPath.
+    #[cfg(unix)]
+    #[test]
+    fn test_canonicalize_non_utf8_is_invalid_path() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let cwd = tempfile::tempdir().unwrap();
+        let component = std::ffi::OsString::from_vec(vec![0x66, 0xff, 0xfe]);
+
+        let err = canonicalize_path(cwd.path(), &PathBuf::from(component)).unwrap_err();
+        assert!(matches!(err, Error::InvalidPath(_)), "got {err:?}");
+    }
+}

--- a/file-cla/src/watcher.rs
+++ b/file-cla/src/watcher.rs
@@ -1,8 +1,10 @@
-use super::*;
 use notify_debouncer_full::{
     DebouncedEvent, new_debouncer,
     notify::{EventKind, RecursiveMode, event::CreateKind},
 };
+use tokio::fs::{metadata, read_dir};
+
+use super::*;
 
 impl Cla {
     /// Starts the file watcher for the outbox directory.
@@ -63,6 +65,37 @@ async fn watcher_task(
         .trace_expect("Failed to watch file");
 
     info!("Watching '{outbox}' for new files");
+
+    // Dispatch files already queued in the outbox: bundles are routinely
+    // dropped in the directory while the CLA is not running (removable media,
+    // restarts), and the watcher only reports files created after the watch is
+    // installed. The watch is installed before this scan, so a file arriving
+    // mid-scan is seen by at least one of the two paths; the forwarder
+    // tolerates the resulting duplicate.
+    match read_dir(&outbox).await {
+        Ok(mut entries) => loop {
+            match entries.next_entry().await {
+                Ok(Some(entry)) => {
+                    // `metadata` follows symlinks where `DirEntry::file_type`
+                    // does not: inotify reports the creation of a symlink as
+                    // an ordinary file creation, so the scan has to accept one
+                    // too, or the two paths disagree about the same entry.
+                    let path = entry.path();
+                    if metadata(&path).await.is_ok_and(|m| m.is_file())
+                        && path_tx.send_async(path).await.is_err()
+                    {
+                        return;
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    error!("Failed to scan outbox '{outbox}': {e}");
+                    break;
+                }
+            }
+        },
+        Err(e) => error!("Failed to scan outbox '{outbox}': {e}"),
+    }
 
     loop {
         tokio::select! {

--- a/file-cla/tests/cla.rs
+++ b/file-cla/tests/cla.rs
@@ -1,0 +1,231 @@
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+use hardy_bpa::cla::{Cla as _, ClaAddress, ForwardBundleResult};
+use hardy_bpv7::{bundle::FragmentInfo, eid::NodeId};
+use hardy_file_cla::{Cla, Config};
+
+// A Sink stub that records add_peer addresses; the forward path never
+// dispatches inbound bundles.
+struct StubSink(Arc<Mutex<Vec<ClaAddress>>>);
+
+#[hardy_bpa::async_trait]
+impl hardy_bpa::cla::Sink for StubSink {
+    async fn unregister(&self) {}
+
+    async fn dispatch(
+        &self,
+        _peer_node: Option<&NodeId>,
+        _peer_addr: Option<&ClaAddress>,
+        _stream: &mut dyn hardy_bpa::stream::Receiver<hardy_bpa::cla::Segment>,
+    ) -> hardy_bpa::cla::Result<()> {
+        unreachable!("forward tests never dispatch inbound bundles");
+    }
+
+    async fn add_peer(
+        &self,
+        cla_addr: ClaAddress,
+        _node_ids: &[NodeId],
+    ) -> hardy_bpa::cla::Result<bool> {
+        self.0.lock().unwrap().push(cla_addr);
+        Ok(true)
+    }
+
+    async fn remove_peer(&self, _cla_addr: &ClaAddress) -> hardy_bpa::cla::Result<bool> {
+        Ok(true)
+    }
+
+    async fn transfer_outcome(
+        &self,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        _outcome: hardy_bpa::cla::TransferOutcome,
+    ) -> hardy_bpa::cla::Result<()> {
+        Ok(())
+    }
+}
+
+// Registered CLA with a single peer inbox, plus the ClaAddress the CLA
+// announced for that inbox.
+async fn registered_cla(inbox: &Path) -> (Cla, ClaAddress) {
+    let peer: NodeId = "ipn:9.0".parse::<NodeId>().unwrap();
+    let cla = Cla::new(&Config {
+        outbox: None,
+        peers: HashMap::from([(peer, inbox.to_path_buf())]),
+    })
+    .unwrap();
+
+    let peers = Arc::new(Mutex::new(Vec::new()));
+    cla.on_register(Box::new(StubSink(peers.clone())), &[])
+        .await;
+
+    let addr = peers
+        .lock()
+        .unwrap()
+        .first()
+        .cloned()
+        .expect("no peer registered");
+    (cla, addr)
+}
+
+fn dtn_bundle_id() -> hardy_bpv7::bundle::Id {
+    hardy_bpv7::bundle::Id {
+        source: "dtn://source-node/some/service".parse().unwrap(),
+        ..Default::default()
+    }
+}
+
+// forward() writes the bundle bytes into the peer inbox under a sanitized,
+// single-component filename.
+#[tokio::test]
+async fn test_forward_writes_inbox() {
+    let dir = tempfile::tempdir().unwrap();
+    let (cla, addr) = registered_cla(dir.path()).await;
+
+    let bundle = b"raw-bundle-bytes";
+    let result = cla
+        .forward(
+            None,
+            &addr,
+            &dtn_bundle_id(),
+            bundle.len() as u64,
+            &mut hardy_bpa::Bytes::from_static(bundle),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(result, ForwardBundleResult::Sent));
+
+    let entries: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap())
+        .collect();
+    assert_eq!(entries.len(), 1, "exactly one file written to the inbox");
+    assert!(entries[0].file_type().unwrap().is_file());
+
+    let name = entries[0].file_name().into_string().unwrap();
+    assert!(
+        !name.contains(['\\', '/', ':', ' ']),
+        "filename must be sanitized: {name:?}"
+    );
+    assert_eq!(std::fs::read(entries[0].path()).unwrap(), bundle);
+}
+
+// A fragment's filename carries the `_fragment_<offset>` suffix.
+#[tokio::test]
+async fn test_forward_fragment_suffix() {
+    let dir = tempfile::tempdir().unwrap();
+    let (cla, addr) = registered_cla(dir.path()).await;
+
+    let bundle_id = hardy_bpv7::bundle::Id {
+        fragment_info: Some(FragmentInfo {
+            offset: 42,
+            total_adu_length: 100,
+        }),
+        ..dtn_bundle_id()
+    };
+
+    let result = cla
+        .forward(
+            None,
+            &addr,
+            &bundle_id,
+            4,
+            &mut hardy_bpa::Bytes::from_static(b"frag"),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(result, ForwardBundleResult::Sent));
+
+    let entry = std::fs::read_dir(dir.path())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+    let name = entry.file_name().into_string().unwrap();
+    assert!(
+        name.ends_with("_fragment_42"),
+        "fragment filename must carry the offset suffix: {name:?}"
+    );
+}
+
+// An address that is not a configured inbox is NoNeighbour, and nothing is
+// written.
+#[tokio::test]
+async fn test_forward_unknown_address_is_no_neighbour() {
+    let dir = tempfile::tempdir().unwrap();
+    let (cla, _addr) = registered_cla(dir.path()).await;
+
+    let unknown = ClaAddress::Private(hardy_bpa::Bytes::from_static(
+        b"/definitely/not/a/registered/inbox",
+    ));
+    let result = cla
+        .forward(
+            None,
+            &unknown,
+            &dtn_bundle_id(),
+            4,
+            &mut hardy_bpa::Bytes::from_static(b"data"),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(result, ForwardBundleResult::NoNeighbour));
+    assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+}
+
+// A failed inbox write surfaces as Error::Internal.
+#[tokio::test]
+async fn test_forward_write_failure_is_internal_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let inbox = dir.path().join("inbox");
+    let (cla, addr) = registered_cla(&inbox).await;
+
+    std::fs::remove_dir_all(&inbox).unwrap();
+
+    let Err(err) = cla
+        .forward(
+            None,
+            &addr,
+            &dtn_bundle_id(),
+            4,
+            &mut hardy_bpa::Bytes::from_static(b"data"),
+        )
+        .await
+    else {
+        panic!("expected a write failure");
+    };
+    assert!(
+        matches!(err, hardy_bpa::cla::Error::Internal(_)),
+        "got {err:?}"
+    );
+}
+
+// forward() before on_register is Disconnected.
+#[tokio::test]
+async fn test_forward_before_register_is_disconnected() {
+    let dir = tempfile::tempdir().unwrap();
+    let cla = Cla::new(&Config {
+        outbox: None,
+        peers: HashMap::from([("ipn:9.0".parse().unwrap(), dir.path().to_path_buf())]),
+    })
+    .unwrap();
+
+    let addr = ClaAddress::Private(hardy_bpa::Bytes::from_static(b"unused"));
+    let Err(err) = cla
+        .forward(
+            None,
+            &addr,
+            &dtn_bundle_id(),
+            4,
+            &mut hardy_bpa::Bytes::from_static(b"data"),
+        )
+        .await
+    else {
+        panic!("expected an error before registration");
+    };
+    assert!(
+        matches!(err, hardy_bpa::cla::Error::Disconnected),
+        "got {err:?}"
+    );
+}

--- a/file-cla/tests/watcher.rs
+++ b/file-cla/tests/watcher.rs
@@ -1,0 +1,174 @@
+use std::{collections::HashMap, path::Path, time::Duration};
+
+use hardy_bpa::cla::{Cla as _, ClaAddress};
+use hardy_bpv7::eid::NodeId;
+use hardy_file_cla::{Cla, Config};
+
+// Regression bound for inotify-driven outcomes, not a synchronization
+// primitive: the watcher debounces events for 1 second and the OS offers
+// no synchronous hook, so tests wait on the observable outcome with a
+// deadline far above the debounce window.
+const REGRESSION_BOUND: Duration = Duration::from_secs(30);
+
+// A Sink stub that forwards every dispatched bundle's bytes to a channel
+// the test can await.
+struct StubSink(flume::Sender<Vec<u8>>);
+
+#[hardy_bpa::async_trait]
+impl hardy_bpa::cla::Sink for StubSink {
+    async fn unregister(&self) {}
+
+    async fn dispatch(
+        &self,
+        _peer_node: Option<&NodeId>,
+        _peer_addr: Option<&ClaAddress>,
+        stream: &mut dyn hardy_bpa::stream::Receiver<hardy_bpa::cla::Segment>,
+    ) -> hardy_bpa::cla::Result<()> {
+        let mut buffer = Vec::new();
+        loop {
+            match stream
+                .recv()
+                .await
+                .map_err(|_| hardy_bpa::cla::Error::StreamCancelled)?
+            {
+                hardy_bpa::cla::Segment::Next(bytes) => buffer.extend_from_slice(&bytes),
+                hardy_bpa::cla::Segment::Final(bytes) => {
+                    buffer.extend_from_slice(&bytes);
+                    break;
+                }
+            }
+        }
+        self.0
+            .send_async(buffer)
+            .await
+            .map_err(|_| hardy_bpa::cla::Error::Disconnected)
+    }
+
+    async fn add_peer(
+        &self,
+        _cla_addr: ClaAddress,
+        _node_ids: &[NodeId],
+    ) -> hardy_bpa::cla::Result<bool> {
+        Ok(true)
+    }
+
+    async fn remove_peer(&self, _cla_addr: &ClaAddress) -> hardy_bpa::cla::Result<bool> {
+        Ok(true)
+    }
+
+    async fn transfer_outcome(
+        &self,
+        _bundle_id: &hardy_bpv7::bundle::Id,
+        _outcome: hardy_bpa::cla::TransferOutcome,
+    ) -> hardy_bpa::cla::Result<()> {
+        Ok(())
+    }
+}
+
+// Registered CLA watching `outbox`, plus the channel of dispatched bundles.
+async fn start_cla(outbox: &Path) -> (Cla, flume::Receiver<Vec<u8>>) {
+    let cla = Cla::new(&Config {
+        outbox: Some(outbox.to_path_buf()),
+        peers: HashMap::new(),
+    })
+    .unwrap();
+
+    let (tx, rx) = flume::unbounded();
+    cla.on_register(Box::new(StubSink(tx)), &[]).await;
+    (cla, rx)
+}
+
+async fn recv_dispatch(rx: &flume::Receiver<Vec<u8>>) -> Vec<u8> {
+    tokio::time::timeout(REGRESSION_BOUND, rx.recv_async())
+        .await
+        .expect("bundle was not dispatched within the regression bound")
+        .expect("dispatch channel closed")
+}
+
+// Poll until the file has been removed after dispatch; deletion follows
+// dispatch with no synchronous hook, so this is deadline-bounded polling
+// on the observable outcome.
+async fn wait_removed(path: &Path) {
+    let deadline = tokio::time::Instant::now() + REGRESSION_BOUND;
+    while path.exists() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "dispatched file was not removed within the regression bound"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+// Files already queued in the outbox when the CLA starts are dispatched
+// and removed: the removable-media use case means bundles routinely arrive
+// while the CLA is not running.
+#[tokio::test]
+async fn test_outbox_pickup_preexisting_file() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("queued"), b"queued-bundle").unwrap();
+
+    let (cla, rx) = start_cla(dir.path()).await;
+
+    assert_eq!(recv_dispatch(&rx).await, b"queued-bundle");
+    wait_removed(&dir.path().join("queued")).await;
+
+    cla.on_unregister().await;
+}
+
+// A symlink queued in the outbox before the CLA starts is dispatched like
+// any other file: inotify reports the creation of a symlink as an ordinary
+// file creation, so the startup scan follows links too rather than leaving
+// the two paths disagreeing about the same entry.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_outbox_pickup_preexisting_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // The target lives outside the outbox, so only the link itself is a
+    // candidate for the scan.
+    let target_dir = tempfile::tempdir().unwrap();
+    let target = target_dir.path().join("target");
+    std::fs::write(&target, b"symlinked-bundle").unwrap();
+    std::os::unix::fs::symlink(&target, dir.path().join("link")).unwrap();
+
+    let (cla, rx) = start_cla(dir.path()).await;
+
+    assert_eq!(recv_dispatch(&rx).await, b"symlinked-bundle");
+    wait_removed(&dir.path().join("link")).await;
+
+    cla.on_unregister().await;
+}
+
+// A file created after the watcher starts is dispatched and removed. The
+// marker file's dispatch proves the one-shot startup scan has finished, so
+// the second file can only be picked up via a filesystem event.
+#[tokio::test]
+async fn test_outbox_pickup_created_file() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("marker"), b"marker-bundle").unwrap();
+    let (cla, rx) = start_cla(dir.path()).await;
+    assert_eq!(recv_dispatch(&rx).await, b"marker-bundle");
+
+    std::fs::write(dir.path().join("created"), b"created-bundle").unwrap();
+
+    assert_eq!(recv_dispatch(&rx).await, b"created-bundle");
+    wait_removed(&dir.path().join("created")).await;
+
+    cla.on_unregister().await;
+}
+
+// on_unregister stops the watcher and forwarder tasks; a hang here is a
+// shutdown regression.
+#[tokio::test]
+async fn test_shutdown_stops_watcher() {
+    let dir = tempfile::tempdir().unwrap();
+    let (cla, rx) = start_cla(dir.path()).await;
+
+    // Prove the watcher is live before shutting it down.
+    std::fs::write(dir.path().join("live"), b"live-bundle").unwrap();
+    assert_eq!(recv_dispatch(&rx).await, b"live-bundle");
+
+    tokio::time::timeout(REGRESSION_BOUND, cla.on_unregister())
+        .await
+        .expect("shutdown did not complete within the regression bound");
+}


### PR DESCRIPTION
Extracted from #703 (the storage/CLA test-overhaul branch), where this fix first surfaced, so it can land ahead of that PR. #703 will shed these files on its next rebase.

The bug
The watcher only reacts to Create(File) filesystem events, which cover files created after the watch is installed. A bundle queued in the outbox while the CLA was not running — the removable-media use case the design doc promises, or simply a restart with queued files — was never dispatched: it sat in the directory indefinitely until something touched it again.

The fix
watcher_task now scans the outbox once, immediately after installing the watch, and feeds any file already present into the same channel the event path uses. The ordering matters: with the watch installed before the scan, a file arriving mid-scan is seen by at least one of the two paths, and the forwarder tolerates the resulting duplicate (the second read finds the file already dispatched and deleted, logs, and moves on). Scan errors are logged and non-fatal.

Deliberate difference from the version in #703
The scan uses metadata() (which follows symlinks) rather than DirEntry::file_type() (which does not). inotify reports the creation of a symlink as an ordinary Create(File), so the event path dispatches symlinked files; a scan that skipped them would leave the two paths disagreeing about the same directory entry. This is pinned by the new test_outbox_pickup_preexisting_symlink test and a design-doc paragraph, both of which exist only on this branch — when #703 rebases over this, the scan here is the version to keep.

Also carried
The file-cla test coverage from #703 rides along unchanged (tests/cla.rs forward-path suite, tests/watcher.rs, canonicalize_path unit tests, tempfile dev-dependency): the watcher tests are what pin this fix, and the rest re-sequences already-reviewed #703 content so that branch shrinks. The event-path test uses a two-phase marker (the marker's dispatch proves the startup scan already ran) so the scan cannot mask an event-path regression; waits are bounded by a generous deadline that only bounds a regression, since real filesystem events offer no synchronous hook.